### PR TITLE
fix: remove gnome-system-monitor from image

### DIFF
--- a/elements/core/meta-gnome-core-apps.bst
+++ b/elements/core/meta-gnome-core-apps.bst
@@ -7,6 +7,5 @@ description: |
 depends:
   - gnome-build-meta.bst:core/baobab.bst
   - gnome-build-meta.bst:core/gnome-disk-utility.bst
-  - gnome-build-meta.bst:core/gnome-system-monitor.bst
   - gnome-build-meta.bst:core/nautilus.bst
   - gnome-build-meta.bst:sdk/yelp.bst


### PR DESCRIPTION
<!-- This PR does not implement age verification -->
Mission Center will be used instead.