### PR TITLE
fix(Justfile): auto-detect headless for boot-vm, add ttyS1/monitor sockets

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -235,12 +235,21 @@ boot-vm $base_dir=base_dir:
             cp "$OVMF_VARS_SRC" "$OVMF_VARS"
         fi
 
-        echo "==> Booting ${DISK} in QEMU (UEFI, KVM)..."
+        # Auto-detect headless: use -display none when no graphical display is available
+        if [ -n "${DISPLAY:-}" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
+            DISPLAY_ARGS="-display gtk -device virtio-vga -device virtio-keyboard -device virtio-mouse"
+            echo "==> Booting ${DISK} in QEMU (UEFI, KVM, display: gtk)..."
+        else
+            DISPLAY_ARGS="-display none"
+            echo "==> Booting ${DISK} in QEMU (UEFI, KVM, headless)..."
+            echo "    SSH available on port 2222 once the system is up"
+        fi
         echo "    Firmware: ${OVMF_CODE}"
         echo "    RAM: {{vm_ram}}M, CPUs: {{vm_cpus}}"
         echo "    Serial debug shell on ttyS1 available via QEMU monitor"
         echo ""
 
+        # shellcheck disable=SC2086
         qemu-system-x86_64 \
             -enable-kvm \
             -m "{{vm_ram}}" \
@@ -249,16 +258,14 @@ boot-vm $base_dir=base_dir:
             -drive file="${DISK}",format=raw,if=virtio \
             -drive if=pflash,format=raw,readonly=on,file="${OVMF_CODE}" \
             -drive if=pflash,format=raw,file="${OVMF_VARS}" \
-            -device virtio-vga \
-            -display gtk \
-            -device virtio-keyboard \
-            -device virtio-mouse \
             -device virtio-net-pci,netdev=net0 \
             -netdev user,id=net0,hostfwd=tcp:127.0.0.1:2222-:22 \
             -chardev stdio,id=char0,mux=on,signal=off \
             -serial chardev:char0 \
-            -serial chardev:char0 \
-            -mon chardev=char0
+            -serial unix:/tmp/qemu-ttyS1.sock,server,nowait \
+            -mon chardev=char0 \
+            -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
+            ${DISPLAY_ARGS}
 
     else
         echo "==> qemu-system-x86_64 not found, falling back to docker.io/qemux/qemu-docker..."


### PR DESCRIPTION
## Summary

Auto-detect headless mode in `boot-vm`: when `DISPLAY`/`WAYLAND_DISPLAY` are unset (headless server, CI, homelab without monitor), use `-display none` instead of `-display gtk`. Drops virtio-vga/keyboard/mouse in headless mode.

Also fixes the serial configuration:
- Separates ttyS1 to a Unix socket (`/tmp/qemu-ttyS1.sock`) so the debug shell (`systemd.debug_shell=ttyS1`) is accessible independently of stdio
- Adds QEMU HMP monitor socket at `/tmp/qemu-monitor.sock`

**Connect to debug shell:** `socat -,rawer UNIX-CONNECT:/tmp/qemu-ttyS1.sock`  
**Connect to monitor:** `echo 'info version' | socat - UNIX-CONNECT:/tmp/qemu-monitor.sock`

## Testing

Validated on ghost homelab (headless, no monitor attached) — VM boots cleanly to login prompt. Also validated end-to-end upgrade test: old image (no `IMAGE_VERSION`) → new image (`IMAGE_VERSION=20260419`) → ldconfig ran on boot 1, skipped on boot 2, GDM active.

Related: #271 (IMAGE_VERSION fix that required this headless testing workflow)