### PR TITLE
Generate updatable tarball

### DIFF
--- a/elements/bluefin/brew-tarball.bst
+++ b/elements/bluefin/brew-tarball.bst
@@ -1,22 +1,37 @@
 kind: manual
 
 build-depends:
-  - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+- freedesktop-sdk.bst:components/tar.bst
+- freedesktop-sdk.bst:components/zstd.bst
+- freedesktop-sdk.bst:components/git.bst
 
 runtime-depends:
-  - bluefin/brew.bst
+- bluefin/brew.bst
 
 sources:
-  - kind: remote
-    url: github_files:ublue-os/packages/releases/download/homebrew-2026-01-27-01-30-36/homebrew-x86_64.tar.zst
-    ref: e644c70109eae00a01d2a6b09dc08ba5697e88cddb63fee035d6b127187b88ef
+- kind: tar
+  url: https://github.com/Homebrew/brew/archive/refs/tags/5.0.13.tar.gz
+  ref: 1fa35433c49b9ae1e8600af5c5cbd04badfc96d68f5a4a3427ab2c654a6baf77
 variables:
   strip-binaries: ""
 
 config:
+  configure-commands:
+  - |
+    git config --global user.email "buildstream@projectbluefin.io"
+    git config --global user.name "Dakota"
+    git init
+    git remote add origin https://github.com/Homebrew/brew
+    git add .
+    git commit -m "Buildstreamed"
+    git branch -M main
+    git update-ref refs/remotes/origin/main "$(git rev-parse HEAD)"
+  
   install-commands:
-    - |
-      mkdir -p "%{install-root}%{datadir}"
-      mv homebrew-x86_64.tar.zst "%{install-root}%{datadir}/homebrew.tar.zst"
-    - |
-      %{install-extra}
+  - |
+    mkdir -p "%{install-root}/home/linuxbrew/.linuxbrew"
+    cp -a . "%{install-root}/home/linuxbrew/.linuxbrew/"
+    install -d "%{install-root}%{datadir}"
+    tar --zstd -cf "%{install-root}%{datadir}/homebrew.tar.zst" \
+        -C "%{install-root}/home" linuxbrew

--- a/elements/bluefin/brew-tarball.bst
+++ b/elements/bluefin/brew-tarball.bst
@@ -34,5 +34,5 @@ config:
   - |
     install -d "%{install-root}%{datadir}"
     
-    git archive --format=tar --prefix=linuxbrew/.linuxbrew/ HEAD | \
+    git archive --format=tar --prefix=home/linuxbrew/.linuxbrew/ HEAD | \
     zstd -z -o "%{install-root}%{datadir}/homebrew.tar.zst"

--- a/elements/bluefin/brew-tarball.bst
+++ b/elements/bluefin/brew-tarball.bst
@@ -10,29 +10,31 @@ runtime-depends:
 - bluefin/brew.bst
 
 sources:
-- kind: tar
-  url: https://github.com/Homebrew/brew/archive/refs/tags/5.0.13.tar.gz
-  ref: 1fa35433c49b9ae1e8600af5c5cbd04badfc96d68f5a4a3427ab2c654a6baf77
+- kind: git_repo
+  url: github:Homebrew/brew
+  track: "*"
+  ref: 5.0.14-0-g6e88ffd4d26b5074cdbcad13f7dcff4222e8677f
 variables:
   strip-binaries: "true"
 
 config:
   configure-commands:
   - |
+    rm -rf .git
     git init -b main
-    
+
     git config --global user.email "buildstream@projectbluefin.io"
     git config --global user.name "Dakota"
-    
+
     git remote add origin https://github.com/Homebrew/brew
     git add --force .
     git commit -m "Buildstreamed"
-    
+
     git update-ref refs/remotes/origin/main "$(git rev-parse HEAD)"
 
   install-commands:
   - |
     install -d "%{install-root}%{datadir}"
-    
+
     git archive --format=tar --prefix=home/linuxbrew/.linuxbrew/ HEAD | \
     zstd -z -o "%{install-root}%{datadir}/homebrew.tar.zst"

--- a/elements/bluefin/brew-tarball.bst
+++ b/elements/bluefin/brew-tarball.bst
@@ -14,24 +14,25 @@ sources:
   url: https://github.com/Homebrew/brew/archive/refs/tags/5.0.13.tar.gz
   ref: 1fa35433c49b9ae1e8600af5c5cbd04badfc96d68f5a4a3427ab2c654a6baf77
 variables:
-  strip-binaries: ""
+  strip-binaries: "true"
 
 config:
   configure-commands:
   - |
+    git init -b main
+    
     git config --global user.email "buildstream@projectbluefin.io"
     git config --global user.name "Dakota"
-    git init
+    
     git remote add origin https://github.com/Homebrew/brew
-    git add .
+    git add --force .
     git commit -m "Buildstreamed"
-    git branch -M main
+    
     git update-ref refs/remotes/origin/main "$(git rev-parse HEAD)"
-  
+
   install-commands:
   - |
-    mkdir -p "%{install-root}/home/linuxbrew/.linuxbrew"
-    cp -a . "%{install-root}/home/linuxbrew/.linuxbrew/"
     install -d "%{install-root}%{datadir}"
-    tar --zstd -cf "%{install-root}%{datadir}/homebrew.tar.zst" \
-        -C "%{install-root}/home" linuxbrew
+    
+    git archive --format=tar --prefix=linuxbrew/.linuxbrew/ HEAD | \
+    zstd -z -o "%{install-root}%{datadir}/homebrew.tar.zst"


### PR DESCRIPTION
Fix #12 

This generate a tarball from the official brew releases (compatible with the ublue brew install script).

The git stuff is so it can be updated with "brew update"


I need help with some testing before this can be merged