### PR TITLE
oci: normalize /var layout with relative symlinks

### DIFF
--- a/elements/oci/layers/bluefin-stack.bst
+++ b/elements/oci/layers/bluefin-stack.bst
@@ -3,3 +3,18 @@ kind: stack
 depends:
   - bluefin/deps.bst
   - gnome-build-meta.bst:oci/gnomeos/stack.bst
+
+public:
+  bst:
+    integration-commands:
+      # Wipe /var (may contain build-time state) and all FHS dirs that should
+      # be symlinks into /var, then recreate with the correct structure.
+      # Relative symlinks (var/home not /var/home) match zirconium-hawaii and
+      # are safer in chroot/deploy tooling flows.
+      - rm -rfv /home /root /opt /mnt /srv /var
+      - mkdir -p /var/home /var/roothome /var/opt /var/mnt /var/srv /var/tmp
+      - ln -s var/home /home
+      - ln -s var/roothome /root
+      - ln -s var/opt /opt
+      - ln -s var/mnt /mnt
+      - ln -s var/srv /srv


### PR DESCRIPTION
Wipe build-time `/var` state and FHS dirs that should be symlinks into `/var`, then recreate with proper structure following the zirconium-hawaii pattern.

## Changes vs gnome-build-meta upstream `integration-commands`

- `rm /var` before recreating (drops accumulated build-time state)
- `rm /home /root /opt /mnt /srv` before symlinking (handles pre-existing dirs)
- Add `/var/srv` + `ln -s var/srv /srv` (was missing upstream)
- Add `/var/tmp`
- Use relative symlinks (`var/home`) instead of absolute (`/var/home`)

## File

`elements/oci/layers/bluefin-stack.bst` — adds `integration-commands` block to the existing `kind: stack` element.