### PR TITLE
feat(extensions): replace LogoMenu with Custom Command Menu

### DIFF
--- a/.github/workflows/track-bst-sources.yml
+++ b/.github/workflows/track-bst-sources.yml
@@ -42,7 +42,7 @@ jobs:
               bluefin/shell-extensions/dash-to-dock.bst
               bluefin/shell-extensions/gsconnect.bst
               bluefin/shell-extensions/search-light.bst
-              bluefin/shell-extensions/logomenu.bst
+              bluefin/shell-extensions/custom-command-menu.bst
           - group: manual-merge
             branch: auto/track-core-sources
             title: "chore(deps): track core and junction sources"

--- a/elements/bluefin/gnome-shell-extensions.bst
+++ b/elements/bluefin/gnome-shell-extensions.bst
@@ -7,7 +7,7 @@ depends:
   - bluefin/shell-extensions/dash-to-dock.bst
   - bluefin/shell-extensions/gsconnect.bst
   - bluefin/shell-extensions/search-light.bst
-  - bluefin/shell-extensions/logomenu.bst
+  - bluefin/shell-extensions/custom-command-menu.bst
   - bluefin/shell-extensions/caffeine.bst
   # Since we use gnomeos nightly atm, no extension works with the current shell version
   - bluefin/shell-extensions/disable-ext-validator.bst

--- a/elements/bluefin/shell-extensions/custom-command-menu.bst
+++ b/elements/bluefin/shell-extensions/custom-command-menu.bst
@@ -2,9 +2,9 @@ kind: manual
 
 sources:
   - kind: git_repo
-    url: github:ublue-os/Logomenu.git
-    track: main
-    ref: ab8b37e524d6795f4eb7170cc62b7f90de7f5729
+    url: github:StorageB/custom-command-menu.git
+    track: v*
+    ref: v12-0-g8749b1247e681e86e07a3c7e7db5bdcead139639
 
 build-depends:
   - freedesktop-sdk.bst:public-stacks/buildsystem-make.bst

--- a/elements/bluefin/shell-extensions/custom-command-menu.bst
+++ b/elements/bluefin/shell-extensions/custom-command-menu.bst
@@ -4,7 +4,7 @@ sources:
   - kind: git_repo
     url: github:StorageB/custom-command-menu.git
     track: v*
-    ref: v12-0-g8749b1247e681e86e07a3c7e7db5bdcead139639
+    ref: f7d4eb671aece43c9ee8b52bf8d740f948202bf4
 
 build-depends:
   - freedesktop-sdk.bst:public-stacks/buildsystem-make.bst

--- a/elements/bluefin/shell-extensions/disable-ext-validator.bst
+++ b/elements/bluefin/shell-extensions/disable-ext-validator.bst
@@ -14,7 +14,7 @@ config:
       cat <<EOF > "%{install-root}%{datadir}/glib-2.0/schemas/zz3-bluefin-unsupported-stuff.gschema.override"
       [org.gnome.shell]
       disable-extension-version-validation=true
-      enabled-extensions=['caffeine@patapon.info', 'appindicatorsupport@rgcjonas.gmail.com', 'blur-my-shell@aunetx', 'dash-to-dock@micxgx.gmail.com', 'gsconnect@andyholmes.github.io', 'logomenu@aryan_k', 'search-light@icedman.github.com']
+      enabled-extensions=['caffeine@patapon.info', 'appindicatorsupport@rgcjonas.gmail.com', 'blur-my-shell@aunetx', 'dash-to-dock@micxgx.gmail.com', 'gsconnect@andyholmes.github.io', 'custom-command-list@storageb.github.com', 'search-light@icedman.github.com']
       EOF
 
     - "%{install-extra}"


### PR DESCRIPTION
Ok so this menu is clean and very easy for users to extend, and we can drop the fork/rpm, so this is nice and clean. Also upstream is looking at accepting our PR to add the hostname there. So the subtle menu will have the machine hostname. Very clean. 

Swaps logomenu for StorageB/custom-command-menu, which is actively maintained, supports translations, and is fully customizable. Depends on projectbluefin/common#264.