### PR TITLE
fix: correct double docker:// prefix breaking bootc update

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -27,6 +27,7 @@ depends:
 
   - bluefin/uutils-coreutils.bst
   - bluefin/sudo-rs.bst
+  - bluefin/fix-bootc-imgref.bst
 
   # Include things missing from the gnomeos base image
   - freedesktop-sdk.bst:components/buildstream2.bst

--- a/elements/bluefin/fix-bootc-imgref.bst
+++ b/elements/bluefin/fix-bootc-imgref.bst
@@ -1,0 +1,24 @@
+kind: manual
+
+description: |
+  One-shot systemd service that corrects a broken bootc image reference
+  created by tuna-installer versions that prefixed the targetImgref with
+  an extra docker:// transport, resulting in
+  "docker://docker://ghcr.io/projectbluefin/dakota:latest" being stored
+  in the bootc spec and causing `bootc update` to fail with
+  "invalid reference format".
+
+sources:
+- kind: local
+  path: ../../files/fix-bootc-imgref
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+- freedesktop-sdk.bst:components/systemd.bst
+
+config:
+  install-commands:
+  - install -Dm755 bootc-fix-imgref "%{install-root}%{libexecdir}/bootc-fix-imgref"
+  - install -Dm644 bootc-fix-imgref.service "%{install-root}%{unitdir}/bootc-fix-imgref.service"
+  - mkdir -p "%{install-root}%{unitdir}/multi-user.target.wants"
+  - ln -sf ../bootc-fix-imgref.service "%{install-root}%{unitdir}/multi-user.target.wants/bootc-fix-imgref.service"

--- a/files/fix-bootc-imgref/bootc-fix-imgref
+++ b/files/fix-bootc-imgref/bootc-fix-imgref
@@ -1,0 +1,78 @@
+#!/bin/bash
+# bootc-fix-imgref: correct a broken bootc image reference stored with a
+# spurious docker:// transport prefix, caused by tuna-installer versions
+# prior to the processor.py fix in tuna-os/tuna-installer.
+#
+# Root cause: tuna-installer processor.py line 127 builds
+#   targetImgref = f"docker://{image}"
+# then fisherman passes that verbatim as:
+#   bootc install --target-imgref docker://ghcr.io/…
+# bootc stores this in the deployment's .origin file as:
+#   container-image-reference = ostree-unverified-image:docker://docker://ghcr.io/…
+# causing `bootc update` to fail with "invalid reference format".
+#
+# This script locates the booted deployment's .origin file and strips
+# the duplicate docker:// prefix in-place. It is idempotent and writes
+# a stamp file so it only runs once per installation.
+#
+# See also: https://github.com/tuna-os/tuna-installer (the upstream fix)
+
+set -euo pipefail
+
+STAMP="/var/lib/bootc-imgref-fixed"
+
+if [[ -f "$STAMP" ]]; then
+    echo "bootc-fix-imgref: already applied (stamp exists), skipping"
+    exit 0
+fi
+
+# Identify the booted deployment verity hash from bootc status.
+BOOT_VERITY=$(bootc status --format json 2>/dev/null \
+    | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+v = (d.get('status', {})
+      .get('booted', {})
+      .get('composefs', {})
+      .get('verity', ''))
+print(v)
+" 2>/dev/null || echo "")
+
+if [[ -z "$BOOT_VERITY" ]]; then
+    echo "bootc-fix-imgref: could not determine booted verity hash, skipping"
+    exit 0
+fi
+
+DEPLOY_DIR="/sysroot/state/deploy/${BOOT_VERITY}"
+ORIGIN_FILE="${DEPLOY_DIR}/${BOOT_VERITY}.origin"
+
+if [[ ! -f "$ORIGIN_FILE" ]]; then
+    echo "bootc-fix-imgref: origin file not found at $ORIGIN_FILE, skipping"
+    touch "$STAMP"
+    exit 0
+fi
+
+CURRENT=$(grep '^container-image-reference' "$ORIGIN_FILE" || true)
+
+if [[ "$CURRENT" != *"docker://docker://"* ]]; then
+    echo "bootc-fix-imgref: imgref is correct, nothing to do"
+    echo "  $CURRENT"
+    touch "$STAMP"
+    exit 0
+fi
+
+echo "bootc-fix-imgref: detected double docker:// prefix, fixing..."
+echo "  before: $CURRENT"
+
+# /sysroot is mounted read-only by default; remount writable just long
+# enough to patch the file, then restore.
+mount -o remount,rw /sysroot
+sed -i 's|ostree-unverified-image:docker://docker://|ostree-unverified-image:docker://|g' \
+    "$ORIGIN_FILE"
+mount -o remount,ro /sysroot 2>/dev/null || true   # best-effort; may be busy
+
+FIXED=$(grep '^container-image-reference' "$ORIGIN_FILE" || true)
+echo "  after:  $FIXED"
+echo "bootc-fix-imgref: done — run 'bootc update' to fetch any pending updates"
+
+touch "$STAMP"

--- a/files/fix-bootc-imgref/bootc-fix-imgref.service
+++ b/files/fix-bootc-imgref/bootc-fix-imgref.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Fix bootc image reference corrupted by double docker:// prefix
+Documentation=https://github.com/projectbluefin/dakota/issues
+# Run before any bootc-related services so that subsequent update checks
+# use the corrected reference.  No network needed — we edit the local
+# .origin file directly.
+Before=bootc-fetch-apply-updates.timer
+ConditionPathExists=!/var/lib/bootc-imgref-fixed
+
+[Service]
+Type=oneshot
+# Needs access to /sysroot to find and patch the deployment origin file.
+ExecStart=/usr/libexec/bootc-fix-imgref
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- `sudo bootc update` fails with `invalid reference format` because the booted deployment's `.origin` file stores the image reference with a duplicate `docker://` prefix: `ostree-unverified-image:docker://docker://ghcr.io/projectbluefin/dakota:latest`
- This was written by `tuna-installer` ≤ 0.1.0, where `processor.py:127` builds `targetImgref = f"docker://{image}"` and passes it verbatim as `bootc install --target-imgref docker://ghcr.io/…`.  bootc stores the full string, then prepends `docker://` again on update.
- Adds a one-shot systemd service (`bootc-fix-imgref`) that detects the broken reference in the booted deployment's `.origin` file and strips the duplicate prefix in-place, writing a stamp file so it only runs once.

The canonical upstream fix is in [tuna-os/tuna-installer](https://github.com/tuna-os/tuna-installer) — `processor.py` line 127 should be `target_imgref = image` (no `docker://` prefix, since `--target-transport registry` is already the default). This PR is a workaround to heal existing installations.

## How to reproduce

```
$ sudo bootc update
error: Upgrading composefs: Checking if image docker://ghcr.io/projectbluefin/dakota:latest
is pulled: Getting container info: Opening image
docker://docker://ghcr.io/projectbluefin/dakota:latest: failed to invoke method
OpenImage: invalid reference format
```

Root cause in `/sysroot/state/deploy/<digest>/<digest>.origin`:
```ini
[origin]
container-image-reference = ostree-unverified-image:docker://docker://ghcr.io/projectbluefin/dakota:latest
```

## Test plan

- [ ] Build image with this change and install via tuna-installer
- [ ] Verify `bootc-fix-imgref.service` runs on first boot and patches the `.origin` file
- [ ] Verify `sudo bootc update` succeeds afterwards
- [ ] Verify the stamp file `/var/lib/bootc-imgref-fixed` prevents re-runs on subsequent boots

🤖 Generated with [Claude Code](https://claude.com/claude-code)