### PR TITLE
feat(deps): add efibootmgr 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,7 @@ jobs:
           BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf
         run: |
           just bst build oci/bluefin.bst
-        timeout-minutes: 120
+        timeout-minutes: 300
 
       # ── Export OCI image ──────────────────────────────────────────────
       # Uses the Justfile's `export` recipe: checks out the OCI image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,8 +88,8 @@ jobs:
             message-format: '[%{wallclock}][%{elapsed}][%{key}][%{element}] %{action} %{message}'
             error-lines: 80
 
-          cachedir: /srv/cache
-          logdir: /srv/logs
+          cachedir: /root/.cache/buildstream
+          logdir: /src/logs
 
           build:
             retry-failed: True

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -27,6 +27,7 @@ depends:
 
   - bluefin/uutils-coreutils.bst
   - bluefin/sudo-rs.bst
+  - bluefin/efibootmgr.bst
 
   # Include things missing from the gnomeos base image
   - freedesktop-sdk.bst:components/buildstream2.bst

--- a/elements/bluefin/efibootmgr.bst
+++ b/elements/bluefin/efibootmgr.bst
@@ -1,0 +1,19 @@
+kind: make
+
+sources:
+- kind: git_repo
+  url: github:rhboot/efibootmgr.git
+  track: "18"
+  ref: 18-0-gc3f9f0534e32158f62c43564036878b93b9e0fd6
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-make.bst
+- freedesktop-sdk.bst:components/pkg-config.bst
+
+depends:
+- freedesktop-sdk.bst:components/efivar.bst
+- freedesktop-sdk.bst:components/popt.bst
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  make-args: EFIDIR=bluefin sbindir=%{bindir}


### PR DESCRIPTION
Add efibootmgr v18, built from source against efivar and popt from freedesktop-sdk.

Installs efibootmgr and efibootdump to /usr/sbin with man pages.

Closes #54