### PR TITLE
fix: custom-command-menu shows Hello World on fresh install

### DIFF
--- a/elements/bluefin/shell-extensions/custom-command-menu.bst
+++ b/elements/bluefin/shell-extensions/custom-command-menu.bst
@@ -5,6 +5,8 @@ sources:
   url: github:StorageB/custom-command-menu.git
   track: main
   ref: v14-3-g8391fe24d069fb983999ad8b6439b855af73e07f
+- kind: local
+  path: files/dconf
 
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-make.bst
@@ -30,5 +32,9 @@ config:
     # Install schema to system dir so gschema overrides (e.g. menuicon-setting) apply
     install -Dm644 schemas/org.gnome.shell.extensions.custom-command-list.gschema.xml \
       "%{install-root}/usr/share/glib-2.0/schemas/org.gnome.shell.extensions.custom-command-list.gschema.xml"
+
+    # Install dconf distro keyfile with correct command* keys (fixes: projectbluefin/dakota#228)
+    install -Dm644 05-dakota-custom-command-menu \
+      "%{install-root}%{sysconfdir}/dconf/db/distro.d/05-dakota-custom-command-menu"
   - |
     %{install-extra}

--- a/files/dconf/05-dakota-custom-command-menu
+++ b/files/dconf/05-dakota-custom-command-menu
@@ -1,0 +1,21 @@
+# Custom Command Menu extension configuration
+# https://github.com/StorageB/custom-command-menu
+#
+# Fixes: https://github.com/projectbluefin/dakota/issues/228
+# The extension uses command1-99 keys of type (sssb): (label, command, icon, visible).
+# The upstream common distro db uses stale entryrow* keys not in the schema; this file
+# provides the correct keys so the menu survives dconf reset and fresh installs.
+
+[org/gnome/shell/extensions/custom-command-list]
+command-order=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+command1=('---$(hostname)', '', '', true)
+command2=('About', 'gnome-control-center system about', '', true)
+command3=('System Monitor', 'flatpak run io.missioncenter.MissionCenter', '', true)
+command4=('System Settings', 'gnome-control-center', '', true)
+command5=('---Applications', '', '', true)
+command6=('Bazaar App Store', '/usr/bin/flatpak run io.github.kolunmi.Bazaar', '', true)
+command7=('Extensions', 'flatpak run com.mattjakeman.ExtensionManager', '', true)
+command8=('Terminal', 'xdg-terminal-exec', '', true)
+command9=('---Help', '', '', true)
+command10=('Documentation', 'xdg-open https://docs.projectbluefin.io/', '', true)
+command11=('Ask Bluefin', 'xdg-open https://ask.projectbluefin.io', '', true)

--- a/files/dconf/05-dakota-custom-command-menu
+++ b/files/dconf/05-dakota-custom-command-menu
@@ -10,11 +10,11 @@
 command-order=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 command1=('---$(hostname)', '', '', true)
 command2=('About', 'gnome-control-center system about', '', true)
-command3=('System Monitor', 'flatpak run io.missioncenter.MissionCenter', '', true)
+command3=('System Monitor', '/usr/bin/flatpak run io.missioncenter.MissionCenter', '', true)
 command4=('System Settings', 'gnome-control-center', '', true)
 command5=('---Applications', '', '', true)
 command6=('Bazaar App Store', '/usr/bin/flatpak run io.github.kolunmi.Bazaar', '', true)
-command7=('Extensions', 'flatpak run com.mattjakeman.ExtensionManager', '', true)
+command7=('Extensions', '/usr/bin/flatpak run com.mattjakeman.ExtensionManager', '', true)
 command8=('Terminal', 'xdg-terminal-exec', '', true)
 command9=('---Help', '', '', true)
 command10=('Documentation', 'xdg-open https://docs.projectbluefin.io/', '', true)


### PR DESCRIPTION
Fixes the menu, confirmed working locally. 

Fixes: https://github.com/projectbluefin/dakota/issues/228


Assisted-by: Claude Sonnet 4.6 via GitHub Copilot