### PR TITLE
chore: bump common refs

### DIFF
--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -4,7 +4,7 @@ sources:
 - kind: git_repo
   url: github:projectbluefin/common.git
   track: main
-  ref: v2026.04-30-gd58a378d8c3671eff137fa8b7b0ea7ef370eba74
+  ref: v2026.04-35-g4e00ee0bde963a6a759752e49f337f35a4886f65
 - kind: git_module
   url: github:projectbluefin/branding/
   path: bluefin-branding


### PR DESCRIPTION
Picks up projectbluefin/common#274. adds custom-command-menu icon/location settings to dconf distro database and moves menu to left side of panel.

<!-- This PR does not implement age verification -->