### PR TITLE
feat(distrobox): switch to next branch Go rewrite

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -43,6 +43,6 @@ depends:
   - gnome-build-meta.bst:gnomeos-deps/bpftop.bst
   - gnome-build-meta.bst:core/sysprof-app.bst
 
-  - gnome-build-meta.bst:gnomeos-deps/distrobox.bst
+  - bluefin/distrobox.bst
   - gnome-build-meta.bst:gnomeos-deps/just.bst
   - gnome-build-meta.bst:gnomeos-deps/wl-clipboard.bst

--- a/elements/bluefin/distrobox.bst
+++ b/elements/bluefin/distrobox.bst
@@ -1,0 +1,93 @@
+# Override: distrobox next branch (Go port).
+# Replaces gnome-build-meta.bst:gnomeos-deps/distrobox.bst (shell-based).
+# Tracks 89luca89/distrobox:next — the full Go rewrite.
+kind: manual
+
+build-depends:
+- freedesktop-sdk.bst:components/go.bst
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+runtime-depends:
+- freedesktop-sdk.bst:components/podman.bst
+
+variables:
+  strip-binaries: ""
+
+environment:
+  GOARCH: "%{go-arch}"
+
+config:
+  build-commands:
+  - mv -vf modules.txt vendor/modules.txt
+  - CGO_ENABLED=0 go build -mod=vendor -ldflags="-s -w" -o ./bin/distrobox ./cmd/distrobox
+
+  install-commands:
+  - install -Dm755 ./bin/distrobox "%{install-root}%{bindir}/distrobox"
+  - |
+    for cmd in assemble create enter ephemeral generate-entry list ls rm stop upgrade; do
+      ln -sf distrobox "%{install-root}%{bindir}/distrobox-${cmd}"
+    done
+  - install -Dm644 completions/bash/distrobox "%{install-root}%{datadir}/bash-completion/completions/distrobox"
+  - install -Dm644 completions/zsh/_distrobox "%{install-root}%{datadir}/zsh/site-functions/_distrobox"
+  - install -d "%{install-root}%{mandir}/man1"
+  - install -m644 man/man1/*.1 "%{install-root}%{mandir}/man1/"
+  - "%{install-extra}"
+
+sources:
+- kind: git_repo
+  url: github:89luca89/distrobox.git
+  track: next
+  ref: f547b6d6730f5ad634f6abe41b776f7b7fd0b54d
+
+- kind: local
+  path: files/distrobox/modules.txt
+
+- kind: go_module
+  url: github:davecgh/go-spew.git
+  module: github.com/davecgh/go-spew
+  ref:
+    go-version: v1.1.1
+    git-ref: v1.1.1-0-g8991bc29aa16c548c550c7ff78260e27b9ab7c73
+    explicit: True
+
+- kind: go_module
+  url: github:pmezard/go-difflib.git
+  module: github.com/pmezard/go-difflib
+  ref:
+    go-version: v1.0.0
+    git-ref: v1.0.0-0-g792786c7400a136282c1664665ae0a8db921c6c2
+    explicit: True
+
+- kind: go_module
+  url: github:stretchr/testify.git
+  module: github.com/stretchr/testify
+  ref:
+    go-version: v1.11.1
+    git-ref: v1.11.1-0-g2a57335dc9cd6833daa820bc94d9b40c26a7917d
+    explicit: True
+
+- kind: go_module
+  url: github:urfave/cli.git
+  module: github.com/urfave/cli/v3
+  ref:
+    go-version: v3.5.0
+    git-ref: v3.5.0-0-g495e1d30c76923fbefbc095c0b01f9398529bb67
+    explicit: True
+
+- kind: go_module
+  url: github:go-ini/ini.git
+  module: gopkg.in/ini.v1
+  ref:
+    go-version: v1.67.0
+    git-ref: v1.67.0-0-gb2f570e5b5b844226bbefe6fb521d891f529a951
+    explicit: True
+
+- kind: go_module
+  url: github:go-yaml/yaml.git
+  module: gopkg.in/yaml.v3
+  ref:
+    go-version: v3.0.1
+    git-ref: v3.0.1-0-gf6f7691b1fdeb513f56608cd2c32c51f8194bf51
+    explicit: True

--- a/files/distrobox/modules.txt
+++ b/files/distrobox/modules.txt
@@ -1,0 +1,20 @@
+# github.com/davecgh/go-spew v1.1.1
+## explicit
+github.com/davecgh/go-spew/spew
+# github.com/pmezard/go-difflib v1.0.0
+## explicit
+github.com/pmezard/go-difflib/difflib
+# github.com/stretchr/testify v1.11.1
+## explicit; go 1.17
+github.com/stretchr/testify/assert
+github.com/stretchr/testify/assert/yaml
+github.com/stretchr/testify/require
+# github.com/urfave/cli/v3 v3.5.0
+## explicit; go 1.22
+github.com/urfave/cli/v3
+# gopkg.in/ini.v1 v1.67.0
+## explicit
+gopkg.in/ini.v1
+# gopkg.in/yaml.v3 v3.0.1
+## explicit
+gopkg.in/yaml.v3

--- a/project.conf
+++ b/project.conf
@@ -95,6 +95,7 @@ plugins:
       - cargo2
       - git_module
       - git_repo
+      - go_module
       - patch_queue
       - zip
 


### PR DESCRIPTION
Talked to Luca, 2.0 is in RC so let's plop it in here and we can swap back to the GNOMEOS version post release. This lets us bang on it for a while. 


Agent notes:

Replace gnome-build-meta.bst:gnomeos-deps/distrobox.bst (shell-based, v1.8.x) with a new elements/bluefin/distrobox.bst that builds from the `next` branch of 89luca89/distrobox — a full rewrite in Go.

Changes:
- Add elements/bluefin/distrobox.bst (kind: manual, go_module sources)
- Add files/distrobox/modules.txt (vendor/modules.txt for -mod=vendor)
- Register go_module source plugin in project.conf
- Swap deps.bst entry from junction ref to bluefin/distrobox.bst

Build details:
- HEAD ref: f547b6d6730f5ad634f6abe41b776f7b7fd0b54d (next branch)
- CGO_ENABLED=0, pure Go binary, no C dependencies
- Go toolchain: freedesktop-sdk.bst:components/go.bst (ships 1.25.7, satisfies go.mod requirement of 1.25.3+)
- Binary: /usr/bin/distrobox (~12.8MB), version: 1.0.0
- 6 Go module dependencies sourced via go_module source kind
- gopkg.in modules use GitHub mirror URLs (git_https: alias not available in dakota project scope)

Build verified locally:
  just bst build bluefin/distrobox.bst → SUCCESS just bst shell bluefin/distrobox.bst -- /usr/bin/distrobox --version → distrobox version 1.0.0

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot