### PR TITLE
revert: "chore(deps): update dependency buildstream-plugins to v2.5.0"

### DIFF
--- a/elements/plugins/buildstream-plugins.bst
+++ b/elements/plugins/buildstream-plugins.bst
@@ -2,5 +2,5 @@ kind: junction
 
 sources:
 - kind: tar
-  url: pypi:d4/25/b7912ba305e6bd5e4cade588c5ae80e56b7cb70fb7fb9b318a1168223349/buildstream-plugins-2.5.0.tar.gz
+  url: pypi:d4/25/b7912ba305e6bd5e4cade588c5ae80e56b7cb70fb7fb9b318a1168223349/buildstream-plugins-2.2.0.tar.gz
   ref: 9ee14fda3712d086f7ab6c76584fa1e01bc08960ab047a3e8f33247e8c1d68f6


### PR DESCRIPTION
Reverts projectbluefin/dakota#58