### PR TITLE
tailscale: substitute PORT/FLAGS defaults after stripping EnvironmentFile

### DIFF
--- a/elements/bluefin/tailscale/tailscale.inc
+++ b/elements/bluefin/tailscale/tailscale.inc
@@ -12,6 +12,8 @@ config:
     - |
       sed -e 's|/usr/sbin/tailscaled|/usr/bin/tailscaled|g' \
           -e '/^EnvironmentFile=/d' \
+          -e 's|--port=${PORT}|--port=41641|g' \
+          -e 's| ${FLAGS}||g' \
           systemd/tailscaled.service > tailscaled.service.patched
       install -Dm644 -t "%{install-root}%{indep-libdir}/systemd/system" tailscaled.service.patched
       mv "%{install-root}%{indep-libdir}/systemd/system/tailscaled.service.patched" \


### PR DESCRIPTION
## Problem

The build strips `EnvironmentFile=` from the upstream `tailscaled.service` unit (since `/etc/sysconfig/` doesn't exist on this image), but leaves `${PORT}` and `$FLAGS` in `ExecStart` unresolved.

This causes `tailscaled` to receive `--port=` (empty string) on startup, which it rejects as an invalid argument (`status=2/INVALIDARGUMENT`), leaving Tailscale completely broken on fresh installs.

Reported in #167.

## Fix

Extend the existing `sed` pass to also substitute the variable references with their upstream defaults:
- `--port=${PORT}` → `--port=41641` (tailscale's default DERP/wireguard port)
- `$FLAGS` → removed (was empty by default upstream anyway)

## Testing

After this change the resulting unit reads:
```
ExecStart=/usr/bin/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/run/tailscale/tailscaled.sock --port=41641
```

Verified the workaround (`Environment=PORT=41641` drop-in) resolves the issue on an affected machine.