### PR TITLE
feat(core): add ptyxis 50.1 terminal

### DIFF
--- a/elements/core/meta-gnome-core-apps.bst
+++ b/elements/core/meta-gnome-core-apps.bst
@@ -5,6 +5,7 @@ description: |
   Overridden to only keep some applications.
 
 depends:
+  - core/ptyxis.bst
   - gnome-build-meta.bst:core/baobab.bst
   - gnome-build-meta.bst:core/gnome-disk-utility.bst
   - gnome-build-meta.bst:core/gnome-system-monitor.bst

--- a/elements/core/ptyxis.bst
+++ b/elements/core/ptyxis.bst
@@ -1,0 +1,29 @@
+kind: meson
+
+sources:
+- kind: git_repo
+  url: gnome_gitlab:chergert/ptyxis.git
+  track: "50.1"
+  ref: 50.1-0-g0f045a653db114e22fe7bf4b409fcb30d7763fa9
+
+build-depends:
+- freedesktop-sdk.bst:components/desktop-file-utils.bst
+- freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+- gnome-build-meta.bst:sdk/blueprint-compiler.bst
+- freedesktop-sdk.bst:components/itstool.bst
+
+runtime-depends:
+- gnome-build-meta.bst:sdk/adwaita-icon-theme.bst
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+- gnome-build-meta.bst:core-deps/libgtop.bst
+- gnome-build-meta.bst:core-deps/libportal.bst
+- gnome-build-meta.bst:core-deps/vte.bst
+- gnome-build-meta.bst:core/nautilus.bst
+- gnome-build-meta.bst:sdk/gtk.bst
+- gnome-build-meta.bst:sdk/libadwaita.bst
+
+variables:
+  meson-local: >-
+    -Dgeneric=terminal


### PR DESCRIPTION
Add ptyxis 50.1 back to the image as a core app.

Builds from source with -Dgeneric=terminal so it shows as Console.
Adds libportal dep required by 50.x.

Closes #53