### PR TITLE
fix(os-release): add IMAGE_REF and image metadata to /usr/lib/os-release

### DIFF
--- a/elements/oci/os-release.bst
+++ b/elements/oci/os-release.bst
@@ -40,6 +40,11 @@ config:
       SUPPORT_URL="${SUPPORT_URL}"
       LOGO=img-logo-icon
       DEFAULT_HOSTNAME="bluefin"
+      IMAGE_NAME="${IMAGE_NAME}"
+      IMAGE_VENDOR="${IMAGE_VENDOR}"
+      IMAGE_REF="${IMAGE_REF}"
+      IMAGE_FLAVOR="${IMAGE_FLAVOR}"
+      IMAGE_TAG="${IMAGE_TAG}"
       EOF
       mkdir -p %{install-root}%{sysconfdir}/
       ln -sf ../usr/lib/os-release %{install-root}%{sysconfdir}/os-release


### PR DESCRIPTION
## Problem

`IMAGE_REF`, `IMAGE_NAME`, `IMAGE_VENDOR`, `IMAGE_FLAVOR`, and `IMAGE_TAG` are defined as BST environment variables in `elements/oci/os-release.bst` but are never written into the heredoc that generates `/usr/lib/os-release`.

`bootc` reads `IMAGE_REF` from `/usr/lib/os-release` to determine the upgrade target. Without it, fresh installations have no stored upgrade ref and `bootc upgrade` may not function correctly.

The `image-info.json` already had these fields correctly set — this brings `/usr/lib/os-release` into parity.

## Critical Secondary Impact: Silent Boot Failure After `bootc upgrade`

Missing `VERSION_ID` (included in this fix) breaks the `ldconfig.service` stamp mechanism:

- `gnome-build-meta` ships `always-ldconfig.conf` which uses `ConditionPathExists=|!/etc/ld.so.cache.stamp-%A`
- `%A` is the systemd specifier for `VERSION_ID` from os-release
- Without `VERSION_ID`, `%A` expands to `""` → stamp is always `/etc/ld.so.cache.stamp-`
- After `bootc upgrade`, the stamp already exists → `ldconfig.service` skips → **stale `ld.so.cache` persists**
- When Mesa upgrades across images (e.g. 25.3.5 → 26.0.4), `libgallium-26.0.4.so` is not in the cache
- `mutter`/gnome-shell silently fails to initialize the GPU renderer → GDM loops "Session never registered"

**Workaround for affected systems:**
```bash
sudo ldconfig && sudo systemctl restart gdm
```

**This PR fixes the root cause** — once `VERSION_ID` is set, `%A` changes between image versions, the old stamp is absent, and `ldconfig` runs correctly on every upgrade.

Confirmed on an Intel NUC running run #228 (6f9373f0), upgraded via `bootc upgrade`.

## Fix

Add the missing variables to the heredoc:

```
IMAGE_NAME="dakota"
IMAGE_VENDOR="projectbluefin"
IMAGE_REF="ostree-image-signed:docker://ghcr.io/projectbluefin/dakota"
IMAGE_FLAVOR="main"
IMAGE_TAG="latest"
VERSION_ID="20260418"
```

## Testing

Verify with:
```bash
podman run --rm ghcr.io/projectbluefin/dakota:latest grep -E "IMAGE_REF|VERSION_ID" /usr/lib/os-release
```