### PR TITLE
ci(aarch64): add native aarch64 build and multi-arch manifest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -435,8 +435,9 @@ jobs:
       - name: Login to GHCR
         if: >-
           steps.arm_build.outcome == 'success' &&
-          github.event_name == 'push' &&
-          github.ref == 'refs/heads/main'
+          (github.event_name == 'merge_group' ||
+           github.event_name == 'schedule' ||
+           github.event_name == 'workflow_dispatch')
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | \
             sudo podman login ghcr.io --username ${{ github.actor }} --password-stdin
@@ -444,8 +445,9 @@ jobs:
       - name: Tag image for GHCR
         if: >-
           steps.arm_build.outcome == 'success' &&
-          github.event_name == 'push' &&
-          github.ref == 'refs/heads/main'
+          (github.event_name == 'merge_group' ||
+           github.event_name == 'schedule' ||
+           github.event_name == 'workflow_dispatch')
         run: |
           sudo podman tag "localhost/${{ steps.export.outputs.image_ref }}" \
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:aarch64"
@@ -455,8 +457,9 @@ jobs:
       - name: Push to GHCR
         if: >-
           steps.arm_build.outcome == 'success' &&
-          github.event_name == 'push' &&
-          github.ref == 'refs/heads/main'
+          (github.event_name == 'merge_group' ||
+           github.event_name == 'schedule' ||
+           github.event_name == 'workflow_dispatch')
         run: |
           for tag in aarch64 "${{ github.sha }}-aarch64"; do
             for i in 1 2 3; do
@@ -481,6 +484,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [build, build-aarch64]
     if: >-
+      (github.event_name == 'merge_group' ||
+       github.event_name == 'schedule' ||
+       github.event_name == 'workflow_dispatch') &&
       needs.build.result == 'success' &&
       needs.build-aarch64.outputs.build_ok == 'true'
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,6 +269,7 @@ jobs:
 # block x86_64 pushes. The create-manifest job gates on outputs.build_ok.
   build-aarch64:
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 360
     continue-on-error: true
     outputs:
       build_ok: ${{ steps.arm_status.outputs.build_ok }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -242,6 +242,10 @@ jobs:
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
           sudo podman tag "localhost/${{ steps.export.outputs.image_ref }}" \
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
+          sudo podman tag "localhost/${{ steps.export.outputs.image_ref }}" \
+            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:amd64"
+          sudo podman tag "localhost/${{ steps.export.outputs.image_ref }}" \
+            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64"
 
       - name: Push to GHCR
         if: >-
@@ -249,10 +253,254 @@ jobs:
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_dispatch'
         run: |
-          for tag in latest "${{ github.sha }}"; do
+          for tag in latest "${{ github.sha }}" amd64 "${{ github.sha }}-amd64"; do
             for i in 1 2 3; do
               sudo podman push "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${tag}" && break
               echo "Push attempt $i failed for tag ${tag}, retrying..."
+              sleep 5
+            done
+          done
+
+# ── aarch64 native build ──────────────────────────────────────────────────
+# Runs on GitHub's native arm64 runner. BuildStream pulls aarch64 artifacts
+# from the GNOME build cache (gbm.gnome.org), so most elements are cache hits.
+#
+# continue-on-error: true — arm failures do NOT fail the overall workflow or
+# block x86_64 pushes. The create-manifest job gates on outputs.build_ok.
+  build-aarch64:
+    runs-on: ubuntu-24.04-arm
+    continue-on-error: true
+    outputs:
+      build_ok: ${{ steps.arm_status.outputs.build_ok }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Mount BTRFS for podman storage
+        id: container-storage
+        uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6
+        continue-on-error: true
+        with:
+          target-dir: /var/lib/containers
+          mount-opts: compress-force=zstd:2
+          loopback-free: '1'
+
+      - name: Remove unwanted software
+        uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
+
+      - name: Setup Just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
+      - name: Capture build timestamp
+        id: timestamp
+        run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
+      - name: Generate BuildStream CI config
+        env:
+          CASD_CLIENT_CERT: ${{ vars.CASD_CLIENT_CERT }}
+          CASD_CLIENT_KEY: ${{ secrets.CASD_CLIENT_KEY }}
+        run: |
+          mkdir -p logs
+
+          echo "$CASD_CLIENT_CERT" > client.crt
+          echo "$CASD_CLIENT_KEY" > client.key
+          cat > buildstream-ci.conf <<'BSTCONF'
+          scheduler:
+            on-error: continue
+            fetchers: 32
+            builders: 4
+            network-retries: 3
+
+          logging:
+            message-format: '[%{wallclock}][%{elapsed}][%{key}][%{element}] %{action} %{message}'
+            error-lines: 80
+
+          cachedir: /root/.cache/buildstream
+          logdir: /src/logs
+
+          build:
+            retry-failed: True
+
+          BSTCONF
+
+          if [[ -n "$CASD_CLIENT_CERT" ]] && [[ -n "$CASD_CLIENT_KEY" ]]; then
+            cat >> buildstream-ci.conf <<'BSTCONFPUSH'
+          artifacts:
+            servers:
+            - url: https://cache.projectbluefin.io:11002
+              push: true
+              connection-config:
+                keepalive-time: 60
+                retry-limit: 5
+                retry-delay: 1000
+                request-timeout: 180
+              auth:
+                client-key: /src/client.key
+                client-cert: /src/client.crt
+
+          source-caches:
+            servers:
+            - url: https://cache.projectbluefin.io:11002
+              push: true
+              connection-config:
+                keepalive-time: 60
+                retry-limit: 5
+                retry-delay: 1000
+                request-timeout: 180
+              auth:
+                client-key: /src/client.key
+                client-cert: /src/client.crt
+
+          cache:
+            storage-service:
+              url: https://cache.projectbluefin.io:11002
+              connection-config:
+                keepalive-time: 60
+                retry-limit: 5
+                retry-delay: 1000
+                request-timeout: 180
+              auth:
+                client-key: /src/client.key
+                client-cert: /src/client.crt
+
+          remote-execution:
+            execution-service:
+              url: https://cache.projectbluefin.io:11002
+              connection-config:
+                keepalive-time: 60
+                retry-limit: 5
+                retry-delay: 1000
+                request-timeout: 180
+              auth:
+                client-key: /src/client.key
+                client-cert: /src/client.crt
+            action-cache-service:
+              url: https://cache.projectbluefin.io:11002
+              connection-config:
+                keepalive-time: 60
+                retry-limit: 5
+                retry-delay: 1000
+                request-timeout: 180
+              auth:
+                client-key: /src/client.key
+                client-cert: /src/client.crt
+          BSTCONFPUSH
+          fi
+
+          echo "=== BuildStream CI config ==="
+          cat buildstream-ci.conf
+
+      - name: Build OCI image (aarch64) with BuildStream
+        id: arm_build
+        env:
+          BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf --option arch aarch64
+        run: |
+          just bst build oci/bluefin.bst
+        timeout-minutes: 300
+
+      - name: Export OCI image from BuildStream
+        id: export
+        if: steps.arm_build.outcome == 'success'
+        env:
+          BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf --option arch aarch64
+          BUILD_IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          OCI_IMAGE_CREATED: ${{ steps.timestamp.outputs.created }}
+          OCI_IMAGE_REVISION: ${{ github.sha }}
+          OCI_IMAGE_VERSION: aarch64
+        run: |
+          just export
+          echo "image_ref=${{ env.IMAGE_NAME }}:aarch64" >> "$GITHUB_OUTPUT"
+
+      - name: Verify image loaded
+        if: steps.arm_build.outcome == 'success'
+        run: sudo podman images
+
+      - name: Validate with bootc container lint
+        if: steps.arm_build.outcome == 'success'
+        run: just lint
+
+      - name: Upload build logs
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: buildstream-logs-aarch64
+          path: logs/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Login to GHCR
+        if: >-
+          steps.arm_build.outcome == 'success' &&
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            sudo podman login ghcr.io --username ${{ github.actor }} --password-stdin
+
+      - name: Tag image for GHCR
+        if: >-
+          steps.arm_build.outcome == 'success' &&
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main'
+        run: |
+          sudo podman tag "localhost/${{ steps.export.outputs.image_ref }}" \
+            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:aarch64"
+          sudo podman tag "localhost/${{ steps.export.outputs.image_ref }}" \
+            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-aarch64"
+
+      - name: Push to GHCR
+        if: >-
+          steps.arm_build.outcome == 'success' &&
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main'
+        run: |
+          for tag in aarch64 "${{ github.sha }}-aarch64"; do
+            for i in 1 2 3; do
+              sudo podman push "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${tag}" && break
+              echo "Push attempt $i failed for tag ${tag}, retrying..."
+              sleep 5
+            done
+          done
+
+      # Report arm build outcome as a job output so create-manifest can gate
+      # on actual success even with continue-on-error: true masking the result.
+      - name: Report arm build status
+        id: arm_status
+        if: always()
+        run: |
+          echo "build_ok=${{ steps.arm_build.outcome == 'success' }}" >> "$GITHUB_OUTPUT"
+
+# ── Multi-arch manifest ───────────────────────────────────────────────────
+# Combines x86_64 (:amd64) and aarch64 (:aarch64) into a multi-arch :latest.
+# Only runs when BOTH arch builds succeeded and pushed their arch-specific tags.
+  create-manifest:
+    runs-on: ubuntu-24.04
+    needs: [build, build-aarch64]
+    if: >-
+      needs.build.result == 'success' &&
+      needs.build-aarch64.outputs.build_ok == 'true'
+    permissions:
+      packages: write
+    steps:
+      - name: Login to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            sudo podman login ghcr.io --username ${{ github.actor }} --password-stdin
+
+      - name: Create and push multi-arch manifest
+        run: |
+          for tag in latest "${{ github.sha }}"; do
+            sudo podman manifest create \
+              "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${tag}" \
+              "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64" \
+              "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-aarch64"
+            for i in 1 2 3; do
+              sudo podman manifest push \
+                "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${tag}" && break
+              echo "Manifest push attempt $i failed for tag ${tag}, retrying..."
               sleep 5
             done
           done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,92 @@
+# bluefin-dakota -- Fork Workflow Notes
+
+This file captures fork-local workflow for `castrojo/dakota`.
+Project build and architecture details remain in `README.md`, `Justfile`, and `docs/plans/`.
+
+## Fork Identity
+
+- **Upstream:** `projectbluefin/dakota`
+- **Fork:** `castrojo/dakota`
+- **Local path:** `~/src/bluefin-dakota`
+- **Tracking remote:** `upstream` -> `git@github.com:projectbluefin/dakota.git`
+
+## Skills
+
+cat ~/src/skills/workflow/SKILL.md              # push confirmation, PR safety, session guardrails
+cat ~/src/skills/bluefin-build/SKILL.md         # bluefin ecosystem build/validation workflow
+cat ~/src/skills/dakota-overview/SKILL.md       # repo purpose, gap analysis, package positioning
+cat ~/src/skills/dakota-buildstream/SKILL.md    # .bst authoring reference, variables, source kinds
+cat ~/src/skills/dakota-debugging/SKILL.md      # build failure triage for BuildStream
+cat ~/src/skills/dakota-ci/SKILL.md             # CI pipeline operations and troubleshooting
+
+## Session Start
+
+```bash
+git fetch upstream
+git status --short --branch
+just --list
+```
+
+Use `workflow/SKILL.md` session start protocol from `~/src` before mutating anything.
+
+## Quick Reference
+
+| What | Where |
+|---|---|
+| Build target | `elements/oci/bluefin.bst` |
+| Local build | `just build` |
+| End-to-end local test | `just show-me-the-future` |
+| Local registry | `just registry-start` / `just publish` |
+| CI workflow (primary) | `.github/workflows/build.yml` |
+| Build config | `project.conf` |
+| Plans | `docs/plans/` |
+
+## Build and Validate
+
+```bash
+just build
+just lint
+```
+
+For heavyweight end-to-end validation:
+
+```bash
+just show-me-the-future
+```
+
+## Workflow Rules (Fork)
+
+- Never open upstream PRs from automation.
+- Push only to `origin` (`castrojo/dakota`), never to upstream.
+- Before any push, state branch name, remote, and commit SHA, then wait for explicit confirmation.
+- Keep changes scoped; do not include unrelated dirty worktree files.
+
+## Branch and PR Flow
+
+```bash
+git switch -c <type>/<short-description>
+```
+
+- Branch names must follow conventional format (`feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `ci/`, `test/`).
+- Keep `main` aligned with upstream except fork-local metadata commits.
+- Use compare links or `~/src/skills/bluefin-build/scripts/open-pr.sh` for human PR handoff.
+
+## Repository Layout
+
+```
+elements/                BuildStream elements (.bst)
+  bluefin/               Bluefin-specific packages
+  core/                  Core overrides
+  oci/                   Image assembly pipeline
+patches/                 Junction patches (freedesktop-sdk, gnome-build-meta)
+include/                 Shared YAML includes
+docs/plans/              Implementation plans and rationale
+Justfile                 Local build and test entrypoints
+project.conf             BuildStream project settings
+```
+
+## Notes
+
+- BuildStream runs inside the pinned bst2 container from `Justfile`.
+- Builds are cache-sensitive; warm cache behavior is expected.
+- For package additions/removals, prefer the dedicated Dakota package skills from `~/src/skills/INDEX.md`.


### PR DESCRIPTION
Adds a parallel native aarch64 build job on `ubuntu-24.04-arm` runners and a `create-manifest` job that combines both arches into a multi-arch `:latest` manifest.

## Fixes
- aarch64 Login/Tag/Push steps were gated on `event_name == push && ref == refs/heads/main` — a trigger that no longer exists. Fixed to use `merge_group | schedule | workflow_dispatch` consistent with the amd64 job.
- `create-manifest` was missing the event type guard, causing it to run on `pull_request` events before either arch image was pushed to GHCR (`manifest unknown` error). Fixed.

## Behavior
- ARM failures use `continue-on-error: true` and gate on a job output (`build_ok`) — arm failures do **not** block x86_64 publication
- `create-manifest` only runs on publish events when both arches succeeded