### PR TITLE
tailscale: bump to 1.96.4

### DIFF
--- a/elements/bluefin/tailscale/tailscale-aarch64.bst
+++ b/elements/bluefin/tailscale/tailscale-aarch64.bst
@@ -4,5 +4,5 @@ kind: manual
 
 sources:
   - kind: tar
-    url: tailscale_pkgs:tailscale_1.94.2_arm64.tgz
-    ref: 76300e808c57eb7853090d69c8bd8806e86341862e244183f6611f9105799bba
+    url: tailscale_pkgs:tailscale_1.96.4_arm64.tgz
+    ref: a27249bc70d7b37a68f8be7f5c4507ea5f354e592dce43cb5d4f3e742b313c3c

--- a/elements/bluefin/tailscale/tailscale-x86_64.bst
+++ b/elements/bluefin/tailscale/tailscale-x86_64.bst
@@ -4,5 +4,5 @@ kind: manual
 
 sources:
   - kind: tar
-    url: tailscale_pkgs:tailscale_1.94.2_amd64.tgz
-    ref: c6f99a5d774c7783b56902188d69e9756fc3dddfb08ac6be4cb2585f3fecdc32
+    url: tailscale_pkgs:tailscale_1.96.4_amd64.tgz
+    ref: a1cba18826b1f91cb25ef7f5b8259b5258339b42db7867af9269e21829ea78cc


### PR DESCRIPTION
Closes #174

## Summary

Bump Tailscale from 1.94.2 → 1.96.4 for both x86_64 and aarch64.

## Problem

1.94.2 has a bug where WireGuard cannot receive data via IPv6 link-local (`fe80::`) endpoints. When a LAN peer is discovered via link-local IPv6, `magicsock_recv_data_bytes_ipv6` stays at 0 and all connections silently time out. Disco/keepalive packets continue to work (different code path), making the failure difficult to diagnose.

Symptoms:
- `tailscale ping <peer>` (disco) succeeds
- `tailscale ping --tsmp <peer>` (WireGuard data plane) times out
- `tailscale debug metrics | grep recv_data_bytes_ipv6` → `0`
- Switching the peer path to global IPv6 or IPv4 immediately restores connectivity

This manifests as connections breaking after sleep when peer path discovery settles on the link-local IPv6 route.

## Test plan

- [ ] Build image with Tailscale 1.96.4
- [ ] Suspend/resume and verify LAN peers reconnect automatically
- [ ] `tailscale ping --tsmp <lan-peer>` succeeds after wake

🤖 Generated with [Claude Code](https://claude.com/claude-code)