### PR TITLE
fix: inject IMAGE_VERSION into os-release at export time

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -104,7 +104,7 @@ export:
     # and replaced here at export time — after the BST cache key is already fixed.
     DATE_TAG="$(date -u +%Y%m%d)"
     # shellcheck disable=SC2086
-    printf 'FROM %s\nRUN sed -i "s/^VERSION_ID=.*/VERSION_ID=\\"%s\\"/" /usr/lib/os-release\n' "$IMAGE_ID" "$DATE_TAG" \
+    printf 'FROM %s\nRUN sed -i "s/^VERSION_ID=.*/VERSION_ID=\\"%s\\"/" /usr/lib/os-release \\\n    && sed -i "s/^IMAGE_VERSION=.*/IMAGE_VERSION=\\"%s\\"/" /usr/lib/os-release\n' "$IMAGE_ID" "$DATE_TAG" "$DATE_TAG" \
         | $SUDO_CMD podman build --pull=never --security-opt label=type:unconfined_t --squash-all ${LABEL_ARGS} -t "{{image_name}}:{{image_tag}}" -f - .
     $SUDO_CMD podman rmi "$IMAGE_ID" || true
 

--- a/elements/oci/os-release.bst
+++ b/elements/oci/os-release.bst
@@ -15,6 +15,7 @@ environment:
   IMAGE_FLAVOR: "main"
   IMAGE_TAG: "latest"
   VERSION_ID: "0"
+  IMAGE_VERSION: "0"
 
   IMAGE_PRETTY_NAME: "Bluefin"
   HOME_URL: "https://projectbluefin.io"
@@ -47,6 +48,7 @@ config:
       IMAGE_FLAVOR="${IMAGE_FLAVOR}"
       IMAGE_TAG="${IMAGE_TAG}"
       VERSION_ID="${VERSION_ID}"
+      IMAGE_VERSION="${IMAGE_VERSION}"
       EOF
       mkdir -p %{install-root}%{sysconfdir}/
       ln -sf ../usr/lib/os-release %{install-root}%{sysconfdir}/os-release


### PR DESCRIPTION
always-ldconfig.conf uses %A systemd specifier which resolves to IMAGE_VERSION (not VERSION_ID as incorrectly stated in PRs #266, #269, #271). Without IMAGE_VERSION set, the ldconfig stamp path is always /etc/ld.so.cache.stamp- (empty suffix), so ldconfig never re-runs after upgrades, leaving a stale ld.so.cache that causes GDM failures when Mesa or other libraries update.

- elements/oci/os-release.bst: add IMAGE_VERSION="0" placeholder (BST env
  + heredoc) so the field exists for overriding at export time
- Justfile export recipe: chain a second sed to inject IMAGE_VERSION="DATE" alongside the existing VERSION_ID injection

Fixes: castrojo/dakota#257 (BLS entry filename collision also resolved since bootc uses IMAGE_VERSION for the BLS entry filename; without it all entries are named bootc_bluefin_dakota-latest-1.conf causing collision on upgrade)


Assisted-by: Claude Sonnet 4.6 via GitHub Copilot