### PR TITLE
fix(ci): disable broken GNOME lorry-mirrors

### DIFF
--- a/patches/gnome-build-meta/disable-lorry-mirrors.patch
+++ b/patches/gnome-build-meta/disable-lorry-mirrors.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dylan Taylor <dylan@dylanmtaylor.com>
+Date: Fri, 11 Apr 2026 00:00:00 +0000
+Subject: [PATCH] Disable lorry-mirrors to avoid 404/403 fetch failures
+
+GNOME's lorry-mirrors on gitlab.gnome.org are returning 404/403 for
+crate tarballs and git repos, causing hundreds of failed fetches that
+must be retried against the original sources. This adds enough overhead
+to push CI builds past the 120-minute timeout.
+
+Remove the mirrors include so fetches go directly to upstream sources
+(github.com, static.crates.io, etc).
+
+---
+ project.conf | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/project.conf b/project.conf
+--- a/project.conf
++++ b/project.conf
+@@ -32,7 +32,6 @@
+ (@):
+ - freedesktop-sdk.bst:include/runtime.yml
+ - include/aliases.yml
+-- include/mirrors.yml
+ - include/shell.yml
+ 
+ # Options to specify for the project, these provide


### PR DESCRIPTION
GNOME's lorry-mirrors on gitlab.gnome.org are returning 404/403 for crate tarballs and git repos. This causes hundreds of failed fetch attempts per build (bootc.bst, efitools.bst, etc). BuildStream retries against the original sources but the extra time pushes CI past the 120-minute timeout.

This patches gnome-build-meta to remove the `include/mirrors.yml` include so fetches go directly to upstream (github.com, static.crates.io, etc).

No change to the built image. Same sources, just fetched from the original URLs. Also unblocks PR #163 and other PRs hitting the same timeout.