### PR TITLE
fix(common): map Bluefin icons to GNOME OS expected names

### DIFF
--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -19,6 +19,7 @@ public:
     overlap-whitelist:
     - /etc/environment
     - /etc/containers/policy.json
+    - /usr/share/pixmaps/gnome-boot-logo.png
 
 variables:
   strip-binaries: ""
@@ -37,6 +38,14 @@ config:
     cp -r system_files/bluefin/etc/./ "%{install-root}%{sysconfdir}/"
     cp -r system_files/shared/etc/./ "%{install-root}%{sysconfdir}/"
     cp -r bluefin-branding/system_files/etc/./ "%{install-root}%{sysconfdir}/"
+
+    # Map Bluefin icons to GNOME OS expected names
+    # About dialog (gnome-control-center reads LOGO=img-logo-icon from os-release,
+    # then looks for img-logo-icon-text-dark, img-logo-icon-text, img-logo-icon-dark, img-logo-icon)
+    cp "%{install-root}%{datadir}/pixmaps/fedora-logo-icon.png" "%{install-root}%{datadir}/pixmaps/img-logo-icon.png"
+    cp "%{install-root}%{datadir}/pixmaps/fedora-logo-icon.png" "%{install-root}%{datadir}/pixmaps/img-logo-icon-dark.png"
+    # Override GNOME OS boot logo with Bluefin branding
+    cp "%{install-root}%{datadir}/pixmaps/fedora-gdm-logo.png" "%{install-root}%{datadir}/pixmaps/gnome-boot-logo.png"
 
     # Create dconf profile so the distro system database is read
     mkdir -p "%{install-root}%{sysconfdir}/dconf/profile"


### PR DESCRIPTION
The common repo ships Bluefin icons under `fedora-*` names, but GNOME OS doesn't look for those. This copies them to the names GNOME OS actually expects:

- `img-logo-icon.png` / `img-logo-icon-dark.png` for the About dialog (`LOGO=img-logo-icon` in os-release)

<img width="733" height="501" alt="image" src="https://github.com/user-attachments/assets/637f5bf1-fe4c-45d7-8e29-1379c4e36855" />

- `gnome-boot-logo.png` to override the GNOME foot in pixmaps 
<img width="150" height="61" alt="image" src="https://github.com/user-attachments/assets/fc5525a5-2725-4c7c-b08c-9d2cfac11f67" />
