### PR TITLE
fix(os-release): inject VERSION_ID at export time, remove invalid BST…

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -102,9 +102,9 @@ export:
     # Squash, inject build-date VERSION_ID, and apply dynamic labels.
     # BST has no string option type, so VERSION_ID is set to "0" in os-release.bst
     # and replaced here at export time — after the BST cache key is already fixed.
-    DATE_TAG="$(date +%Y%m%d)"
+    DATE_TAG="$(date -u +%Y%m%d)"
     # shellcheck disable=SC2086
-    printf 'FROM %s\nRUN sed -i "s/^VERSION_ID=.*/VERSION_ID=%s/" /usr/lib/os-release\n' "$IMAGE_ID" "$DATE_TAG" \
+    printf 'FROM %s\nRUN sed -i "s/^VERSION_ID=.*/VERSION_ID=\\"%s\\"/" /usr/lib/os-release\n' "$IMAGE_ID" "$DATE_TAG" \
         | $SUDO_CMD podman build --pull=never --security-opt label=type:unconfined_t --squash-all ${LABEL_ARGS} -t "{{image_name}}:{{image_tag}}" -f - .
     $SUDO_CMD podman rmi "$IMAGE_ID" || true
 

--- a/Justfile
+++ b/Justfile
@@ -32,7 +32,6 @@ bst *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p "${HOME}/.cache/buildstream"
-    VERSION_ID_OPT="--option version-id $(date +%Y%m%d)"
     # BST_FLAGS env var allows CI to inject --no-interactive, --config, etc.
     # Word-splitting is intentional here (flags are space-separated).
     # shellcheck disable=SC2086
@@ -44,7 +43,7 @@ bst *ARGS:
         -v "${HOME}/.cache/buildstream:/root/.cache/buildstream:rw" \
         -w /src \
         "{{bst2_image}}" \
-        bash -c 'bst --colors "$@"' -- ${BST_FLAGS:-} ${VERSION_ID_OPT} {{ARGS}}
+        bash -c 'bst --colors "$@"' -- ${BST_FLAGS:-} {{ARGS}}
 
 # ── Build ─────────────────────────────────────────────────────────────
 # Build the OCI image and load it into podman.
@@ -100,9 +99,12 @@ export:
         LABEL_ARGS="${LABEL_ARGS} --label org.opencontainers.image.version=${OCI_IMAGE_VERSION}"
     fi
     
-    # Squash and apply dynamic labels
+    # Squash, inject build-date VERSION_ID, and apply dynamic labels.
+    # BST has no string option type, so VERSION_ID is set to "0" in os-release.bst
+    # and replaced here at export time — after the BST cache key is already fixed.
+    DATE_TAG="$(date +%Y%m%d)"
     # shellcheck disable=SC2086
-    printf 'FROM %s\n' "$IMAGE_ID" \
+    printf 'FROM %s\nRUN sed -i "s/^VERSION_ID=.*/VERSION_ID=%s/" /usr/lib/os-release\n' "$IMAGE_ID" "$DATE_TAG" \
         | $SUDO_CMD podman build --pull=never --security-opt label=type:unconfined_t --squash-all ${LABEL_ARGS} -t "{{image_name}}:{{image_tag}}" -f - .
     $SUDO_CMD podman rmi "$IMAGE_ID" || true
 

--- a/elements/oci/os-release.bst
+++ b/elements/oci/os-release.bst
@@ -14,7 +14,7 @@ environment:
   IMAGE_REF: "ostree-image-signed:docker://ghcr.io/projectbluefin/dakota"
   IMAGE_FLAVOR: "main"
   IMAGE_TAG: "latest"
-  VERSION_ID: "%{version-id}"
+  VERSION_ID: "0"
 
   IMAGE_PRETTY_NAME: "Bluefin"
   HOME_URL: "https://projectbluefin.io"

--- a/project.conf
+++ b/project.conf
@@ -21,12 +21,6 @@ options:
       - aarch64
       - x86_64
 
-  version-id:
-    type: string
-    description: Build date for VERSION_ID in /usr/lib/os-release (YYYYMMDD)
-    variable: version-id
-    default: "0"
-
 sandbox:
   build-arch: "%{arch}"
 


### PR DESCRIPTION
… string option

BST has no 'string' option type (valid: bool, enum, flags, arch, os, element-mask). The version-id option in project.conf was doubly broken:
  1. Hyphen in option name (BST requires alphanumeric + underscores only)
  2. type: string is not a valid BST option type

Remove the option entirely. Instead inject VERSION_ID post-BST in the export recipe using a RUN sed command inside the podman build squash step. This runs after the BST cache key is already fixed, so it doesn't invalidate rebuilds.

The VERSION_ID placeholder in os-release.bst is set to "0" and replaced with the build date (YYYYMMDD) at export time. This ensures:
  - /usr/lib/os-release contains VERSION_ID=YYYYMMDD on the installed system
  - systemd %A specifier in always-ldconfig.conf expands to a non-empty value
  - /etc/ld.so.cache.stamp-YYYYMMDD path changes each build day
  - ldconfig reruns after bootc upgrade, regenerating ld.so.cache for new Mesa