### PR TITLE
Revert "chore(deps): track core and junction sources"

### DIFF
--- a/elements/gnome-build-meta.bst
+++ b/elements/gnome-build-meta.bst
@@ -4,7 +4,7 @@ sources:
 - kind: git_repo
   url: gnome:gnome-build-meta.git
   track: master
-  ref: 49-branchpoint-554-gcdf411cf27f45c5586d4ecf62b37a364acb1b4ac
+  ref: 49-branchpoint-538-g8a5eb51a9629804a4f6e58de8dd2d814ae2dbc49
 - kind: patch_queue
   path: patches/gnome-build-meta
 


### PR DESCRIPTION
This reverts commit b4a0c6c0d305d63c2711db7598075c337f513f68.