### PR TITLE
fix(bashrc): add login_shell guard to profile.d sourcing

### DIFF
--- a/patches/freedesktop-sdk/0008-bash-config-Add-login-shell-guard-to-bashrc.patch
+++ b/patches/freedesktop-sdk/0008-bash-config-Add-login-shell-guard-to-bashrc.patch
@@ -1,0 +1,37 @@
+From 993a27ec1cfa311544c83f7011ff82f3d89396d4 Mon Sep 17 00:00:00 2001
+From: "Jorge O. Castro" <jorge.castro@gmail.com>
+Date: Sun, 19 Apr 2026 12:22:57 -0400
+Subject: [PATCH] bash-config: Add login_shell guard to profile.d sourcing in
+ /etc/bashrc
+
+---
+ files/bash-config/bashrc | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/files/bash-config/bashrc b/files/bash-config/bashrc
+index f823cb6..9559178 100644
+--- a/files/bash-config/bashrc
++++ b/files/bash-config/bashrc
+@@ -4,11 +4,13 @@ alias ls='ls --color=auto'
+ # to set it in interactive non-login shells from the same session.
+ export PS1='[\u@\h \W]\$ '
+ 
+-for i in /etc/profile.d/*.sh; do
+-  if [ -r "${i}" ]; then
+-    . "${i}"
+-  fi
+-done
+-unset i
++if ! shopt -q login_shell; then
++  for i in /etc/profile.d/*.sh; do
++    if [ -r "${i}" ]; then
++      . "${i}"
++    fi
++  done
++  unset i
++fi
+ 
+ export PATH="${HOME}/.local/bin:${PATH}"
+-- 
+2.52.0
+


### PR DESCRIPTION
Carrying this now to hide the problem. Add the same login_shell guard Fedora uses to prevent the double-source.  Tested and confirmed locally. 

Fixes: https://github.com/projectbluefin/dakota/issues/200

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot