### PR TITLE
project.conf: Add x86_64_v3 option and enable it by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,7 +203,7 @@ jobs:
 
       - name: Build OCI image with BuildStream
         env:
-          BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf
+          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
         run: |
           just bst build ${{ matrix.element }}
         timeout-minutes: 420

--- a/Justfile
+++ b/Justfile
@@ -242,7 +242,7 @@ boot-vm $base_dir=base_dir:
     # Check for native QEMU
     if command -v qemu-system-x86_64 &>/dev/null; then
         echo "==> Using native qemu-system-x86_64..."
-        
+
         # Auto-detect OVMF firmware paths
         OVMF_CODE=""
         for candidate in \
@@ -324,7 +324,7 @@ boot-vm $base_dir=base_dir:
             port=$(( port + 1 ))
         done
         echo "==> Web/VNC accessible at http://localhost:${port}"
-        
+
         # Try to open browser
         xdg-open "http://localhost:${port}" &>/dev/null || true
 
@@ -353,17 +353,17 @@ boot-vm $base_dir=base_dir:
 convert-to-qcow2 $base_dir=base_dir:
     #!/usr/bin/env bash
     set -euo pipefail
-    
+
     RAW="{{base_dir}}/bootable.raw"
     QCOW2="{{base_dir}}/bootable.qcow2"
-    
+
     if [ ! -e "$RAW" ]; then
         echo "ERROR: ${RAW} not found. Run 'just generate-bootable-image' first." >&2
         exit 1
     fi
-    
+
     echo "==> Converting ${RAW} to ${QCOW2}..."
-    
+
     if command -v qemu-img &>/dev/null; then
         qemu-img convert -f raw -O qcow2 "$RAW" "$QCOW2"
     else

--- a/elements/freedesktop-sdk.bst
+++ b/elements/freedesktop-sdk.bst
@@ -12,12 +12,16 @@ config:
   options:
     target_arch: '%{arch}'
     (?):
+    - x86_64_v3:
+        x86_64_v3: true
     - arch == 'x86_64':
         bootstrap_build_arch: 'x86_64'
     - arch == 'aarch64':
         bootstrap_build_arch: 'aarch64'
     - arch == "ppc64le":
         bootstrap_build_arch: "ppc64le"
+    - arch == "riscv64":
+        bootstrap_build_arch: "x86_64"
 
   overrides:
     components/at-spi2-core.bst: gnome-build-meta.bst:sdk/at-spi2-core.bst

--- a/elements/gnome-build-meta.bst
+++ b/elements/gnome-build-meta.bst
@@ -9,6 +9,12 @@ sources:
   path: patches/gnome-build-meta
 
 config:
+  options:
+    arch: '%{arch}'
+    (?):
+    - x86_64_v3:
+        x86_64_v3: true
+
   overrides:
     # This along with the patches is required and has to match what gnome-build-meta is using
     freedesktop-sdk.bst: freedesktop-sdk.bst

--- a/patches/freedesktop-sdk/0001-components-frei0r-Disable-sse4.1-until-it-works.patch
+++ b/patches/freedesktop-sdk/0001-components-frei0r-Disable-sse4.1-until-it-works.patch
@@ -1,0 +1,39 @@
+From 784d33a444f1284d23e8b86e2de4d925ad2842f2 Mon Sep 17 00:00:00 2001
+From: Jordan Petridis <jpetridis@gnome.org>
+Date: Sat, 2 May 2026 00:59:54 +0300
+Subject: [PATCH] components/frei0r: Disable sse4.1 until it works
+
+---
+ elements/components/frei0r.bst | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/elements/components/frei0r.bst b/elements/components/frei0r.bst
+index af344c8f0..82b9dc5c9 100644
+--- a/elements/components/frei0r.bst
++++ b/elements/components/frei0r.bst
+@@ -5,15 +5,22 @@ build-depends:
+ 
+ depends:
+ - public-stacks/runtime-minimal.bst
+ - components/cairo.bst
+ 
+ variables:
+   cmake-local: >-
+     -DWITHOUT_OPENCV=ON
+     -DWITHOUT_GAVL=ON
+ 
++  # Disable SSE 4.1 until they fix things
++  # https://github.com/dyne/frei0r/issues/228
++  # https://github.com/dyne/frei0r/issues/239
++  (?):
++  - target_arch in ["x86_64"]:
++      local_flags: "-mno-sse4.1"
++
+ sources:
+ - kind: git_repo
+   url: github:dyne/frei0r.git
+   track: v*
+   ref: v3.1.3-0-g32e91405d2ec5e222f75175b36dc4cc7bc0667ef
+-- 
+2.54.0
+

--- a/project.conf
+++ b/project.conf
@@ -20,6 +20,13 @@ options:
     values:
       - aarch64
       - x86_64
+  # Default to false since we would have to disable
+  # it for every invocation on aarch64 and it would
+  # be annoying
+  x86_64_v3:
+    type: bool
+    description: Enable x86_64-v3
+    default: false
 
 sandbox:
   build-arch: "%{arch}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in support for x86_64-v3 targeting
  * riscv64 bootstrap support for wider platform compatibility

* **Chores**
  * Build tooling propagates architecture options across the build
  * Build execution now enables x86_64-v3 where applicable in CI
  * Disabled SSE4.1 optimizations for a component to improve build compatibility
  * Minor formatting/whitespace cleanup in build recipes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->