### PR TITLE
feat: add asusctl 6.3.7 for ASUS ROG/TUF laptop support

### DIFF
--- a/elements/bluefin/asusctl.bst
+++ b/elements/bluefin/asusctl.bst
@@ -1,0 +1,2845 @@
+kind: make
+
+build-depends:
+  - freedesktop-sdk.bst:components/rust.bst
+  - freedesktop-sdk.bst:public-stacks/buildsystem-make.bst
+  - freedesktop-sdk.bst:components/pkg-config.bst
+  - freedesktop-sdk.bst:components/systemd-libs.bst
+
+depends:
+  - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+  - freedesktop-sdk.bst:components/systemd-libs.bst
+
+config:
+  build-commands:
+    # Remove rog-control-center from workspace members so cargo does not try to resolve
+    # its git-only Slint/supergfxctl deps. Two patterns cover both forms used at 6.3.7:
+    #   members list (one entry per line) and inline default-members array.
+    # The trailing guard fails loudly if upstream reformats and the removal is incomplete.
+    - |
+      sed -i \
+        '/^[[:space:]]*"rog-control-center"[[:space:],]*$/d' \
+        Cargo.toml
+      sed -i \
+        's/, *"rog-control-center"//g; s/"rog-control-center", *//g' \
+        Cargo.toml
+      if grep -q '"rog-control-center"' Cargo.toml; then
+        echo "ERROR: rog-control-center still present in Cargo.toml after patch — update sed patterns" >&2
+        exit 1
+      fi
+    - cargo build --release --offline --package asusctl --package asusd --package asus-shutdown --package asusd-user
+
+  install-commands:
+    # Binaries
+    - install -Dm755 target/release/asusctl     "%{install-root}%{bindir}/asusctl"
+    - install -Dm755 target/release/asusd       "%{install-root}%{bindir}/asusd"
+    - install -Dm755 target/release/asus-shutdown "%{install-root}%{bindir}/asus-shutdown"
+    - install -Dm755 target/release/asusd-user  "%{install-root}%{bindir}/asusd-user"
+
+    # udev rules — hardware gate (DMI vendor + product family + asus-nb-wmi driver probe)
+    - install -Dm644 data/asusd.rules "%{install-root}%{indep-libdir}/udev/rules.d/99-asusd.rules"
+
+    # D-Bus policy
+    - install -Dm644 data/asusd.conf "%{install-root}%{datadir}/dbus-1/system.d/asusd.conf"
+
+    # systemd system services (stock, unmodified — udev SYSTEMD_WANTS activates both)
+    - install -Dm644 data/asusd.service         "%{install-root}%{indep-libdir}/systemd/system/asusd.service"
+    - install -Dm644 data/asus-shutdown.service "%{install-root}%{indep-libdir}/systemd/system/asus-shutdown.service"
+
+    # systemd user service
+    - install -Dm644 data/asusd-user.service "%{install-root}%{indep-libdir}/systemd/user/asusd-user.service"
+
+    # Aura keyboard support data
+    - install -Dm644 rog-aura/data/aura_support.ron "%{install-root}%{datadir}/asusd/aura_support.ron"
+
+    # AniMe matrix display data
+    - |
+      cd rog-anime/data && find ./anime -type f | while read f; do
+        install -Dm644 "$f" "%{install-root}%{datadir}/asusd/$f"
+      done
+
+    # Keyboard layout RON files (asusd-user loads from /usr/share/rog-gui/layouts/)
+    - |
+      cd rog-aura/data/layouts && find . -type f -name "*.ron" | while read f; do
+        install -Dm644 "$f" "%{install-root}%{datadir}/rog-gui/layouts/$f"
+      done
+
+    # System notification icons — use find to avoid hard failure if upstream renames the glob
+    - |
+      find data/icons -maxdepth 1 -name 'asus_notif_*.png' -type f | while read icon; do
+        install -Dm644 "$icon" "%{install-root}%{datadir}/icons/hicolor/512x512/apps/$(basename "$icon")"
+      done
+
+    - "%{install-extra}"
+
+
+sources:
+  - kind: git_repo
+    url: gitlab:asus-linux/asusctl.git
+    track: refs/tags/6.3.7
+    ref: de4297a1c0490527f7b427db011bae4a35c7c832
+
+  - kind: cargo2
+    url: crates:crates
+    ref:
+    - kind: git
+      name: sg
+      version: 0.4.0
+      repo: github:flukejones/sg-rs.git
+      commit: b1ce961ae42b0aad22166bac84e5105a918debd3
+    - kind: registry
+      name: ab_glyph
+      version: 0.2.32
+      sha: 01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2
+    - kind: registry
+      name: ab_glyph_rasterizer
+      version: 0.1.10
+      sha: 366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618
+    - kind: registry
+      name: adler
+      version: 1.0.2
+      sha: f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe
+    - kind: registry
+      name: adler2
+      version: 2.0.1
+      sha: 320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa
+    - kind: registry
+      name: ahash
+      version: 0.8.12
+      sha: 5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75
+    - kind: registry
+      name: aho-corasick
+      version: 1.1.4
+      sha: ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301
+    - kind: registry
+      name: aligned
+      version: 0.4.3
+      sha: ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685
+    - kind: registry
+      name: aligned-vec
+      version: 0.6.4
+      sha: dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b
+    - kind: registry
+      name: allocator-api2
+      version: 0.2.21
+      sha: 683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923
+    - kind: registry
+      name: android-activity
+      version: 0.6.1
+      sha: 0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd
+    - kind: registry
+      name: android-properties
+      version: 0.2.2
+      sha: fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04
+    - kind: registry
+      name: android_system_properties
+      version: 0.1.5
+      sha: 819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311
+    - kind: registry
+      name: annotate-snippets
+      version: 0.12.15
+      sha: 92570a3f9c98e7e84df84b71d0965ac99b1871fcd75a3773a3bd1bad13f64cf7
+    - kind: registry
+      name: anstyle
+      version: 1.0.14
+      sha: 940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000
+    - kind: registry
+      name: anyhow
+      version: 1.0.102
+      sha: 7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c
+    - kind: registry
+      name: arbitrary
+      version: 1.4.2
+      sha: c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1
+    - kind: registry
+      name: arg_enum_proc_macro
+      version: 0.3.4
+      sha: 0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea
+    - kind: registry
+      name: argh
+      version: 0.1.19
+      sha: 211818e820cda9ca6f167a64a5c808837366a6dfd807157c64c1304c486cd033
+    - kind: registry
+      name: argh_derive
+      version: 0.1.19
+      sha: c442a9d18cef5dde467405d27d461d080d68972d6d0dfd0408265b6749ec427d
+    - kind: registry
+      name: argh_shared
+      version: 0.1.19
+      sha: e5ade012bac4db278517a0132c8c10c6427025868dca16c801087c28d5a411f1
+    - kind: registry
+      name: arrayref
+      version: 0.3.9
+      sha: 76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb
+    - kind: registry
+      name: arrayvec
+      version: 0.7.6
+      sha: 7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50
+    - kind: registry
+      name: as-raw-xcb-connection
+      version: 1.0.1
+      sha: 175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b
+    - kind: registry
+      name: as-slice
+      version: 0.2.1
+      sha: 516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516
+    - kind: registry
+      name: async-broadcast
+      version: 0.7.2
+      sha: 435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532
+    - kind: registry
+      name: async-channel
+      version: 2.5.0
+      sha: 924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2
+    - kind: registry
+      name: async-executor
+      version: 1.14.0
+      sha: c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a
+    - kind: registry
+      name: async-fs
+      version: 2.2.0
+      sha: 8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5
+    - kind: registry
+      name: async-io
+      version: 2.6.0
+      sha: 456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc
+    - kind: registry
+      name: async-lock
+      version: 3.4.2
+      sha: 290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311
+    - kind: registry
+      name: async-net
+      version: 2.0.0
+      sha: b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7
+    - kind: registry
+      name: async-process
+      version: 2.5.0
+      sha: fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75
+    - kind: registry
+      name: async-recursion
+      version: 1.1.1
+      sha: 3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11
+    - kind: registry
+      name: async-signal
+      version: 0.2.14
+      sha: 52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485
+    - kind: registry
+      name: async-stream
+      version: 0.3.6
+      sha: 0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476
+    - kind: registry
+      name: async-stream-impl
+      version: 0.3.6
+      sha: c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d
+    - kind: registry
+      name: async-task
+      version: 4.7.1
+      sha: 8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de
+    - kind: registry
+      name: async-trait
+      version: 0.1.89
+      sha: 9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb
+    - kind: registry
+      name: atomic-waker
+      version: 1.1.2
+      sha: 1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0
+    - kind: registry
+      name: auto_enums
+      version: 0.8.8
+      sha: 65398a2893f41bce5c9259f6e1a4f03fbae40637c1bdc755b4f387f48c613b03
+    - kind: registry
+      name: autocfg
+      version: 1.5.0
+      sha: c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8
+    - kind: registry
+      name: av-scenechange
+      version: 0.14.1
+      sha: 0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394
+    - kind: registry
+      name: av1-grain
+      version: 0.2.5
+      sha: 8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8
+    - kind: registry
+      name: avif-serialize
+      version: 0.8.8
+      sha: 375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d
+    - kind: registry
+      name: axum
+      version: 0.7.9
+      sha: edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f
+    - kind: registry
+      name: axum-core
+      version: 0.4.5
+      sha: 09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199
+    - kind: registry
+      name: base64
+      version: 0.21.7
+      sha: 9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567
+    - kind: registry
+      name: base64
+      version: 0.22.1
+      sha: 72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6
+    - kind: registry
+      name: bincode
+      version: 2.0.1
+      sha: 36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740
+    - kind: registry
+      name: bindgen
+      version: 0.71.1
+      sha: 5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3
+    - kind: registry
+      name: bindgen
+      version: 0.72.1
+      sha: 993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895
+    - kind: registry
+      name: bit_field
+      version: 0.10.3
+      sha: 1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6
+    - kind: registry
+      name: bitflags
+      version: 1.3.2
+      sha: bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a
+    - kind: registry
+      name: bitflags
+      version: 2.11.0
+      sha: 843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af
+    - kind: registry
+      name: bitstream-io
+      version: 4.9.0
+      sha: 60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757
+    - kind: registry
+      name: block
+      version: 0.1.6
+      sha: 0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a
+    - kind: registry
+      name: block2
+      version: 0.5.1
+      sha: 2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f
+    - kind: registry
+      name: block2
+      version: 0.6.2
+      sha: cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5
+    - kind: registry
+      name: blocking
+      version: 1.6.2
+      sha: e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21
+    - kind: registry
+      name: borsh
+      version: 1.6.1
+      sha: cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a
+    - kind: registry
+      name: built
+      version: 0.8.0
+      sha: f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64
+    - kind: registry
+      name: bumpalo
+      version: 3.20.2
+      sha: 5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb
+    - kind: registry
+      name: by_address
+      version: 1.2.1
+      sha: 64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06
+    - kind: registry
+      name: bytemuck
+      version: 1.25.0
+      sha: c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec
+    - kind: registry
+      name: bytemuck_derive
+      version: 1.10.2
+      sha: f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff
+    - kind: registry
+      name: byteorder
+      version: 1.5.0
+      sha: 1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b
+    - kind: registry
+      name: byteorder-lite
+      version: 0.1.0
+      sha: 8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495
+    - kind: registry
+      name: bytes
+      version: 1.11.1
+      sha: 1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33
+    - kind: registry
+      name: calloop
+      version: 0.13.0
+      sha: b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec
+    - kind: registry
+      name: calloop
+      version: 0.14.4
+      sha: 4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7
+    - kind: registry
+      name: calloop-wayland-source
+      version: 0.3.0
+      sha: 95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20
+    - kind: registry
+      name: calloop-wayland-source
+      version: 0.4.1
+      sha: 138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa
+    - kind: registry
+      name: cargo-husky
+      version: 1.5.0
+      sha: 7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad
+    - kind: registry
+      name: cc
+      version: 1.2.60
+      sha: 43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20
+    - kind: registry
+      name: cexpr
+      version: 0.6.0
+      sha: 6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766
+    - kind: registry
+      name: cfg-if
+      version: 1.0.4
+      sha: 9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801
+    - kind: registry
+      name: cfg_aliases
+      version: 0.2.1
+      sha: 613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724
+    - kind: registry
+      name: cgl
+      version: 0.3.2
+      sha: 0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff
+    - kind: registry
+      name: chrono
+      version: 0.4.44
+      sha: c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0
+    - kind: registry
+      name: clang-sys
+      version: 1.8.1
+      sha: 0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4
+    - kind: registry
+      name: clipboard-win
+      version: 5.4.1
+      sha: bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4
+    - kind: registry
+      name: clru
+      version: 0.6.3
+      sha: 197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5
+    - kind: registry
+      name: color_quant
+      version: 1.1.0
+      sha: 3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b
+    - kind: registry
+      name: combine
+      version: 4.6.7
+      sha: ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd
+    - kind: registry
+      name: concat-idents
+      version: 1.1.5
+      sha: f76990911f2267d837d9d0ad060aa63aaad170af40904b29461734c339030d4d
+    - kind: registry
+      name: concurrent-queue
+      version: 2.5.0
+      sha: 4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973
+    - kind: registry
+      name: console-api
+      version: 0.8.1
+      sha: 8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857
+    - kind: registry
+      name: console-subscriber
+      version: 0.4.1
+      sha: 6539aa9c6a4cd31f4b1c040f860a1eac9aa80e7df6b05d506a6e7179936d6a01
+    - kind: registry
+      name: convert_case
+      version: 0.10.0
+      sha: 633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9
+    - kind: registry
+      name: copypasta
+      version: 0.10.2
+      sha: 3e6811e17f81fe246ef2bc553f76b6ee6ab41a694845df1d37e52a92b7bbd38a
+    - kind: registry
+      name: core-foundation
+      version: 0.9.4
+      sha: 91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f
+    - kind: registry
+      name: core-foundation
+      version: 0.10.1
+      sha: b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6
+    - kind: registry
+      name: core-foundation-sys
+      version: 0.8.7
+      sha: 773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b
+    - kind: registry
+      name: core-graphics
+      version: 0.23.2
+      sha: c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081
+    - kind: registry
+      name: core-graphics-types
+      version: 0.1.3
+      sha: 45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf
+    - kind: registry
+      name: core2
+      version: 0.4.0
+      sha: b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505
+    - kind: registry
+      name: core_maths
+      version: 0.1.1
+      sha: 77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30
+    - kind: registry
+      name: countme
+      version: 3.0.1
+      sha: 7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636
+    - kind: registry
+      name: crc32fast
+      version: 1.5.0
+      sha: 9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511
+    - kind: registry
+      name: critical-section
+      version: 1.2.0
+      sha: 790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b
+    - kind: registry
+      name: crossbeam-channel
+      version: 0.5.15
+      sha: 82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2
+    - kind: registry
+      name: crossbeam-deque
+      version: 0.8.6
+      sha: 9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51
+    - kind: registry
+      name: crossbeam-epoch
+      version: 0.9.18
+      sha: 5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e
+    - kind: registry
+      name: crossbeam-utils
+      version: 0.8.21
+      sha: d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28
+    - kind: registry
+      name: crunchy
+      version: 0.2.4
+      sha: 460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5
+    - kind: registry
+      name: ctor-lite
+      version: 0.1.2
+      sha: e162d0c2e2068eb736b71e5597eff0b9944e6b973cd9f37b6a288ab9bf20e300
+    - kind: registry
+      name: cursor-icon
+      version: 1.2.0
+      sha: f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f
+    - kind: registry
+      name: data-url
+      version: 0.3.2
+      sha: be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376
+    - kind: registry
+      name: deranged
+      version: 0.5.8
+      sha: 7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c
+    - kind: registry
+      name: derive_more
+      version: 2.1.1
+      sha: d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134
+    - kind: registry
+      name: derive_more-impl
+      version: 2.1.1
+      sha: 799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb
+    - kind: registry
+      name: derive_utils
+      version: 0.15.1
+      sha: 362f47930db19fe7735f527e6595e4900316b893ebf6d48ad3d31be928d57dd6
+    - kind: registry
+      name: dirs
+      version: 4.0.0
+      sha: ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059
+    - kind: registry
+      name: dirs-sys
+      version: 0.3.7
+      sha: 1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6
+    - kind: registry
+      name: dispatch
+      version: 0.2.0
+      sha: bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b
+    - kind: registry
+      name: dispatch2
+      version: 0.3.1
+      sha: 1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38
+    - kind: registry
+      name: displaydoc
+      version: 0.2.5
+      sha: 97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0
+    - kind: registry
+      name: dlib
+      version: 0.5.3
+      sha: ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a
+    - kind: registry
+      name: downcast-rs
+      version: 1.2.1
+      sha: 75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2
+    - kind: registry
+      name: dpi
+      version: 0.1.2
+      sha: d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76
+    - kind: registry
+      name: drm
+      version: 0.14.1
+      sha: 80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f
+    - kind: registry
+      name: drm-ffi
+      version: 0.9.1
+      sha: 51a91c9b32ac4e8105dec255e849e0d66e27d7c34d184364fb93e469db08f690
+    - kind: registry
+      name: drm-fourcc
+      version: 2.2.0
+      sha: 0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4
+    - kind: registry
+      name: drm-sys
+      version: 0.8.1
+      sha: ecc8e1361066d91f5ffccff060a3c3be9c3ecde15be2959c1937595f7a82a9f8
+    - kind: registry
+      name: either
+      version: 1.15.0
+      sha: 48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719
+    - kind: registry
+      name: endi
+      version: 1.1.1
+      sha: 66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099
+    - kind: registry
+      name: enumflags2
+      version: 0.7.12
+      sha: 1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef
+    - kind: registry
+      name: enumflags2_derive
+      version: 0.7.12
+      sha: 67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827
+    - kind: registry
+      name: env_logger
+      version: 0.10.2
+      sha: 4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580
+    - kind: registry
+      name: equator
+      version: 0.4.2
+      sha: 4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc
+    - kind: registry
+      name: equator-macro
+      version: 0.4.2
+      sha: 44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3
+    - kind: registry
+      name: equivalent
+      version: 1.0.2
+      sha: 877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f
+    - kind: registry
+      name: errno
+      version: 0.3.14
+      sha: 39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb
+    - kind: registry
+      name: error-code
+      version: 3.3.2
+      sha: dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59
+    - kind: registry
+      name: euclid
+      version: 0.22.14
+      sha: f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06
+    - kind: registry
+      name: event-listener
+      version: 5.4.1
+      sha: e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab
+    - kind: registry
+      name: event-listener-strategy
+      version: 0.5.4
+      sha: 8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93
+    - kind: registry
+      name: exr
+      version: 1.74.0
+      sha: 4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be
+    - kind: registry
+      name: fastrand
+      version: 2.4.1
+      sha: 9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6
+    - kind: registry
+      name: fax
+      version: 0.2.6
+      sha: f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab
+    - kind: registry
+      name: fax_derive
+      version: 0.2.0
+      sha: a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d
+    - kind: registry
+      name: fdeflate
+      version: 0.3.7
+      sha: 1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c
+    - kind: registry
+      name: femtovg
+      version: 0.23.2
+      sha: 727c5dd9d601f3f4ea133b8a6ba37d37ca67ed59781675dc1c9c9f1701e0d197
+    - kind: registry
+      name: field-offset
+      version: 0.3.6
+      sha: 38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f
+    - kind: registry
+      name: filetime
+      version: 0.2.27
+      sha: f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db
+    - kind: registry
+      name: find-msvc-tools
+      version: 0.1.9
+      sha: 5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582
+    - kind: registry
+      name: flate2
+      version: 1.1.9
+      sha: 843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c
+    - kind: registry
+      name: float-cmp
+      version: 0.9.0
+      sha: 98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4
+    - kind: registry
+      name: fnv
+      version: 1.0.7
+      sha: 3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1
+    - kind: registry
+      name: foldhash
+      version: 0.1.5
+      sha: d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2
+    - kind: registry
+      name: foldhash
+      version: 0.2.0
+      sha: 77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb
+    - kind: registry
+      name: font-types
+      version: 0.11.3
+      sha: 5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7
+    - kind: registry
+      name: fontdb
+      version: 0.23.0
+      sha: 457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905
+    - kind: registry
+      name: fontique
+      version: 0.8.0
+      sha: 23358480a54a886d51b306718d5ca743fdfe238e5df38ef650f4e72f29c5d9e9
+    - kind: registry
+      name: foreign-types
+      version: 0.5.0
+      sha: d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965
+    - kind: registry
+      name: foreign-types-macros
+      version: 0.2.3
+      sha: 1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742
+    - kind: registry
+      name: foreign-types-shared
+      version: 0.3.1
+      sha: aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b
+    - kind: registry
+      name: form_urlencoded
+      version: 1.2.2
+      sha: cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf
+    - kind: registry
+      name: futures
+      version: 0.3.32
+      sha: 8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d
+    - kind: registry
+      name: futures-channel
+      version: 0.3.32
+      sha: 07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d
+    - kind: registry
+      name: futures-core
+      version: 0.3.32
+      sha: 7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d
+    - kind: registry
+      name: futures-executor
+      version: 0.3.32
+      sha: baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d
+    - kind: registry
+      name: futures-io
+      version: 0.3.32
+      sha: cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718
+    - kind: registry
+      name: futures-lite
+      version: 2.6.1
+      sha: f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad
+    - kind: registry
+      name: futures-macro
+      version: 0.3.32
+      sha: e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b
+    - kind: registry
+      name: futures-sink
+      version: 0.3.32
+      sha: c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893
+    - kind: registry
+      name: futures-task
+      version: 0.3.32
+      sha: 037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393
+    - kind: registry
+      name: futures-util
+      version: 0.3.32
+      sha: 389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6
+    - kind: registry
+      name: gbm
+      version: 0.18.0
+      sha: ce852e998d3ca5e4a97014fb31c940dc5ef344ec7d364984525fd11e8a547e6a
+    - kind: registry
+      name: gbm-sys
+      version: 0.4.0
+      sha: c13a5f2acc785d8fb6bf6b7ab6bfb0ef5dad4f4d97e8e70bb8e470722312f76f
+    - kind: registry
+      name: gethostname
+      version: 1.1.0
+      sha: 1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8
+    - kind: registry
+      name: getopts
+      version: 0.2.24
+      sha: cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df
+    - kind: registry
+      name: getrandom
+      version: 0.2.17
+      sha: ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0
+    - kind: registry
+      name: getrandom
+      version: 0.3.4
+      sha: 899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd
+    - kind: registry
+      name: getrandom
+      version: 0.4.2
+      sha: 0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555
+    - kind: registry
+      name: gettext-rs
+      version: 0.7.7
+      sha: 5d5857dc1b7f0fee86961de833f434e29494d72af102ce5355738c0664222bdf
+    - kind: registry
+      name: gettext-sys
+      version: 0.26.0
+      sha: 4ea859ab0dd7e70ff823032b3e077d03d39c965d68c6c10775add60e999d8ee9
+    - kind: registry
+      name: gif
+      version: 0.12.0
+      sha: 80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045
+    - kind: registry
+      name: gif
+      version: 0.14.2
+      sha: ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159
+    - kind: registry
+      name: gl_generator
+      version: 0.14.0
+      sha: 1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d
+    - kind: registry
+      name: glam
+      version: 0.22.0
+      sha: 12f597d56c1bd55a811a1be189459e8fad2bbc272616375602443bdfb37fa774
+    - kind: registry
+      name: glob
+      version: 0.3.3
+      sha: 0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280
+    - kind: registry
+      name: glow
+      version: 0.17.0
+      sha: 29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5
+    - kind: registry
+      name: glutin
+      version: 0.32.3
+      sha: 12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325
+    - kind: registry
+      name: glutin-winit
+      version: 0.5.0
+      sha: 85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f
+    - kind: registry
+      name: glutin_egl_sys
+      version: 0.7.1
+      sha: 4c4680ba6195f424febdc3ba46e7a42a0e58743f2edb115297b86d7f8ecc02d2
+    - kind: registry
+      name: glutin_glx_sys
+      version: 0.6.1
+      sha: 8a7bb2938045a88b612499fbcba375a77198e01306f52272e692f8c1f3751185
+    - kind: registry
+      name: glutin_wgl_sys
+      version: 0.6.1
+      sha: 2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e
+    - kind: registry
+      name: grid
+      version: 1.0.0
+      sha: f9e2d4c0a8296178d8802098410ca05d86b17a10bb5ab559b3fb404c1f948220
+    - kind: registry
+      name: gumdrop
+      version: 0.8.1
+      sha: 5bc700f989d2f6f0248546222d9b4258f5b02a171a431f8285a81c08142629e3
+    - kind: registry
+      name: gumdrop_derive
+      version: 0.8.1
+      sha: 729f9bd3449d77e7831a18abfb7ba2f99ee813dfd15b8c2167c9a54ba20aa99d
+    - kind: registry
+      name: h2
+      version: 0.4.13
+      sha: 2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54
+    - kind: registry
+      name: half
+      version: 2.7.1
+      sha: 6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b
+    - kind: registry
+      name: harfrust
+      version: 0.5.2
+      sha: 9da2e5ae821f6e96664977bf974d6d6a2d6682f9ccee23e62ec1d134246845f9
+    - kind: registry
+      name: hashbrown
+      version: 0.12.3
+      sha: 8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888
+    - kind: registry
+      name: hashbrown
+      version: 0.14.5
+      sha: e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1
+    - kind: registry
+      name: hashbrown
+      version: 0.15.5
+      sha: 9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1
+    - kind: registry
+      name: hashbrown
+      version: 0.16.1
+      sha: 841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100
+    - kind: registry
+      name: hashbrown
+      version: 0.17.0
+      sha: 4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51
+    - kind: registry
+      name: hdrhistogram
+      version: 7.5.4
+      sha: 765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d
+    - kind: registry
+      name: heck
+      version: 0.5.0
+      sha: 2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea
+    - kind: registry
+      name: hermit-abi
+      version: 0.3.9
+      sha: d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024
+    - kind: registry
+      name: hermit-abi
+      version: 0.5.2
+      sha: fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c
+    - kind: registry
+      name: hex
+      version: 0.4.3
+      sha: 7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70
+    - kind: registry
+      name: htmlparser
+      version: 0.2.1
+      sha: 48ce8546b993eaf241d69ded33b1be6d205dd9857ec879d9d18bd05d3676e144
+    - kind: registry
+      name: http
+      version: 1.4.0
+      sha: e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a
+    - kind: registry
+      name: http-body
+      version: 1.0.1
+      sha: 1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184
+    - kind: registry
+      name: http-body-util
+      version: 0.1.3
+      sha: b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a
+    - kind: registry
+      name: httparse
+      version: 1.10.1
+      sha: 6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87
+    - kind: registry
+      name: httpdate
+      version: 1.0.3
+      sha: df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9
+    - kind: registry
+      name: humantime
+      version: 2.3.0
+      sha: 135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424
+    - kind: registry
+      name: hyper
+      version: 1.9.0
+      sha: 6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca
+    - kind: registry
+      name: hyper-timeout
+      version: 0.5.2
+      sha: 2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0
+    - kind: registry
+      name: hyper-util
+      version: 0.1.20
+      sha: 96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0
+    - kind: registry
+      name: iana-time-zone
+      version: 0.1.65
+      sha: e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470
+    - kind: registry
+      name: iana-time-zone-haiku
+      version: 0.1.2
+      sha: f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f
+    - kind: registry
+      name: icu_collections
+      version: 2.2.0
+      sha: 2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c
+    - kind: registry
+      name: icu_locale
+      version: 2.2.0
+      sha: d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26
+    - kind: registry
+      name: icu_locale_core
+      version: 2.2.0
+      sha: 92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29
+    - kind: registry
+      name: icu_locale_data
+      version: 2.2.0
+      sha: d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993
+    - kind: registry
+      name: icu_normalizer
+      version: 2.2.0
+      sha: c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4
+    - kind: registry
+      name: icu_normalizer_data
+      version: 2.2.0
+      sha: da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38
+    - kind: registry
+      name: icu_properties
+      version: 2.2.0
+      sha: bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de
+    - kind: registry
+      name: icu_properties_data
+      version: 2.2.0
+      sha: 8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14
+    - kind: registry
+      name: icu_provider
+      version: 2.2.0
+      sha: 139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421
+    - kind: registry
+      name: icu_segmenter
+      version: 2.2.0
+      sha: 5c0794db0b1a86193ac9c48768d0e6c52c54448e0870ad87907d456ee0dac964
+    - kind: registry
+      name: icu_segmenter_data
+      version: 2.2.0
+      sha: e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f
+    - kind: registry
+      name: id-arena
+      version: 2.3.0
+      sha: 3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954
+    - kind: registry
+      name: idna
+      version: 1.1.0
+      sha: 3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de
+    - kind: registry
+      name: idna_adapter
+      version: 1.2.1
+      sha: 3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344
+    - kind: registry
+      name: image
+      version: 0.25.10
+      sha: 85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104
+    - kind: registry
+      name: image-webp
+      version: 0.2.4
+      sha: 525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3
+    - kind: registry
+      name: imagesize
+      version: 0.14.0
+      sha: 09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c
+    - kind: registry
+      name: imgref
+      version: 1.12.0
+      sha: e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8
+    - kind: registry
+      name: indexmap
+      version: 1.9.3
+      sha: bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99
+    - kind: registry
+      name: indexmap
+      version: 2.14.0
+      sha: d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9
+    - kind: registry
+      name: inotify
+      version: 0.10.2
+      sha: fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc
+    - kind: registry
+      name: inotify-sys
+      version: 0.1.5
+      sha: e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb
+    - kind: registry
+      name: input
+      version: 0.9.1
+      sha: fbdc09524a91f9cacd26f16734ff63d7dc650daffadd2b6f84d17a285bd875a9
+    - kind: registry
+      name: input-sys
+      version: 1.19.0
+      sha: 36eee07d8e02bd95bf52b2e642cf13d33701b94c6e4b04fbf1d1fb07e9cb19e7
+    - kind: registry
+      name: integer-sqrt
+      version: 0.1.5
+      sha: 276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770
+    - kind: registry
+      name: interpolate_name
+      version: 0.2.4
+      sha: c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60
+    - kind: registry
+      name: io-lifetimes
+      version: 1.0.11
+      sha: eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2
+    - kind: registry
+      name: is-terminal
+      version: 0.4.17
+      sha: 3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46
+    - kind: registry
+      name: itertools
+      version: 0.13.0
+      sha: 413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186
+    - kind: registry
+      name: itertools
+      version: 0.14.0
+      sha: 2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285
+    - kind: registry
+      name: itoa
+      version: 1.0.18
+      sha: 8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682
+    - kind: registry
+      name: jni
+      version: 0.22.4
+      sha: 5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498
+    - kind: registry
+      name: jni-macros
+      version: 0.22.4
+      sha: a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3
+    - kind: registry
+      name: jni-sys
+      version: 0.3.1
+      sha: 41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258
+    - kind: registry
+      name: jni-sys
+      version: 0.4.1
+      sha: c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2
+    - kind: registry
+      name: jni-sys-macros
+      version: 0.4.1
+      sha: 38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264
+    - kind: registry
+      name: jobserver
+      version: 0.1.34
+      sha: 9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33
+    - kind: registry
+      name: js-sys
+      version: 0.3.95
+      sha: 2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca
+    - kind: registry
+      name: keyboard-types
+      version: 0.7.0
+      sha: b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a
+    - kind: registry
+      name: khronos_api
+      version: 3.1.0
+      sha: e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc
+    - kind: registry
+      name: ksni
+      version: 0.3.4
+      sha: a7ca513d0be42df5edb485af9f44a12b2cb85af773d91c27dc796d1c58b78edc
+    - kind: registry
+      name: kurbo
+      version: 0.13.0
+      sha: 7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb
+    - kind: registry
+      name: lazy_static
+      version: 1.5.0
+      sha: bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe
+    - kind: registry
+      name: leb128fmt
+      version: 0.1.0
+      sha: 09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2
+    - kind: registry
+      name: lebe
+      version: 0.5.3
+      sha: 7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8
+    - kind: registry
+      name: libc
+      version: 0.2.185
+      sha: 52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f
+    - kind: registry
+      name: libfuzzer-sys
+      version: 0.4.12
+      sha: f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d
+    - kind: registry
+      name: libloading
+      version: 0.8.9
+      sha: d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55
+    - kind: registry
+      name: libm
+      version: 0.2.16
+      sha: b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981
+    - kind: registry
+      name: libredox
+      version: 0.1.16
+      sha: e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c
+    - kind: registry
+      name: libudev-sys
+      version: 0.1.4
+      sha: 3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324
+    - kind: registry
+      name: libusb1-sys
+      version: 0.7.0
+      sha: da050ade7ac4ff1ba5379af847a10a10a8e284181e060105bf8d86960ce9ce0f
+    - kind: registry
+      name: linebender_resource_handle
+      version: 0.1.1
+      sha: d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4
+    - kind: registry
+      name: linked-hash-map
+      version: 0.5.6
+      sha: 0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f
+    - kind: registry
+      name: linked_hash_set
+      version: 0.1.6
+      sha: 984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8
+    - kind: registry
+      name: linux-raw-sys
+      version: 0.4.15
+      sha: d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab
+    - kind: registry
+      name: linux-raw-sys
+      version: 0.9.4
+      sha: cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12
+    - kind: registry
+      name: linux-raw-sys
+      version: 0.12.1
+      sha: 32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53
+    - kind: registry
+      name: litemap
+      version: 0.8.2
+      sha: 92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0
+    - kind: registry
+      name: locale_config
+      version: 0.3.0
+      sha: 08d2c35b16f4483f6c26f0e4e9550717a2f6575bcd6f12a53ff0c490a94a6934
+    - kind: registry
+      name: log
+      version: 0.4.29
+      sha: 5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897
+    - kind: registry
+      name: logind-zbus
+      version: 5.3.2
+      sha: 469c962578b549a82f3d0cc72d0f77d1123780fa7121e2b03d78b0780f6ccac6
+    - kind: registry
+      name: loop9
+      version: 0.1.5
+      sha: 0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062
+    - kind: registry
+      name: lyon_algorithms
+      version: 1.0.19
+      sha: 9815fac08e6fd96733a11dce4f9d15a3f338e96a2e2311ee21e1b738efc2bc0f
+    - kind: registry
+      name: lyon_extra
+      version: 1.1.0
+      sha: 7755f08423275157ad1680aaecc9ccb7e0cc633da3240fea2d1522935cc15c72
+    - kind: registry
+      name: lyon_geom
+      version: 1.0.19
+      sha: 4336502e29e32af93cf2dad2214ed6003c17ceb5bd499df77b1de663b9042b92
+    - kind: registry
+      name: lyon_path
+      version: 1.0.19
+      sha: 5c463f9c428b7fc5ec885dcd39ce4aa61e29111d0e33483f6f98c74e89d8621e
+    - kind: registry
+      name: mac-notification-sys
+      version: 0.6.12
+      sha: 29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3
+    - kind: registry
+      name: malloc_buf
+      version: 0.0.6
+      sha: 62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb
+    - kind: registry
+      name: matchers
+      version: 0.2.0
+      sha: d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9
+    - kind: registry
+      name: matchit
+      version: 0.7.3
+      sha: 0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94
+    - kind: registry
+      name: maybe-rayon
+      version: 0.1.1
+      sha: 8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519
+    - kind: registry
+      name: memchr
+      version: 2.8.0
+      sha: f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79
+    - kind: registry
+      name: memmap2
+      version: 0.9.10
+      sha: 714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3
+    - kind: registry
+      name: memoffset
+      version: 0.9.1
+      sha: 488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a
+    - kind: registry
+      name: mime
+      version: 0.3.17
+      sha: 6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a
+    - kind: registry
+      name: minimal-lexical
+      version: 0.2.1
+      sha: 68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a
+    - kind: registry
+      name: miniz_oxide
+      version: 0.4.4
+      sha: a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b
+    - kind: registry
+      name: miniz_oxide
+      version: 0.8.9
+      sha: 1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316
+    - kind: registry
+      name: mio
+      version: 0.8.11
+      sha: a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c
+    - kind: registry
+      name: mio
+      version: 1.2.0
+      sha: 50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1
+    - kind: registry
+      name: moxcms
+      version: 0.8.1
+      sha: bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b
+    - kind: registry
+      name: muda
+      version: 0.17.2
+      sha: 7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177
+    - kind: registry
+      name: natord
+      version: 1.0.9
+      sha: 308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c
+    - kind: registry
+      name: ndk
+      version: 0.9.0
+      sha: c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4
+    - kind: registry
+      name: ndk-context
+      version: 0.1.1
+      sha: 27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b
+    - kind: registry
+      name: ndk-sys
+      version: 0.6.0+11769913
+      sha: ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873
+    - kind: registry
+      name: new_debug_unreachable
+      version: 1.0.6
+      sha: 650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086
+    - kind: registry
+      name: nix
+      version: 0.29.0
+      sha: 71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46
+    - kind: registry
+      name: nix
+      version: 0.30.1
+      sha: 74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6
+    - kind: registry
+      name: nom
+      version: 7.1.3
+      sha: d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a
+    - kind: registry
+      name: nom
+      version: 8.0.0
+      sha: df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405
+    - kind: registry
+      name: noop_proc_macro
+      version: 0.3.0
+      sha: 0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8
+    - kind: registry
+      name: notify-rust
+      version: 4.14.0
+      sha: 1b2c9bc1689653cfbc04400b8719f2562638ff9c545bbd48cc58c657a14526df
+    - kind: registry
+      name: num-bigint
+      version: 0.4.6
+      sha: a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9
+    - kind: registry
+      name: num-conv
+      version: 0.2.1
+      sha: c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967
+    - kind: registry
+      name: num-derive
+      version: 0.4.2
+      sha: ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202
+    - kind: registry
+      name: num-integer
+      version: 0.1.46
+      sha: 7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f
+    - kind: registry
+      name: num-rational
+      version: 0.4.2
+      sha: f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824
+    - kind: registry
+      name: num-traits
+      version: 0.2.19
+      sha: 071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841
+    - kind: registry
+      name: num_enum
+      version: 0.7.6
+      sha: 5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26
+    - kind: registry
+      name: num_enum_derive
+      version: 0.7.6
+      sha: 680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8
+    - kind: registry
+      name: objc
+      version: 0.2.7
+      sha: 915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1
+    - kind: registry
+      name: objc-foundation
+      version: 0.1.1
+      sha: 1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9
+    - kind: registry
+      name: objc-sys
+      version: 0.3.5
+      sha: cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310
+    - kind: registry
+      name: objc2
+      version: 0.5.2
+      sha: 46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804
+    - kind: registry
+      name: objc2
+      version: 0.6.4
+      sha: 3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f
+    - kind: registry
+      name: objc2-app-kit
+      version: 0.2.2
+      sha: e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff
+    - kind: registry
+      name: objc2-app-kit
+      version: 0.3.2
+      sha: d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c
+    - kind: registry
+      name: objc2-cloud-kit
+      version: 0.2.2
+      sha: 74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009
+    - kind: registry
+      name: objc2-cloud-kit
+      version: 0.3.2
+      sha: 73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c
+    - kind: registry
+      name: objc2-contacts
+      version: 0.2.2
+      sha: a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889
+    - kind: registry
+      name: objc2-core-data
+      version: 0.2.2
+      sha: 617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef
+    - kind: registry
+      name: objc2-core-data
+      version: 0.3.2
+      sha: 0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa
+    - kind: registry
+      name: objc2-core-foundation
+      version: 0.3.2
+      sha: 2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536
+    - kind: registry
+      name: objc2-core-graphics
+      version: 0.3.2
+      sha: e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807
+    - kind: registry
+      name: objc2-core-image
+      version: 0.2.2
+      sha: 55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80
+    - kind: registry
+      name: objc2-core-image
+      version: 0.3.2
+      sha: e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006
+    - kind: registry
+      name: objc2-core-location
+      version: 0.2.2
+      sha: 000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781
+    - kind: registry
+      name: objc2-core-text
+      version: 0.3.2
+      sha: 0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d
+    - kind: registry
+      name: objc2-core-video
+      version: 0.3.2
+      sha: d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6
+    - kind: registry
+      name: objc2-encode
+      version: 4.1.0
+      sha: ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33
+    - kind: registry
+      name: objc2-foundation
+      version: 0.2.2
+      sha: 0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8
+    - kind: registry
+      name: objc2-foundation
+      version: 0.3.2
+      sha: e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272
+    - kind: registry
+      name: objc2-io-surface
+      version: 0.3.2
+      sha: 180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d
+    - kind: registry
+      name: objc2-link-presentation
+      version: 0.2.2
+      sha: a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398
+    - kind: registry
+      name: objc2-metal
+      version: 0.2.2
+      sha: dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6
+    - kind: registry
+      name: objc2-metal
+      version: 0.3.2
+      sha: a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794
+    - kind: registry
+      name: objc2-quartz-core
+      version: 0.2.2
+      sha: e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a
+    - kind: registry
+      name: objc2-quartz-core
+      version: 0.3.2
+      sha: 96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f
+    - kind: registry
+      name: objc2-symbols
+      version: 0.2.2
+      sha: 0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc
+    - kind: registry
+      name: objc2-ui-kit
+      version: 0.2.2
+      sha: b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f
+    - kind: registry
+      name: objc2-ui-kit
+      version: 0.3.2
+      sha: d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22
+    - kind: registry
+      name: objc2-uniform-type-identifiers
+      version: 0.2.2
+      sha: 44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe
+    - kind: registry
+      name: objc2-user-notifications
+      version: 0.2.2
+      sha: 76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3
+    - kind: registry
+      name: objc_id
+      version: 0.1.1
+      sha: c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b
+    - kind: registry
+      name: once_cell
+      version: 1.21.4
+      sha: 9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50
+    - kind: registry
+      name: orbclient
+      version: 0.3.51
+      sha: 59aed3b33578edcfa1bc96a321d590d31832b6ad55a26f0313362ce687e9abd6
+    - kind: registry
+      name: ordered-stream
+      version: 0.2.0
+      sha: 9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50
+    - kind: registry
+      name: owned_ttf_parser
+      version: 0.25.1
+      sha: 36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b
+    - kind: registry
+      name: parking
+      version: 2.2.1
+      sha: f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba
+    - kind: registry
+      name: parlance
+      version: 0.1.0
+      sha: 4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5
+    - kind: registry
+      name: parley
+      version: 0.8.0
+      sha: d6c00ec192e1a402861526eff91a4b4690a2e5a17a4ae2deb772d72b49daf868
+    - kind: registry
+      name: parley_data
+      version: 0.8.0
+      sha: 232313eddc02ac27f015e8f8eeb7facce8a896116df7e3eda1bfd9f600a9a39d
+    - kind: registry
+      name: paste
+      version: 1.0.15
+      sha: 57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a
+    - kind: registry
+      name: pastey
+      version: 0.1.1
+      sha: 35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec
+    - kind: registry
+      name: pastey
+      version: 0.2.1
+      sha: b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec
+    - kind: registry
+      name: percent-encoding
+      version: 2.3.2
+      sha: 9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220
+    - kind: registry
+      name: pico-args
+      version: 0.5.0
+      sha: 5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315
+    - kind: registry
+      name: pin-project
+      version: 1.1.11
+      sha: f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517
+    - kind: registry
+      name: pin-project-internal
+      version: 1.1.11
+      sha: d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6
+    - kind: registry
+      name: pin-project-lite
+      version: 0.2.17
+      sha: a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd
+    - kind: registry
+      name: pin-utils
+      version: 0.1.0
+      sha: 8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184
+    - kind: registry
+      name: pin-weak
+      version: 1.1.0
+      sha: b330c9d1b92dfe68442ca20b009c717d5f0b1e3cf4965e62f704c3c6e95a1305
+    - kind: registry
+      name: piper
+      version: 0.2.5
+      sha: c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1
+    - kind: registry
+      name: pix
+      version: 0.13.4
+      sha: b6574ffbea793ab0c9a9b09ae99831f1513fdd7732b12aca4c7182c46dc3bc9f
+    - kind: registry
+      name: pkg-config
+      version: 0.3.33
+      sha: 19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e
+    - kind: registry
+      name: plain
+      version: 0.2.3
+      sha: b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6
+    - kind: registry
+      name: png
+      version: 0.17.16
+      sha: 82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526
+    - kind: registry
+      name: png
+      version: 0.18.1
+      sha: 60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61
+    - kind: registry
+      name: png_pong
+      version: 0.8.2
+      sha: 32b76c1da19406fed18e81972b9015a775447532647b04a8949135916d67778f
+    - kind: registry
+      name: polling
+      version: 3.11.0
+      sha: 5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218
+    - kind: registry
+      name: portable-atomic
+      version: 1.13.1
+      sha: c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49
+    - kind: registry
+      name: potential_utf
+      version: 0.1.5
+      sha: 0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564
+    - kind: registry
+      name: powerfmt
+      version: 0.2.0
+      sha: 439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391
+    - kind: registry
+      name: ppv-lite86
+      version: 0.2.21
+      sha: 85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9
+    - kind: registry
+      name: prettyplease
+      version: 0.2.37
+      sha: 479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b
+    - kind: registry
+      name: proc-macro-crate
+      version: 3.5.0
+      sha: e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f
+    - kind: registry
+      name: proc-macro2
+      version: 1.0.106
+      sha: 8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934
+    - kind: registry
+      name: profiling
+      version: 1.0.17
+      sha: 3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773
+    - kind: registry
+      name: profiling-procmacros
+      version: 1.0.17
+      sha: 52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b
+    - kind: registry
+      name: prost
+      version: 0.13.5
+      sha: 2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5
+    - kind: registry
+      name: prost-derive
+      version: 0.13.5
+      sha: 8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d
+    - kind: registry
+      name: prost-types
+      version: 0.13.5
+      sha: 52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16
+    - kind: registry
+      name: pulldown-cmark
+      version: 0.13.3
+      sha: 7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad
+    - kind: registry
+      name: pulldown-cmark-escape
+      version: 0.11.0
+      sha: 007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae
+    - kind: registry
+      name: pxfm
+      version: 0.1.28
+      sha: b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d
+    - kind: registry
+      name: qoi
+      version: 0.4.1
+      sha: 7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001
+    - kind: registry
+      name: quick-error
+      version: 2.0.1
+      sha: a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3
+    - kind: registry
+      name: quick-xml
+      version: 0.37.5
+      sha: 331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb
+    - kind: registry
+      name: quick-xml
+      version: 0.39.2
+      sha: 958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d
+    - kind: registry
+      name: quote
+      version: 1.0.45
+      sha: 41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924
+    - kind: registry
+      name: r-efi
+      version: 5.3.0
+      sha: 69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f
+    - kind: registry
+      name: r-efi
+      version: 6.0.0
+      sha: f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf
+    - kind: registry
+      name: rand
+      version: 0.8.5
+      sha: 34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404
+    - kind: registry
+      name: rand
+      version: 0.9.4
+      sha: 44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea
+    - kind: registry
+      name: rand_chacha
+      version: 0.3.1
+      sha: e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88
+    - kind: registry
+      name: rand_chacha
+      version: 0.9.0
+      sha: d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb
+    - kind: registry
+      name: rand_core
+      version: 0.6.4
+      sha: ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
+    - kind: registry
+      name: rand_core
+      version: 0.9.5
+      sha: 76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c
+    - kind: registry
+      name: rav1e
+      version: 0.8.1
+      sha: 43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b
+    - kind: registry
+      name: ravif
+      version: 0.13.0
+      sha: e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45
+    - kind: registry
+      name: raw-window-handle
+      version: 0.6.2
+      sha: 20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539
+    - kind: registry
+      name: raw-window-metal
+      version: 1.1.0
+      sha: 40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135
+    - kind: registry
+      name: rayon
+      version: 1.11.0
+      sha: 368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f
+    - kind: registry
+      name: rayon-core
+      version: 1.13.0
+      sha: 22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91
+    - kind: registry
+      name: read-fonts
+      version: 0.37.0
+      sha: 7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5
+    - kind: registry
+      name: redox_syscall
+      version: 0.4.1
+      sha: 4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa
+    - kind: registry
+      name: redox_syscall
+      version: 0.5.18
+      sha: ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d
+    - kind: registry
+      name: redox_syscall
+      version: 0.7.4
+      sha: f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a
+    - kind: registry
+      name: redox_users
+      version: 0.4.6
+      sha: ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43
+    - kind: registry
+      name: regex
+      version: 1.12.3
+      sha: e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276
+    - kind: registry
+      name: regex-automata
+      version: 0.4.14
+      sha: 6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f
+    - kind: registry
+      name: regex-syntax
+      version: 0.8.10
+      sha: dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a
+    - kind: registry
+      name: resvg
+      version: 0.47.0
+      sha: 9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81
+    - kind: registry
+      name: rgb
+      version: 0.8.53
+      sha: 47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4
+    - kind: registry
+      name: ron
+      version: 0.12.1
+      sha: 4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc
+    - kind: registry
+      name: rowan
+      version: 0.16.1
+      sha: 417a3a9f582e349834051b8a10c8d71ca88da4211e4093528e36b9845f6b5f21
+    - kind: registry
+      name: roxmltree
+      version: 0.21.1
+      sha: f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb
+    - kind: registry
+      name: rspolib
+      version: 0.1.2
+      sha: 4fda9a7796aff63a7b1b39ccc93fffaaf65e20042984b4843041a49ca4677535
+    - kind: registry
+      name: rusb
+      version: 0.9.4
+      sha: ab9f9ff05b63a786553a4c02943b74b34a988448671001e9a27e2f0565cc05a4
+    - kind: registry
+      name: rustc-hash
+      version: 1.1.0
+      sha: 08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2
+    - kind: registry
+      name: rustc-hash
+      version: 2.1.2
+      sha: 94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe
+    - kind: registry
+      name: rustc_version
+      version: 0.4.1
+      sha: cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92
+    - kind: registry
+      name: rustix
+      version: 0.38.44
+      sha: fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154
+    - kind: registry
+      name: rustix
+      version: 1.1.4
+      sha: b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190
+    - kind: registry
+      name: rustversion
+      version: 1.0.22
+      sha: b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d
+    - kind: registry
+      name: rustybuzz
+      version: 0.20.1
+      sha: fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702
+    - kind: registry
+      name: same-file
+      version: 1.0.6
+      sha: 93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502
+    - kind: registry
+      name: scoped-tls
+      version: 1.0.1
+      sha: e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294
+    - kind: registry
+      name: scoped-tls-hkt
+      version: 0.1.5
+      sha: e9603871ffe5df3ac39cb624790c296dbd47a400d202f56bf3e414045099524d
+    - kind: registry
+      name: scopeguard
+      version: 1.2.0
+      sha: 94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49
+    - kind: registry
+      name: sctk-adwaita
+      version: 0.10.1
+      sha: b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec
+    - kind: registry
+      name: sdl2
+      version: 0.37.0
+      sha: 3b498da7d14d1ad6c839729bd4ad6fc11d90a57583605f3b4df2cd709a9cd380
+    - kind: registry
+      name: sdl2-sys
+      version: 0.37.0
+      sha: 951deab27af08ed9c6068b7b0d05a93c91f0a8eb16b6b816a5e73452a43521d3
+    - kind: registry
+      name: semver
+      version: 1.0.28
+      sha: 8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd
+    - kind: registry
+      name: serde
+      version: 1.0.228
+      sha: 9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e
+    - kind: registry
+      name: serde_core
+      version: 1.0.228
+      sha: 41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad
+    - kind: registry
+      name: serde_derive
+      version: 1.0.228
+      sha: d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79
+    - kind: registry
+      name: serde_json
+      version: 1.0.149
+      sha: 83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86
+    - kind: registry
+      name: serde_repr
+      version: 0.1.20
+      sha: 175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c
+    - kind: registry
+      name: serde_spanned
+      version: 1.1.1
+      sha: 6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26
+    - kind: registry
+      name: sharded-slab
+      version: 0.1.7
+      sha: f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6
+    - kind: registry
+      name: shlex
+      version: 1.3.0
+      sha: 0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64
+    - kind: registry
+      name: signal-hook-registry
+      version: 1.4.8
+      sha: c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b
+    - kind: registry
+      name: simd-adler32
+      version: 0.3.9
+      sha: 703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214
+    - kind: registry
+      name: simd_cesu8
+      version: 1.1.1
+      sha: 94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33
+    - kind: registry
+      name: simd_helpers
+      version: 0.1.0
+      sha: 95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6
+    - kind: registry
+      name: simdutf8
+      version: 0.1.5
+      sha: e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e
+    - kind: registry
+      name: simplecss
+      version: 0.2.2
+      sha: 7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c
+    - kind: registry
+      name: siphasher
+      version: 1.0.2
+      sha: b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e
+    - kind: registry
+      name: skia-bindings
+      version: 0.90.0
+      sha: 8f6f96e00735f14a781aac8a6870c862b8cc831df6d8e4ad77ab78e11411b9af
+    - kind: registry
+      name: skia-safe
+      version: 0.90.0
+      sha: 6a71c01d325d40b1031dee67d251a5e0132e79e2a9ec272149a4f4a0d4b8b3be
+    - kind: registry
+      name: skrifa
+      version: 0.40.0
+      sha: 7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac
+    - kind: registry
+      name: slab
+      version: 0.4.12
+      sha: 0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5
+    - kind: registry
+      name: slotmap
+      version: 1.1.1
+      sha: bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038
+    - kind: registry
+      name: smallvec
+      version: 1.15.1
+      sha: 67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03
+    - kind: registry
+      name: smithay-client-toolkit
+      version: 0.19.2
+      sha: 3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016
+    - kind: registry
+      name: smithay-client-toolkit
+      version: 0.20.0
+      sha: 0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0
+    - kind: registry
+      name: smithay-clipboard
+      version: 0.7.3
+      sha: 71704c03f739f7745053bde45fa203a46c58d25bc5c4efba1d9a60e9dba81226
+    - kind: registry
+      name: smol
+      version: 2.0.2
+      sha: a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f
+    - kind: registry
+      name: smol_str
+      version: 0.2.2
+      sha: dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead
+    - kind: registry
+      name: smol_str
+      version: 0.3.6
+      sha: 4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523
+    - kind: registry
+      name: snafu
+      version: 0.8.9
+      sha: 6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2
+    - kind: registry
+      name: snafu-derive
+      version: 0.8.9
+      sha: c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451
+    - kind: registry
+      name: socket2
+      version: 0.5.10
+      sha: e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678
+    - kind: registry
+      name: socket2
+      version: 0.6.3
+      sha: 3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e
+    - kind: registry
+      name: softbuffer
+      version: 0.4.8
+      sha: aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3
+    - kind: registry
+      name: spin_on
+      version: 0.1.1
+      sha: 076e103ed41b9864aa838287efe5f4e3a7a0362dd00671ae62a212e5e4612da2
+    - kind: registry
+      name: stable_deref_trait
+      version: 1.2.1
+      sha: 6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596
+    - kind: registry
+      name: strict-num
+      version: 0.1.1
+      sha: 6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731
+    - kind: registry
+      name: strum
+      version: 0.28.0
+      sha: 9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd
+    - kind: registry
+      name: strum_macros
+      version: 0.28.0
+      sha: ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664
+    - kind: registry
+      name: svgtypes
+      version: 0.16.1
+      sha: 695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d
+    - kind: registry
+      name: swash
+      version: 0.2.7
+      sha: 842f3cd369c2ba38966204f983eaa5e54a8e84a7d7159ed36ade2b6c335aae64
+    - kind: registry
+      name: syn
+      version: 1.0.109
+      sha: 72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237
+    - kind: registry
+      name: syn
+      version: 2.0.117
+      sha: e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99
+    - kind: registry
+      name: sync_wrapper
+      version: 1.0.2
+      sha: 0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263
+    - kind: registry
+      name: synstructure
+      version: 0.13.2
+      sha: 728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2
+    - kind: registry
+      name: sys-locale
+      version: 0.3.2
+      sha: 8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4
+    - kind: registry
+      name: taffy
+      version: 0.9.2
+      sha: 41ba83ebaf2954d31d05d67340fd46cebe99da2b7133b0dd68d70c65473a437b
+    - kind: registry
+      name: tar
+      version: 0.4.45
+      sha: 22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973
+    - kind: registry
+      name: tauri-winrt-notification
+      version: 0.7.2
+      sha: 0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9
+    - kind: registry
+      name: temp-dir
+      version: 0.1.16
+      sha: 83176759e9416cf81ee66cb6508dbfe9c96f20b8b56265a39917551c23c70964
+    - kind: registry
+      name: tempfile
+      version: 3.27.0
+      sha: 32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd
+    - kind: registry
+      name: termcolor
+      version: 1.4.1
+      sha: 06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755
+    - kind: registry
+      name: text-size
+      version: 1.1.1
+      sha: f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233
+    - kind: registry
+      name: thiserror
+      version: 1.0.69
+      sha: b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52
+    - kind: registry
+      name: thiserror
+      version: 2.0.18
+      sha: 4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4
+    - kind: registry
+      name: thiserror-impl
+      version: 1.0.69
+      sha: 4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1
+    - kind: registry
+      name: thiserror-impl
+      version: 2.0.18
+      sha: ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5
+    - kind: registry
+      name: thread_local
+      version: 1.1.9
+      sha: f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185
+    - kind: registry
+      name: tiff
+      version: 0.11.3
+      sha: b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52
+    - kind: registry
+      name: time
+      version: 0.3.47
+      sha: 743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c
+    - kind: registry
+      name: time-core
+      version: 0.1.8
+      sha: 7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca
+    - kind: registry
+      name: tiny-skia
+      version: 0.11.4
+      sha: 83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab
+    - kind: registry
+      name: tiny-skia
+      version: 0.12.0
+      sha: 47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea
+    - kind: registry
+      name: tiny-skia-path
+      version: 0.11.4
+      sha: 9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93
+    - kind: registry
+      name: tiny-skia-path
+      version: 0.12.0
+      sha: edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9
+    - kind: registry
+      name: tiny-xlib
+      version: 0.2.4
+      sha: 0324504befd01cab6e0c994f34b2ffa257849ee019d3fb3b64fb2c858887d89e
+    - kind: registry
+      name: tinystr
+      version: 0.8.3
+      sha: c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d
+    - kind: registry
+      name: tinyvec
+      version: 1.11.0
+      sha: 3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3
+    - kind: registry
+      name: tinyvec_macros
+      version: 0.1.1
+      sha: 1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20
+    - kind: registry
+      name: tokio
+      version: 1.51.1
+      sha: f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c
+    - kind: registry
+      name: tokio-macros
+      version: 2.7.0
+      sha: 385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496
+    - kind: registry
+      name: tokio-stream
+      version: 0.1.18
+      sha: 32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70
+    - kind: registry
+      name: tokio-util
+      version: 0.7.18
+      sha: 9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098
+    - kind: registry
+      name: toml
+      version: 0.9.12+spec-1.1.0
+      sha: cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863
+    - kind: registry
+      name: toml_datetime
+      version: 0.7.5+spec-1.1.0
+      sha: 92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347
+    - kind: registry
+      name: toml_datetime
+      version: 1.1.1+spec-1.1.0
+      sha: 3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7
+    - kind: registry
+      name: toml_edit
+      version: 0.25.11+spec-1.1.0
+      sha: 0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b
+    - kind: registry
+      name: toml_parser
+      version: 1.1.2+spec-1.1.0
+      sha: a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526
+    - kind: registry
+      name: toml_writer
+      version: 1.1.1+spec-1.1.0
+      sha: 756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db
+    - kind: registry
+      name: tonic
+      version: 0.12.3
+      sha: 877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52
+    - kind: registry
+      name: tower
+      version: 0.4.13
+      sha: b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c
+    - kind: registry
+      name: tower
+      version: 0.5.3
+      sha: ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4
+    - kind: registry
+      name: tower-layer
+      version: 0.3.3
+      sha: 121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e
+    - kind: registry
+      name: tower-service
+      version: 0.3.3
+      sha: 8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3
+    - kind: registry
+      name: tracing
+      version: 0.1.44
+      sha: 63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100
+    - kind: registry
+      name: tracing-attributes
+      version: 0.1.31
+      sha: 7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da
+    - kind: registry
+      name: tracing-core
+      version: 0.1.36
+      sha: db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a
+    - kind: registry
+      name: tracing-subscriber
+      version: 0.3.23
+      sha: cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319
+    - kind: registry
+      name: try-lock
+      version: 0.2.5
+      sha: e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b
+    - kind: registry
+      name: ttf-parser
+      version: 0.25.1
+      sha: d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31
+    - kind: registry
+      name: typed-index-collections
+      version: 3.5.0
+      sha: 898160f1dfd383b4e92e17f0512a7d62f3c51c44937b23b6ffc3a1614a8eaccd
+    - kind: registry
+      name: typeid
+      version: 1.0.3
+      sha: bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c
+    - kind: registry
+      name: udev
+      version: 0.8.0
+      sha: 50051c6e22be28ee6f217d50014f3bc29e81c20dc66ff7ca0d5c5226e1dcc5a1
+    - kind: registry
+      name: udev
+      version: 0.9.3
+      sha: af4e37e9ea4401fc841ff54b9ddfc9be1079b1e89434c1a6a865dd68980f7e9f
+    - kind: registry
+      name: uds_windows
+      version: 1.2.1
+      sha: f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e
+    - kind: registry
+      name: uhid-virt
+      version: 0.0.8
+      sha: fad50862a51d693d984b07f6f6263a571554d415f5d1e16f4cbad2c266448e1b
+    - kind: registry
+      name: uhidrs-sys
+      version: 1.0.4
+      sha: aec7103e0167479f230f6baae49dbf714074d91b2ff141983524d7417c0b98a8
+    - kind: registry
+      name: unicase
+      version: 2.9.0
+      sha: dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142
+    - kind: registry
+      name: unicode-bidi
+      version: 0.3.18
+      sha: 5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5
+    - kind: registry
+      name: unicode-bidi-mirroring
+      version: 0.4.0
+      sha: 5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe
+    - kind: registry
+      name: unicode-ccc
+      version: 0.4.0
+      sha: ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e
+    - kind: registry
+      name: unicode-ident
+      version: 1.0.24
+      sha: e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75
+    - kind: registry
+      name: unicode-linebreak
+      version: 0.1.5
+      sha: 3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f
+    - kind: registry
+      name: unicode-properties
+      version: 0.1.4
+      sha: 7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d
+    - kind: registry
+      name: unicode-script
+      version: 0.5.8
+      sha: 383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee
+    - kind: registry
+      name: unicode-segmentation
+      version: 1.13.2
+      sha: 9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c
+    - kind: registry
+      name: unicode-vo
+      version: 0.1.0
+      sha: b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94
+    - kind: registry
+      name: unicode-width
+      version: 0.2.2
+      sha: b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254
+    - kind: registry
+      name: unicode-xid
+      version: 0.2.6
+      sha: ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853
+    - kind: registry
+      name: unty
+      version: 0.0.4
+      sha: 6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae
+    - kind: registry
+      name: url
+      version: 2.5.8
+      sha: ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed
+    - kind: registry
+      name: usvg
+      version: 0.47.0
+      sha: d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de
+    - kind: registry
+      name: utf8_iter
+      version: 1.0.4
+      sha: b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be
+    - kind: registry
+      name: uuid
+      version: 1.23.0
+      sha: 5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9
+    - kind: registry
+      name: v_frame
+      version: 0.3.9
+      sha: 666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2
+    - kind: registry
+      name: valuable
+      version: 0.1.1
+      sha: ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65
+    - kind: registry
+      name: vcpkg
+      version: 0.2.15
+      sha: accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426
+    - kind: registry
+      name: version-compare
+      version: 0.1.1
+      sha: 579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29
+    - kind: registry
+      name: version_check
+      version: 0.9.5
+      sha: 0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a
+    - kind: registry
+      name: versions
+      version: 6.3.2
+      sha: f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139
+    - kind: registry
+      name: walkdir
+      version: 2.5.0
+      sha: 29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b
+    - kind: registry
+      name: want
+      version: 0.3.1
+      sha: bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e
+    - kind: registry
+      name: wasi
+      version: 0.11.1+wasi-snapshot-preview1
+      sha: ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b
+    - kind: registry
+      name: wasip2
+      version: 1.0.2+wasi-0.2.9
+      sha: 9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5
+    - kind: registry
+      name: wasip3
+      version: 0.4.0+wasi-0.3.0-rc-2026-01-06
+      sha: 5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5
+    - kind: registry
+      name: wasm-bindgen
+      version: 0.2.118
+      sha: 0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89
+    - kind: registry
+      name: wasm-bindgen-futures
+      version: 0.4.68
+      sha: f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8
+    - kind: registry
+      name: wasm-bindgen-macro
+      version: 0.2.118
+      sha: eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed
+    - kind: registry
+      name: wasm-bindgen-macro-support
+      version: 0.2.118
+      sha: 9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904
+    - kind: registry
+      name: wasm-bindgen-shared
+      version: 0.2.118
+      sha: 5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129
+    - kind: registry
+      name: wasm-encoder
+      version: 0.244.0
+      sha: 990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319
+    - kind: registry
+      name: wasm-metadata
+      version: 0.244.0
+      sha: bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909
+    - kind: registry
+      name: wasmparser
+      version: 0.244.0
+      sha: 47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe
+    - kind: registry
+      name: wayland-backend
+      version: 0.3.15
+      sha: 2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d
+    - kind: registry
+      name: wayland-client
+      version: 0.31.14
+      sha: 645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144
+    - kind: registry
+      name: wayland-csd-frame
+      version: 0.3.0
+      sha: 625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e
+    - kind: registry
+      name: wayland-cursor
+      version: 0.31.14
+      sha: 4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d
+    - kind: registry
+      name: wayland-protocols
+      version: 0.32.12
+      sha: 563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f
+    - kind: registry
+      name: wayland-protocols-experimental
+      version: 20250721.0.1
+      sha: 40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1
+    - kind: registry
+      name: wayland-protocols-misc
+      version: 0.3.12
+      sha: 6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8
+    - kind: registry
+      name: wayland-protocols-plasma
+      version: 0.3.12
+      sha: 2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91
+    - kind: registry
+      name: wayland-protocols-wlr
+      version: 0.3.12
+      sha: eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234
+    - kind: registry
+      name: wayland-scanner
+      version: 0.31.10
+      sha: 9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a
+    - kind: registry
+      name: wayland-sys
+      version: 0.31.11
+      sha: d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be
+    - kind: registry
+      name: web-sys
+      version: 0.3.95
+      sha: 4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d
+    - kind: registry
+      name: web-time
+      version: 1.1.0
+      sha: 5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb
+    - kind: registry
+      name: webbrowser
+      version: 1.2.0
+      sha: fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16
+    - kind: registry
+      name: weezl
+      version: 0.1.12
+      sha: a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88
+    - kind: registry
+      name: winapi
+      version: 0.3.9
+      sha: 5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419
+    - kind: registry
+      name: winapi-i686-pc-windows-gnu
+      version: 0.4.0
+      sha: ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6
+    - kind: registry
+      name: winapi-util
+      version: 0.1.11
+      sha: c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22
+    - kind: registry
+      name: winapi-x86_64-pc-windows-gnu
+      version: 0.4.0
+      sha: 712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
+    - kind: registry
+      name: windows
+      version: 0.61.3
+      sha: 9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893
+    - kind: registry
+      name: windows
+      version: 0.62.2
+      sha: 527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580
+    - kind: registry
+      name: windows-collections
+      version: 0.2.0
+      sha: 3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8
+    - kind: registry
+      name: windows-collections
+      version: 0.3.2
+      sha: 23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610
+    - kind: registry
+      name: windows-core
+      version: 0.61.2
+      sha: c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3
+    - kind: registry
+      name: windows-core
+      version: 0.62.2
+      sha: b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb
+    - kind: registry
+      name: windows-future
+      version: 0.2.1
+      sha: fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e
+    - kind: registry
+      name: windows-future
+      version: 0.3.2
+      sha: e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb
+    - kind: registry
+      name: windows-implement
+      version: 0.60.2
+      sha: 053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf
+    - kind: registry
+      name: windows-interface
+      version: 0.59.3
+      sha: 3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358
+    - kind: registry
+      name: windows-link
+      version: 0.1.3
+      sha: 5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a
+    - kind: registry
+      name: windows-link
+      version: 0.2.1
+      sha: f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5
+    - kind: registry
+      name: windows-numerics
+      version: 0.2.0
+      sha: 9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1
+    - kind: registry
+      name: windows-numerics
+      version: 0.3.1
+      sha: 6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26
+    - kind: registry
+      name: windows-result
+      version: 0.3.4
+      sha: 56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6
+    - kind: registry
+      name: windows-result
+      version: 0.4.1
+      sha: 7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5
+    - kind: registry
+      name: windows-strings
+      version: 0.4.2
+      sha: 56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57
+    - kind: registry
+      name: windows-strings
+      version: 0.5.1
+      sha: 7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091
+    - kind: registry
+      name: windows-sys
+      version: 0.48.0
+      sha: 677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9
+    - kind: registry
+      name: windows-sys
+      version: 0.52.0
+      sha: 282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d
+    - kind: registry
+      name: windows-sys
+      version: 0.59.0
+      sha: 1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b
+    - kind: registry
+      name: windows-sys
+      version: 0.60.2
+      sha: f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb
+    - kind: registry
+      name: windows-sys
+      version: 0.61.2
+      sha: ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc
+    - kind: registry
+      name: windows-targets
+      version: 0.48.5
+      sha: 9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c
+    - kind: registry
+      name: windows-targets
+      version: 0.52.6
+      sha: 9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973
+    - kind: registry
+      name: windows-targets
+      version: 0.53.5
+      sha: 4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3
+    - kind: registry
+      name: windows-threading
+      version: 0.1.0
+      sha: b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6
+    - kind: registry
+      name: windows-threading
+      version: 0.2.1
+      sha: 3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37
+    - kind: registry
+      name: windows-version
+      version: 0.1.7
+      sha: e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631
+    - kind: registry
+      name: windows_aarch64_gnullvm
+      version: 0.48.5
+      sha: 2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8
+    - kind: registry
+      name: windows_aarch64_gnullvm
+      version: 0.52.6
+      sha: 32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3
+    - kind: registry
+      name: windows_aarch64_gnullvm
+      version: 0.53.1
+      sha: a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53
+    - kind: registry
+      name: windows_aarch64_msvc
+      version: 0.48.5
+      sha: dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc
+    - kind: registry
+      name: windows_aarch64_msvc
+      version: 0.52.6
+      sha: 09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469
+    - kind: registry
+      name: windows_aarch64_msvc
+      version: 0.53.1
+      sha: b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006
+    - kind: registry
+      name: windows_i686_gnu
+      version: 0.48.5
+      sha: a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e
+    - kind: registry
+      name: windows_i686_gnu
+      version: 0.52.6
+      sha: 8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b
+    - kind: registry
+      name: windows_i686_gnu
+      version: 0.53.1
+      sha: 960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3
+    - kind: registry
+      name: windows_i686_gnullvm
+      version: 0.52.6
+      sha: 0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66
+    - kind: registry
+      name: windows_i686_gnullvm
+      version: 0.53.1
+      sha: fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c
+    - kind: registry
+      name: windows_i686_msvc
+      version: 0.48.5
+      sha: 8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406
+    - kind: registry
+      name: windows_i686_msvc
+      version: 0.52.6
+      sha: 240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66
+    - kind: registry
+      name: windows_i686_msvc
+      version: 0.53.1
+      sha: 1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2
+    - kind: registry
+      name: windows_x86_64_gnu
+      version: 0.48.5
+      sha: 53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e
+    - kind: registry
+      name: windows_x86_64_gnu
+      version: 0.52.6
+      sha: 147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78
+    - kind: registry
+      name: windows_x86_64_gnu
+      version: 0.53.1
+      sha: 9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499
+    - kind: registry
+      name: windows_x86_64_gnullvm
+      version: 0.48.5
+      sha: 0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc
+    - kind: registry
+      name: windows_x86_64_gnullvm
+      version: 0.52.6
+      sha: 24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d
+    - kind: registry
+      name: windows_x86_64_gnullvm
+      version: 0.53.1
+      sha: 0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1
+    - kind: registry
+      name: windows_x86_64_msvc
+      version: 0.48.5
+      sha: ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538
+    - kind: registry
+      name: windows_x86_64_msvc
+      version: 0.52.6
+      sha: 589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec
+    - kind: registry
+      name: windows_x86_64_msvc
+      version: 0.53.1
+      sha: d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650
+    - kind: registry
+      name: winit
+      version: 0.30.13
+      sha: a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d
+    - kind: registry
+      name: winnow
+      version: 0.7.15
+      sha: df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945
+    - kind: registry
+      name: winnow
+      version: 1.0.1
+      sha: 09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5
+    - kind: registry
+      name: wit-bindgen
+      version: 0.51.0
+      sha: d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5
+    - kind: registry
+      name: wit-bindgen-core
+      version: 0.51.0
+      sha: ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc
+    - kind: registry
+      name: wit-bindgen-rust
+      version: 0.51.0
+      sha: b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21
+    - kind: registry
+      name: wit-bindgen-rust-macro
+      version: 0.51.0
+      sha: 0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a
+    - kind: registry
+      name: wit-component
+      version: 0.244.0
+      sha: 9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2
+    - kind: registry
+      name: wit-parser
+      version: 0.244.0
+      sha: ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736
+    - kind: registry
+      name: write-fonts
+      version: 0.45.0
+      sha: f12725b0845073e20b04e79b500dbfb465904d7cbd84883a1f1bbd084debc515
+    - kind: registry
+      name: writeable
+      version: 0.6.3
+      sha: 1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4
+    - kind: registry
+      name: x11-clipboard
+      version: 0.9.3
+      sha: 662d74b3d77e396b8e5beb00b9cad6a9eccf40b2ef68cc858784b14c41d535a3
+    - kind: registry
+      name: x11-dl
+      version: 2.21.0
+      sha: 38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f
+    - kind: registry
+      name: x11rb
+      version: 0.13.2
+      sha: 9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414
+    - kind: registry
+      name: x11rb-protocol
+      version: 0.13.2
+      sha: ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd
+    - kind: registry
+      name: xattr
+      version: 1.6.1
+      sha: 32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156
+    - kind: registry
+      name: xcursor
+      version: 0.3.10
+      sha: bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b
+    - kind: registry
+      name: xkbcommon
+      version: 0.9.0
+      sha: a7a974f48060a14e95705c01f24ad9c3345022f4d97441b8a36beb7ed5c4a02d
+    - kind: registry
+      name: xkbcommon-dl
+      version: 0.4.2
+      sha: d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5
+    - kind: registry
+      name: xkeysym
+      version: 0.2.1
+      sha: b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56
+    - kind: registry
+      name: xml-rs
+      version: 0.8.28
+      sha: 3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f
+    - kind: registry
+      name: xmlwriter
+      version: 0.1.0
+      sha: ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9
+    - kind: registry
+      name: y4m
+      version: 0.8.0
+      sha: 7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448
+    - kind: registry
+      name: yazi
+      version: 0.2.1
+      sha: e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5
+    - kind: registry
+      name: yeslogic-fontconfig-sys
+      version: 6.0.0
+      sha: 503a066b4c037c440169d995b869046827dbc71263f6e8f3be6d77d4f3229dbd
+    - kind: registry
+      name: yoke
+      version: 0.8.2
+      sha: abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca
+    - kind: registry
+      name: yoke-derive
+      version: 0.8.2
+      sha: de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e
+    - kind: registry
+      name: zbus
+      version: 5.14.0
+      sha: ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc
+    - kind: registry
+      name: zbus_macros
+      version: 5.14.0
+      sha: 897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222
+    - kind: registry
+      name: zbus_names
+      version: 4.3.1
+      sha: ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f
+    - kind: registry
+      name: zeno
+      version: 0.3.3
+      sha: 6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524
+    - kind: registry
+      name: zerocopy
+      version: 0.8.48
+      sha: eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9
+    - kind: registry
+      name: zerocopy-derive
+      version: 0.8.48
+      sha: 70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4
+    - kind: registry
+      name: zerofrom
+      version: 0.1.7
+      sha: 69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df
+    - kind: registry
+      name: zerofrom-derive
+      version: 0.1.7
+      sha: 11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1
+    - kind: registry
+      name: zerotrie
+      version: 0.2.4
+      sha: 0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf
+    - kind: registry
+      name: zerovec
+      version: 0.11.6
+      sha: 90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239
+    - kind: registry
+      name: zerovec-derive
+      version: 0.11.3
+      sha: 625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555
+    - kind: registry
+      name: zmij
+      version: 1.0.21
+      sha: b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa
+    - kind: registry
+      name: zune-core
+      version: 0.5.1
+      sha: cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9
+    - kind: registry
+      name: zune-inflate
+      version: 0.2.54
+      sha: 73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02
+    - kind: registry
+      name: zune-jpeg
+      version: 0.5.15
+      sha: 27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296
+    - kind: registry
+      name: zvariant
+      version: 5.10.0
+      sha: 5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b
+    - kind: registry
+      name: zvariant_derive
+      version: 5.10.0
+      sha: 5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c
+    - kind: registry
+      name: zvariant_utils
+      version: 3.3.0
+      sha: f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -28,6 +28,7 @@ depends:
   - bluefin/sudo-rs.bst
   - bluefin/efibootmgr.bst
   - bluefin/xdg-terminal-exec.bst
+  - bluefin/asusctl.bst
 
   # Include things missing from the gnomeos base image
   - freedesktop-sdk.bst:components/buildstream2.bst


### PR DESCRIPTION
This adds the components needed so when 6.19 and 7.0 kernels drop we get better Asus support. Supported by the OGC. 

The GUI we're leaving out, brew is probably the way to go for the GUI apps. 


Agent notes:

Packages the asusctl suite (asusd daemon, asusctl CLI, asus-shutdown, asusd-user) as a cargo2/make BuildStream element.

Hardware gating: upstream udev rules (99-asusd.rules) triple-gate activation via DMI vendor glob (ASUS*), product family allowlist (ROG/TUF/Zephyrus/Strix/Vivobook/Zenbook/ProArt/TX Air/Gaming/EXPERTBOOK), and asus-nb-wmi driver probe. No systemd preset installed — the service is invisible on non-ASUS hardware (never loaded, absent from list-units/--failed, zero journal noise at boot).

Build notes:
- rog-control-center excluded via Cargo.toml workspace patch (two sed patterns cover per-line members list and inline default-members array; guard fails loudly if upstream reformats)
- sg-rs (git dep of rog-scsi → asusd) vendored via cargo2 git entry
- Added pkg-config to build-depends (not in buildsystem-make.bst)
- --offline instead of --locked (workspace patch invalidates lock check)

Installs:
  /usr/bin/{asusd,asusctl,asus-shutdown,asusd-user} /usr/lib/udev/rules.d/99-asusd.rules /usr/lib/systemd/system/{asusd,asus-shutdown}.service /usr/lib/systemd/user/asusd-user.service /usr/share/dbus-1/system.d/asusd.conf /usr/share/asusd/{aura_support.ron,anime/**} /usr/share/rog-gui/layouts/*.ron /usr/share/icons/hicolor/512x512/apps/asus_notif_*.png

Verified: bst build ✅  just build ✅  just lint ✅
Binaries confirmed in final OCI image.

Future: CONFIG_ASUS_ARMOURY (battery limits, fan curves, Aura/RGB on 2021+ ROG hardware) requires kernel ≥6.19; add module to kernel config patch once freedesktop-sdk bumps.