### PR TITLE
fix(os-release): add VERSION_ID to fix ldconfig stamp mechanism

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -32,6 +32,7 @@ bst *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p "${HOME}/.cache/buildstream"
+    VERSION_ID_OPT="--option version-id $(date +%Y%m%d)"
     # BST_FLAGS env var allows CI to inject --no-interactive, --config, etc.
     # Word-splitting is intentional here (flags are space-separated).
     # shellcheck disable=SC2086
@@ -43,7 +44,7 @@ bst *ARGS:
         -v "${HOME}/.cache/buildstream:/root/.cache/buildstream:rw" \
         -w /src \
         "{{bst2_image}}" \
-        bash -c 'bst --colors "$@"' -- ${BST_FLAGS:-} {{ARGS}}
+        bash -c 'bst --colors "$@"' -- ${BST_FLAGS:-} ${VERSION_ID_OPT} {{ARGS}}
 
 # ── Build ─────────────────────────────────────────────────────────────
 # Build the OCI image and load it into podman.

--- a/elements/oci/os-release.bst
+++ b/elements/oci/os-release.bst
@@ -14,6 +14,7 @@ environment:
   IMAGE_REF: "ostree-image-signed:docker://ghcr.io/projectbluefin/dakota"
   IMAGE_FLAVOR: "main"
   IMAGE_TAG: "latest"
+  VERSION_ID: "%{version-id}"
 
   IMAGE_PRETTY_NAME: "Bluefin"
   HOME_URL: "https://projectbluefin.io"
@@ -45,6 +46,7 @@ config:
       IMAGE_REF="${IMAGE_REF}"
       IMAGE_FLAVOR="${IMAGE_FLAVOR}"
       IMAGE_TAG="${IMAGE_TAG}"
+      VERSION_ID="${VERSION_ID}"
       EOF
       mkdir -p %{install-root}%{sysconfdir}/
       ln -sf ../usr/lib/os-release %{install-root}%{sysconfdir}/os-release

--- a/project.conf
+++ b/project.conf
@@ -21,6 +21,12 @@ options:
       - aarch64
       - x86_64
 
+  version-id:
+    type: string
+    description: Build date for VERSION_ID in /usr/lib/os-release (YYYYMMDD)
+    variable: version-id
+    default: "0"
+
 sandbox:
   build-arch: "%{arch}"
 


### PR DESCRIPTION
## Problem

PR #266 added `IMAGE_*` fields to `/usr/lib/os-release` but did not include `VERSION_ID` in the heredoc. This leaves the ldconfig stamp mechanism broken.

`gnome-build-meta` ships `always-ldconfig.conf` which contains:
```ini
[Unit]
[Service]
ExecStartPre=-sh -c "rm /etc/ld.so.cache.stamp-*"
ExecStartPost=touch /etc/ld.so.cache.stamp-%A
```

- `%A` is the systemd specifier for `VERSION_ID` from os-release
- Without `VERSION_ID`, `%A` expands to `""` → stamp path = `/etc/ld.so.cache.stamp-` (empty suffix)
- This empty-name stamp file persists across `bootc upgrade` → `ldconfig.service` condition is met → ldconfig **never reruns**
- When Mesa upgrades (e.g. 25.3.5 → 26.0.4), the old `libgallium-25.3.5.so` entry is in the stale cache but the new `.so` is not → mutter/gnome-shell fails to initialize the GPU renderer → **GDM loops silently**

Confirmed on NUC: `/etc/ld.so.cache.stamp-` exists (empty suffix), no `VERSION_ID` in `/usr/lib/os-release`.

Workaround for affected users: `sudo ldconfig && sudo systemctl restart gdm`

## Fix

Add `VERSION_ID` to the environment block and to the os-release heredoc. With a non-empty `VERSION_ID`, `%A` expands to the version string, the old empty-suffix stamp doesn't match, and ldconfig runs automatically on first boot after upgrade.

## Testing

Built and validated on Intel NUC via ghost testlab:
- Before: `/etc/ld.so.cache.stamp-` (empty suffix)
- After bootc upgrade: `/etc/ld.so.cache.stamp-20260418` created, ldconfig ran automatically, GDM started without manual intervention

Verify with:
```bash
grep VERSION_ID /usr/lib/os-release
ls /etc/ld.so.cache.stamp-*
```