### PR TITLE
Fix the build_image_name again

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -4,7 +4,7 @@ default:
     @just --list
 
 # ── Configuration ─────────────────────────────────────────────────────
-export image_name := env("BUILD_IMAGE_NAME", "ghcr.io/projectbluefin/dakota")
+export image_name := env("BUILD_IMAGE_NAME", "dakota")
 export image_tag := env("BUILD_IMAGE_TAG", "latest")
 export base_dir := env("BUILD_BASE_DIR", ".")
 export filesystem := env("BUILD_FILESYSTEM", "btrfs")


### PR DESCRIPTION
This was reintroduced in the last ab6ac5f that
reverted another change.