### PR TITLE
feat: add Caffeine extension, glow, gum, and fzf

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -10,6 +10,10 @@ depends:
 
   - bluefin/tailscale.bst
 
+  - bluefin/glow.bst
+  - bluefin/gum.bst
+  - bluefin/fzf.bst
+
   - bluefin/common.bst
   - bluefin/wallpapers.bst
 

--- a/elements/bluefin/fzf.bst
+++ b/elements/bluefin/fzf.bst
@@ -1,0 +1,19 @@
+kind: manual
+
+build-depends:
+  - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+sources:
+  - kind: tar
+    url: github_files:junegunn/fzf/releases/download/v0.67.0/fzf-0.67.0-linux_amd64.tar.gz
+    ref: 4be08018ca37b32518c608741933ea335a406de3558242b60619e98f25be2be1
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+    - |
+      install -Dm755 -t "%{install-root}%{bindir}" fzf
+    - |
+      %{install-extra}

--- a/elements/bluefin/glow.bst
+++ b/elements/bluefin/glow.bst
@@ -1,0 +1,25 @@
+kind: manual
+
+build-depends:
+  - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+sources:
+  - kind: tar
+    url: github_files:charmbracelet/glow/releases/download/v2.1.1/glow_2.1.1_Linux_x86_64.tar.gz
+    ref: 59106b08be69b2a0bda1178327bbb7accd584e7c113ba3d2f5ef6e48ff3ac27f
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+    - |
+      install -Dm755 -t "%{install-root}%{bindir}" glow
+    - |
+      install -Dm644 -t "%{install-root}%{datadir}/bash-completion/completions" completions/glow.bash
+      install -Dm644 -t "%{install-root}%{datadir}/zsh/site-functions" completions/glow.zsh
+      install -Dm644 -t "%{install-root}%{datadir}/fish/vendor_completions.d" completions/glow.fish
+    - |
+      install -Dm644 -t "%{install-root}%{datadir}/man/man1" manpages/glow.1.gz
+    - |
+      %{install-extra}

--- a/elements/bluefin/gnome-shell-extensions.bst
+++ b/elements/bluefin/gnome-shell-extensions.bst
@@ -8,6 +8,7 @@ depends:
   - bluefin/shell-extensions/gsconnect.bst
   - bluefin/shell-extensions/search-light.bst
   - bluefin/shell-extensions/logomenu.bst
+  - bluefin/shell-extensions/caffeine.bst
   # Since we use gnomeos nightly atm, no extension works with the current shell version
   - bluefin/shell-extensions/disable-ext-validator.bst
 

--- a/elements/bluefin/gum.bst
+++ b/elements/bluefin/gum.bst
@@ -1,0 +1,25 @@
+kind: manual
+
+build-depends:
+  - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+sources:
+  - kind: tar
+    url: github_files:charmbracelet/gum/releases/download/v0.17.0/gum_0.17.0_Linux_x86_64.tar.gz
+    ref: 69ee169bd6387331928864e94d47ed01ef649fbfe875baed1bbf27b5377a6fdb
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+    - |
+      install -Dm755 -t "%{install-root}%{bindir}" gum
+    - |
+      install -Dm644 -t "%{install-root}%{datadir}/bash-completion/completions" completions/gum.bash
+      install -Dm644 -t "%{install-root}%{datadir}/zsh/site-functions" completions/gum.zsh
+      install -Dm644 -t "%{install-root}%{datadir}/fish/vendor_completions.d" completions/gum.fish
+    - |
+      install -Dm644 -t "%{install-root}%{datadir}/man/man1" manpages/gum.1.gz
+    - |
+      %{install-extra}

--- a/elements/bluefin/shell-extensions/caffeine.bst
+++ b/elements/bluefin/shell-extensions/caffeine.bst
@@ -4,7 +4,7 @@ sources:
   - kind: git_repo
     url: github:eonpatapon/gnome-shell-extension-caffeine.git
     track: v*
-    ref: v59-0-gbe31208
+    ref: v59-0-gbe31208d8ab74cfae215354f242d8703ec3792a4
 
 build-depends:
   - freedesktop-sdk.bst:public-stacks/buildsystem-make.bst

--- a/elements/bluefin/shell-extensions/caffeine.bst
+++ b/elements/bluefin/shell-extensions/caffeine.bst
@@ -1,0 +1,36 @@
+kind: make
+
+sources:
+  - kind: git_repo
+    url: github:eonpatapon/gnome-shell-extension-caffeine.git
+    track: v*
+    ref: v59-0-gbe31208
+
+build-depends:
+  - freedesktop-sdk.bst:public-stacks/buildsystem-make.bst
+  - freedesktop-sdk.bst:components/jq.bst
+
+depends:
+  - freedesktop-sdk.bst:components/gettext.bst
+  - gnome-build-meta.bst:sdk/glib.bst
+  - gnome-build-meta.bst:core/gnome-shell.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+    - |
+      %{make} build
+
+      _uuid="$(jq -r .uuid "caffeine@patapon.info/metadata.json")"
+      install -d "%{install-root}/usr/share/gnome-shell/extensions/${_uuid}"
+      bsdtar xvf "${_uuid}.zip" \
+        -C "%{install-root}/usr/share/gnome-shell/extensions/${_uuid}/" \
+        --no-same-owner
+      if [ -d "%{install-root}/usr/share/gnome-shell/extensions/${_uuid}/schemas" ]; then
+        glib-compile-schemas --strict \
+          "%{install-root}%{datadir}/gnome-shell/extensions/${_uuid}/schemas"
+      fi
+    - |
+      %{install-extra}

--- a/elements/bluefin/shell-extensions/disable-ext-validator.bst
+++ b/elements/bluefin/shell-extensions/disable-ext-validator.bst
@@ -14,6 +14,7 @@ config:
       cat <<EOF > "%{install-root}%{datadir}/glib-2.0/schemas/zz3-bluefin-unsupported-stuff.gschema.override"
       [org.gnome.shell]
       disable-extension-version-validation=true
+      enabled-extensions=['caffeine@patapon.info', 'appindicatorsupport@rgcjonas.gmail.com', 'blur-my-shell@aunetx', 'dash-to-dock@micxgx.gmail.com', 'gsconnect@andyholmes.github.io', 'logomenu@aryan_k', 'search-light@icedman.github.com']
       EOF
 
     - "%{install-extra}"


### PR DESCRIPTION
## Summary

- Add Caffeine GNOME Shell extension (Make + Zip pattern) and enable all installed extensions by default via GSettings override
- Add glow v2.1.1 (markdown renderer) with shell completions and man page
- Add gum v0.17.0 (CLI UX toolkit) with shell completions and man page
- Add fzf v0.67.0 (fuzzy finder)

Implements the plan at `docs/plans/2026-02-15-egg-gap-analysis.md`. All SHA256 checksums verified against upstream releases. `bst show` resolves the full dependency graph cleanly.