### PR TITLE
Add Bitwarden

### DIFF
--- a/elements/bluefin/bitwarden-cli.bst
+++ b/elements/bluefin/bitwarden-cli.bst
@@ -1,0 +1,25 @@
+kind: manual
+
+sources:
+- kind: zip
+  base-dir: ""
+  (?):
+  - arch == "x86_64":
+      url: github_files:bitwarden/clients/releases/download/cli-v2026.3.0/bw-linux-2026.3.0.zip
+      ref: 0bdf85cfa1ad1e3c4f6cd2ae23d0de1af136939405f1f395b6836b7f43479ed2
+  - arch == "aarch64":
+      url: github_files:bitwarden/clients/releases/download/cli-v2026.3.0/bw-linux-arm64-2026.3.0.zip
+      ref: 5826f3c4f0c5ff16151c9dccf0a8b245224b943a86c51f1125070bcdcaec1436
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    install -Dm755 -t "%{install-root}%{bindir}" bw
+  - |
+    %{install-extra}

--- a/elements/bluefin/bitwarden.bst
+++ b/elements/bluefin/bitwarden.bst
@@ -1,0 +1,38 @@
+kind: manual
+
+sources:
+- kind: tar
+  (?):
+  - arch == "x86_64":
+      url: github_files:bitwarden/clients/releases/download/desktop-v2026.3.1/bitwarden_2026.3.1_x64.tar.gz
+      ref: 3558e24b829d90c7bb73ce22962f6fac1a9483b6052c1ed3075663413ec6efab
+  - arch == "aarch64":
+      url: github_files:bitwarden/clients/releases/download/desktop-v2026.3.1/bitwarden_2026.3.1_arm64.tar.gz
+      ref: d0ad123773c8816f1125f0fd15b43c6732ad0d04c873b7d69e3f9bdcfcfc7ecc
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    mkdir -p "%{install-root}/opt/Bitwarden"
+    cp -a . "%{install-root}/opt/Bitwarden/"
+  - |
+    install -dm755 "%{install-root}%{bindir}"
+    ln -sf /opt/Bitwarden/bitwarden "%{install-root}%{bindir}/bitwarden"
+  - |
+    install -Dm644 resources/com.bitwarden.desktop.desktop \
+        "%{install-root}%{datadir}/applications/com.bitwarden.desktop.desktop"
+  - |
+    for size in 16x16 32x32 64x64 128x128 256x256 512x512 1024x1024; do
+      install -Dm644 "resources/icons/${size}.png" \
+          "%{install-root}%{datadir}/icons/hicolor/${size}/apps/com.bitwarden.desktop.png"
+    done
+  - |
+    chmod 4755 "%{install-root}/opt/Bitwarden/chrome-sandbox"
+  - |
+    %{install-extra}

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -13,6 +13,9 @@ depends:
   - bluefin/1password-cli.bst
   - bluefin/1password.bst
 
+  - bluefin/bitwarden-cli.bst
+  - bluefin/bitwarden.bst
+
   - bluefin/ghostty.bst
 
   - bluefin/glow.bst


### PR DESCRIPTION
Adds Bitwarden desktop app and CLI.

- bitwarden.bst: desktop app from upstream tar.gz (x86_64 + aarch64)
- bitwarden-cli.bst: CLI tool from upstream zip (x86_64 + aarch64)
- Both added to deps.bst

Same pattern as the 1Password elements.

<img width="1920" height="1165" alt="image" src="https://github.com/user-attachments/assets/f1cd9bcf-2cde-48bf-b63f-cbd69de3cd91" />
