### PR TITLE
fix(oci): run ldconfig after wiping /var

### DIFF
--- a/elements/oci/layers/bluefin-stack.bst
+++ b/elements/oci/layers/bluefin-stack.bst
@@ -18,3 +18,8 @@ public:
       - ln -s var/opt /opt
       - ln -s var/mnt /mnt
       - ln -s var/srv /srv
+      # Rebuild the ldconfig cache after /var is wiped; wiping /var removes
+      # /var/cache/ldconfig/ auxiliary cache data, so Mesa's libgallium and
+      # other libraries installed under non-standard GL paths won't be found
+      # at runtime without this.
+      - ldconfig


### PR DESCRIPTION
## Problem

Commit 82f7a8f (PR #263) added integration-commands to `bluefin-stack.bst` that delete `/var` and recreate it with the correct relative-symlink structure. However, wiping `/var` also removes `/var/cache/ldconfig/` (the auxiliary ldconfig cache), and `ldconfig` is never re-run afterward.

At runtime, `gnome-shell` uses the Mesa LOADER to open GPU drivers via `dlopen`. The loader searches for `libgallium-<version>.so` using the ldconfig cache. With the cache reflecting the old Mesa version (or missing entries entirely), every `gnome-shell` launch fails:

```
MESA-LOADER: failed to open dri: libgallium-26.0.4.so: cannot open shared object file: No such file or directory
Failed to open gpu '/dev/dri/card1': Failed to create gbm device: No such file or directory  
Failed to setup: No GPUs found
```

GDM retries 5 times, hits `maximum number of display failures reached. Giving up.`, and the system drops to TTY.

## Fix

Add `ldconfig` as the final integration-command so the shared library cache is rebuilt after `/var` is recreated, ensuring all Mesa libraries under non-standard GL paths (e.g. `/usr/lib/x86_64-linux-gnu/GL/default/lib/`) are discoverable at runtime.

## Workaround (for affected systems)

```bash
sudo ldconfig && sudo systemctl restart gdm
```

## Test plan

- [ ] Build image and confirm `ldconfig -p | grep gallium` shows the current Mesa version
- [ ] Boot image and confirm GNOME session starts (no TTY fallback)
- [ ] Confirm `/var/cache/ldconfig/` is present post-boot