### PR TITLE
ci: disable remote-execution for aarch64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -357,27 +357,10 @@ jobs:
                 client-key: /src/client.key
                 client-cert: /src/client.crt
 
-          remote-execution:
-            execution-service:
-              url: https://cache.projectbluefin.io:11002
-              connection-config:
-                keepalive-time: 60
-                retry-limit: 5
-                retry-delay: 1000
-                request-timeout: 180
-              auth:
-                client-key: /src/client.key
-                client-cert: /src/client.crt
-            action-cache-service:
-              url: https://cache.projectbluefin.io:11002
-              connection-config:
-                keepalive-time: 60
-                retry-limit: 5
-                retry-delay: 1000
-                request-timeout: 180
-              auth:
-                client-key: /src/client.key
-                client-cert: /src/client.crt
+          # remote-execution is intentionally omitted for aarch64:
+          # cache.projectbluefin.io only has x86_64 workers and rejects
+          # aarch64 jobs with "Unsupported ISA aarch64". Builds run locally
+          # on the ubuntu-24.04-arm runner; artifacts are still cached.
           BSTCONFPUSH
           fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,6 +263,8 @@ jobs:
   build-aarch64:
     runs-on: ubuntu-24.04-arm
     continue-on-error: true
+    outputs:
+      pushed: ${{ steps.push-aarch64.outputs.pushed }}
     permissions:
       contents: read
       packages: write
@@ -423,6 +425,7 @@ jobs:
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:aarch64-${{ github.sha }}"
 
       - name: Push to GHCR
+        id: push-aarch64
         if: >-
           github.event_name == 'merge_group' ||
           github.event_name == 'schedule' ||
@@ -435,10 +438,13 @@ jobs:
               sleep 5
             done
           done
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
 
   # ── Multi-arch manifest ───────────────────────────────────────────────────
   # Combines :latest (x86_64) and :aarch64 into a single multi-arch manifest.
-  # Only runs when both build jobs succeed and this is a publish event.
+  # Only runs when :aarch64 was actually pushed this run (not just when the
+  # job completed — continue-on-error makes needs.result == 'success' even on
+  # failure, so we gate on the step output instead).
   # ARM failures skip this job without affecting x86_64 publication.
   create-manifest:
     runs-on: ubuntu-24.04
@@ -447,7 +453,7 @@ jobs:
       (github.event_name == 'merge_group' ||
        github.event_name == 'schedule' ||
        github.event_name == 'workflow_dispatch') &&
-      needs.build-aarch64.result == 'success'
+      needs.build-aarch64.outputs.pushed == 'true'
     permissions:
       packages: write
     steps:


### PR DESCRIPTION
## Problem

Two related bugs in the `build-aarch64` CI job:

### 1. Remote execution rejects aarch64

The BST build fails immediately with:
```
FAILURE oci/os-release.bst: Unsupported ISA "aarch64"
```
The remote execution service at `cache.projectbluefin.io:11002` only has x86_64 workers. 58 elements fail per run. Fix: remove the `remote-execution:` block from the aarch64 CI config so BST builds locally on `ubuntu-24.04-arm`. Artifacts/source-caches still use the CAS server.

### 2. `create-manifest` gates on wrong condition

GitHub Actions documents that `needs.<job>.result` returns `'success'` for jobs with `continue-on-error: true`, **even when the job fails**. So the existing condition:
```yaml
needs.build-aarch64.result == 'success'
```
was always true, causing `create-manifest` to run after every publish build even when arm64 never pushed `:aarch64`. This could corrupt `:latest` by pushing a manifest that references a non-existent or stale aarch64 image.

Fix: add `pushed=true` step output to the aarch64 Push to GHCR step. Gate `create-manifest` on `needs.build-aarch64.outputs.pushed == 'true'` — only set when tags are actually in the registry.

## Fixes

1. Remove `remote-execution:` from aarch64 BST config (build locally on arm runner)
2. Gate `create-manifest` on step output, not job result

## Validation

- `feat/aarch64-build` (SHA `ecd36d7e`) succeeded with local builds in 2h30m — proves disk/time is fine
- Step output pattern ensures `create-manifest` only runs when `:aarch64` is actually in the registry