### PR TITLE
feat(ci): add BuildStream build caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,13 @@ jobs:
       - name: Setup Just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
+      - name: Cache BuildStream artifacts
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ~/.cache/buildstream
+          key: buildstream-${{ hashFiles('elements/freedesktop-sdk.bst', 'elements/gnome-build-meta.bst', 'elements/bluefin/deps.bst') }}
+          restore-keys: buildstream-
+
       - name: Capture build timestamp
         id: timestamp
         run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
@@ -88,8 +95,8 @@ jobs:
             message-format: '[%{wallclock}][%{elapsed}][%{key}][%{element}] %{action} %{message}'
             error-lines: 80
 
-          cachedir: /srv/cache
-          logdir: /srv/logs
+          cachedir: /root/.cache/buildstream
+          logdir: /src/logs
 
           build:
             retry-failed: True


### PR DESCRIPTION
Adds GitHub Actions caching for BuildStream artifacts between CI runs.

Two changes:

1. Fixes `cachedir` in the CI config to point to `/root/.cache/buildstream` (the path already mounted from the host via the Justfile). Previously it was `/srv/cache` which was not mounted, so the entire local cache was thrown away after every run.

2. Adds `actions/cache` to persist `~/.cache/buildstream` between runs. Cache key is based on the junction refs and deps list so it invalidates when upstream changes. Partial hits still help via restore-keys fallback.

On a warm cache this should make subsequent builds near-instant since BuildStream can skip pulling artifacts from remote servers entirely.