### PR TITLE
fix(custom-command-menu): install gschema to system dir for override support

### DIFF
--- a/elements/bluefin/shell-extensions/custom-command-menu.bst
+++ b/elements/bluefin/shell-extensions/custom-command-menu.bst
@@ -26,5 +26,9 @@ config:
       glib-compile-schemas --strict schemas/
       install -d "%{install-root}/usr/share/gnome-shell/extensions/${_uuid}"
       cp -R ./* "%{install-root}/usr/share/gnome-shell/extensions/${_uuid}/"
+
+      # Install schema to system dir so gschema overrides (e.g. menuicon-setting) apply
+      install -Dm644 schemas/org.gnome.shell.extensions.custom-command-list.gschema.xml \
+        "%{install-root}/usr/share/glib-2.0/schemas/org.gnome.shell.extensions.custom-command-list.gschema.xml"
     - |
       %{install-extra}


### PR DESCRIPTION
The custom-command-menu extension schema was only in the extension directory, not in `/usr/share/glib-2.0/schemas/`, so the `menuicon-setting='ublue-logo-symbolic'` override was silently ignored. Panel showed the default terminal icon instead of the Bluefin logo.

Installs the schema XML to the system schemas dir so `glib-compile-schemas` picks up the override.

<img width="1920" height="1165" alt="image" src="https://github.com/user-attachments/assets/0398f657-b270-4716-99c1-328d48b8918d" />

<!-- This PR does not implement age verification or birth date checks -->