### PR TITLE
ci: increase build step timeouts from 300 to 420 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ on:
   merge_group:
     branches: [main]
   workflow_dispatch:
+    # WARNING: Do not manually dispatch immediately after auto/track-* ref bumps
+    # (e.g. Renovate PRs updating gnome-build-meta.bst). Cold builds of GNOME
+    # require gbm.gnome.org to have built the new ref first. The 13:00 UTC
+    # schedule above provides this buffer. Early dispatch = cold build = timeout.
 
 env:
   IMAGE_NAME: dakota
@@ -175,7 +179,7 @@ jobs:
           BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf
         run: |
           just bst build oci/bluefin.bst
-        timeout-minutes: 300
+        timeout-minutes: 420
 
       # ── Export OCI image ──────────────────────────────────────────────
       # Uses the Justfile's `export` recipe: checks out the OCI image
@@ -374,7 +378,7 @@ jobs:
           BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf --option arch aarch64
         run: |
           just bst build oci/bluefin.bst
-        timeout-minutes: 300
+        timeout-minutes: 420
 
       - name: Export OCI image from BuildStream
         id: export


### PR DESCRIPTION
## Problem

Both build steps (`Build OCI image with BuildStream` x86 and aarch64) have `timeout-minutes: 300`. This is insufficient for cold-cache builds after a `gnome-build-meta.bst` ref bump.

## Root cause (verified from run 221 CI artifacts)

Run 221 (2026-04-18, triggered after Renovate PRs \#254/\#255 bumped gnome-build-meta to GNOME 50.1):
- All 3 caches (`cache.projectbluefin.io:11002`, `:11001`, `gbm.gnome.org:11003`) returned "does not have artifact cached" for all 262 elements
- 218 elements were built and pushed to cache in **254 minutes**
- 44 elements (gnome-shell, heavy GNOME apps, OCI assembly layers) were never reached
- Step timeout fired at 300 minutes — only 46 minutes after the last completed build

## Fix

- Increase `timeout-minutes: 300 → 420` on both build steps
- 420 min provides a 166-minute buffer above the proven 254-minute floor

Also adds a comment near `workflow_dispatch` warning against manual dispatch immediately after `auto/track-*` ref bumps (before `gbm.gnome.org` has built the new ref).

## Verified diff

Only `.github/workflows/build.yml` is modified — two timeout bumps and one comment block.