### PR TITLE
test(ci): validate build caching + efibootmgr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,13 @@ jobs:
       - name: Setup Just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
+      - name: Cache BuildStream artifacts
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ~/.cache/buildstream
+          key: buildstream-${{ hashFiles('elements/freedesktop-sdk.bst', 'elements/gnome-build-meta.bst', 'elements/bluefin/deps.bst') }}
+          restore-keys: buildstream-
+
       - name: Capture build timestamp
         id: timestamp
         run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
@@ -88,8 +95,8 @@ jobs:
             message-format: '[%{wallclock}][%{elapsed}][%{key}][%{element}] %{action} %{message}'
             error-lines: 80
 
-          cachedir: /srv/cache
-          logdir: /srv/logs
+          cachedir: /root/.cache/buildstream
+          logdir: /src/logs
 
           build:
             retry-failed: True

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -27,6 +27,7 @@ depends:
 
   - bluefin/uutils-coreutils.bst
   - bluefin/sudo-rs.bst
+  - bluefin/efibootmgr.bst
 
   # Include things missing from the gnomeos base image
   - freedesktop-sdk.bst:components/buildstream2.bst

--- a/elements/bluefin/efibootmgr.bst
+++ b/elements/bluefin/efibootmgr.bst
@@ -1,0 +1,19 @@
+kind: make
+
+sources:
+- kind: git_repo
+  url: github:rhboot/efibootmgr.git
+  track: "18"
+  ref: 18-0-gc3f9f0534e32158f62c43564036878b93b9e0fd6
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-make.bst
+- freedesktop-sdk.bst:components/pkg-config.bst
+
+depends:
+- freedesktop-sdk.bst:components/efivar.bst
+- freedesktop-sdk.bst:components/popt.bst
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  make-args: EFIDIR=bluefin sbindir=%{bindir}


### PR DESCRIPTION
Draft PR to test CI caching optimizations from `feat/ci-build-caching` combined with the efibootmgr element from #163.

**Changes stacked:**
1. fix(ci): disable broken GNOME lorry-mirrors (#190)
2. feat(ci): add BuildStream build caching (fixes cachedir mismatch + adds actions/cache)
3. feat(deps): add efibootmgr 18 (#163)

This is a test run — will close after verifying CI behavior.