### PR TITLE
ci: add nightly schedule at 13:00 UTC; drop redundant push trigger

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,85 @@
+> Pointer-only wrapper. Full rules and procedures live in the domain skills.
+> Skills index: `cat ~/src/skills/INDEX.md`
+> Load domain skills before any dakota work:
+> - CI/workflow changes: `cat ~/src/skills/dakota-ci/SKILL.md`
+> - BST element authoring: `cat ~/src/skills/dakota-buildstream/SKILL.md`
+> - Package-specific: `cat ~/src/skills/dakota-package-<lang>/SKILL.md`
+> - OCI layer assembly: `cat ~/src/skills/dakota-oci-layers/SKILL.md`
+
+## Build commands
+
+```bash
+just bst build oci/bluefin.bst   # full image build (inside bst2 container)
+just build                        # alias for the above
+just export                       # export OCI image from BST into podman
+just lint                         # bootc container lint (requires exported image)
+just bst show oci/bluefin.bst     # inspect element dependency graph
+```
+
+Builds run inside the pinned `bst2` container. `BST_FLAGS` env var injects flags:
+
+```bash
+BST_FLAGS="--no-interactive" just bst build oci/bluefin.bst
+```
+
+## ⚠️ Hard rules (learned from real mistakes)
+
+### 1. Always branch from upstream/main
+
+```bash
+git checkout upstream/main -b feature/my-change
+```
+
+**Never branch from local `main`.** The `castrojo/dakota` fork diverges from `projectbluefin/dakota` by 20+ commits. Branching from local `main` creates PRs with hundreds of unrelated files.
+
+Verify before pushing:
+```bash
+git diff upstream/main...HEAD --stat
+```
+
+### 2. cargo2 source blocks are generated — never hand-written
+
+```bash
+python3 files/scripts/generate_cargo_sources.py path/to/Cargo.lock
+```
+
+The first ~65 lines of a Rust BST element are hand-authored (build commands, install paths). Everything after that is generated crate manifest. Do not write crate entries by hand.
+
+### 3. Layer elements must be `kind: compose`, not `kind: stack`
+
+Elements staged as `/layer` in OCI script elements **must** be `kind: compose`. `kind: stack` is a dependency aggregator that produces **zero filesystem output** — the image builds successfully but the layer is silently empty.
+
+```yaml
+# ✅ correct — produces filesystem content
+kind: compose
+
+# ❌ wrong — silently empty layer
+kind: stack
+```
+
+### 4. No /issues/NNN paths in issue bodies
+
+GitHub autolinks `org/repo#NNN` and `/issues/NNN` paths regardless of code fence context, firing cross-repo notifications. Write upstream references as plain text:
+
+```
+# ✅ correct
+bootc-dev/bootc issue 7
+
+# ❌ wrong — spams the other repo
+https://github.com/bootc-dev/bootc/issues/7
+```
+
+## CI overview
+
+- **Schedule:** nightly at 13:00 UTC (after gnome-build-meta nightly ~08:00 UTC finish)
+- **Publish triggers:** `merge_group`, `schedule`, `workflow_dispatch` (not `pull_request`)
+- **Remote cache:** `cache.projectbluefin.io:11002` (mTLS — `CASD_CLIENT_CERT` + `CASD_CLIENT_KEY`)
+- **Image:** `ghcr.io/projectbluefin/dakota:latest` and `:<sha>`
+
+## Key architecture
+
+- Built on gnome-build-meta + freedesktop-sdk via BST junctions
+- `elements/bluefin/deps.bst` (`kind: stack`) — add new packages here
+- `elements/oci/layers/` — compose chain filters artifacts into the final layer
+- `elements/oci/bluefin.bst` — final OCI assembly script
+- `patches/gnome-build-meta/` — drop `.patch` files here (alphabetical order, no edits to `gnome-build-meta.bst`)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,11 @@
 name: Build Bluefin dakota
 
 on:
-  push:
-    branches: [main]
-    paths-ignore: ["**/*.md"]
+  schedule:
+    # 13:00 UTC daily — gnome-build-meta nightly starts ~02:00 UTC and typically
+    # finishes by ~08:00 UTC (worst-case ~11:30). The 2-hour buffer here handles
+    # normal build-time fluctuations so dakota always picks up the freshest artifacts.
+    - cron: '0 13 * * *'
   pull_request:
     branches: [main]
   merge_group:
@@ -222,13 +224,19 @@ jobs:
           if-no-files-found: ignore
 
       - name: Login to GHCR
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: >-
+          github.event_name == 'merge_group' ||
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch'
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | \
             sudo podman login ghcr.io --username ${{ github.actor }} --password-stdin
 
       - name: Tag image for GHCR
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: >-
+          github.event_name == 'merge_group' ||
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch'
         run: |
           sudo podman tag "localhost/${{ steps.export.outputs.image_ref }}" \
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
@@ -236,7 +244,10 @@ jobs:
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
 
       - name: Push to GHCR
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: >-
+          github.event_name == 'merge_group' ||
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch'
         run: |
           for tag in latest "${{ github.sha }}"; do
             for i in 1 2 3; do


### PR DESCRIPTION
gnome-build-meta nightly pipelines start ~02:00 UTC and typically complete by ~08:00 UTC (observed worst-case ~11:30 UTC). Scheduling at 13:00 UTC ensures dakota always builds against the freshest upstream artifacts with adequate buffer for pipeline fluctuations.

Remove the push:main trigger — merge_group already validates a speculative merge commit before it lands on main, making a second post-merge CI run redundant. Update GHCR publish condition to fire on merge_group, schedule, and workflow_dispatch instead.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot