### PR TITLE
feat(brew): switch brew tarball to ublue-os/brew releases

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,6 +46,21 @@
       "versioningTemplate": "pep440"
     },
 
+    // ── Homebrew tarball from ublue-os/brew ──
+    // Matches: url: github_files:ublue-os/brew/releases/download/<version>/homebrew-<arch>.tar.zst
+    //          ref: <sha256>
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/elements/bluefin/brew-tarball\\.bst$/"
+      ],
+      "matchStrings": [
+        "url:\\s*github_files:(?<depName>ublue-os/brew)/releases/download/(?<currentValue>\\d+\\.\\d+\\.\\d+)/homebrew-[a-z0-9_]+\\.tar\\.zst\\n\\s+ref:\\s*(?<currentDigest>[a-f0-9]{64})"
+      ],
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^(?<version>.+)$"
+    },
+
     // ── Nerd Fonts GitHub release tarball ──
     // Matches: url: github_files:ryanoasis/nerd-fonts/releases/download/v<version>/JetBrainsMono.tar.xz
     //          ref: <sha256>

--- a/elements/bluefin/brew-tarball.bst
+++ b/elements/bluefin/brew-tarball.bst
@@ -4,11 +4,11 @@ sources:
 - kind: remote
   (?):
   - arch == "x86_64":
-      url: github_files:ublue-os/packages/releases/download/homebrew-2026-03-03-01-31-47/homebrew-x86_64.tar.zst
-      ref: 46e546da7ac2a4e916f0c89db61e9c0292b90e8b4b6b5662d2c5df5f668fb40c
+      url: github_files:ublue-os/brew/releases/download/5.1.5/homebrew-x86_64.tar.zst
+      ref: 0000000000000000000000000000000000000000000000000000000000000000
   - arch == "aarch64":
-      url: github_files:ublue-os/packages/releases/download/homebrew-2026-02-17-01-32-11/homebrew-aarch64.tar.zst
-      ref: 08813d100ff0f69c57038b1d397e641789701e0ca109200e1377473cd7bad001
+      url: github_files:ublue-os/brew/releases/download/5.1.5/homebrew-aarch64.tar.zst
+      ref: 0000000000000000000000000000000000000000000000000000000000000000
 
 build-depends:
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst


### PR DESCRIPTION
Switches brew-tarball.bst from the dead ublue-os/packages tarballs to ublue-os/brew releases, per Jorge's request on #164 to keep brew consistent across Bluefin variants.

Depends on ublue-os/brew#14 to start publishing release tarballs. Refs are placeholders until the first release is cut.

Also adds a renovate rule to auto-track new ublue-os/brew releases.