### PR TITLE
feat(packages): add xdg-terminal-exec

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -26,6 +26,7 @@ depends:
   - bluefin/uutils-coreutils.bst
   - bluefin/sudo-rs.bst
   - bluefin/efibootmgr.bst
+  - bluefin/xdg-terminal-exec.bst
 
   # Include things missing from the gnomeos base image
   - freedesktop-sdk.bst:components/buildstream2.bst

--- a/elements/bluefin/xdg-terminal-exec.bst
+++ b/elements/bluefin/xdg-terminal-exec.bst
@@ -1,0 +1,22 @@
+kind: manual
+
+sources:
+- kind: git_repo
+  url: github:Vladimir-csp/xdg-terminal-exec.git
+  track: master
+  ref: e675f61c1fa1175b1295f9d2ed5338f73a2cb679
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    install -Dm755 xdg-terminal-exec "%{install-root}%{bindir}/xdg-terminal-exec"
+  - |
+    install -Dm644 xdg-terminals.list "%{install-root}%{datadir}/xdg-terminal-exec/xdg-terminals.list"
+  - |
+    %{install-extra}


### PR DESCRIPTION
## Summary

- Adds [xdg-terminal-exec](https://github.com/Vladimir-csp/xdg-terminal-exec), the shell-based reference implementation of the XDG Default Terminal Execution Specification
- Installs `/usr/bin/xdg-terminal-exec` and `/usr/share/xdg-terminal-exec/xdg-terminals.list`
- Builds locally and full image build passes

## Test plan

- [x] `just bst build bluefin/xdg-terminal-exec.bst` — passes
- [x] `just build` — full image build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)