### PR TITLE
fix(keybindings): use xdg-terminal-exec instead of ptyxis

### DIFF
--- a/elements/bluefin/shell-extensions/custom-command-menu.bst
+++ b/elements/bluefin/shell-extensions/custom-command-menu.bst
@@ -36,5 +36,9 @@ config:
     # Install dconf distro keyfile with correct command* keys (fixes: projectbluefin/dakota#228)
     install -Dm644 05-dakota-custom-command-menu \
       "%{install-root}%{sysconfdir}/dconf/db/distro.d/05-dakota-custom-command-menu"
+
+    # Override bluefin-common's ptyxis keybindings with xdg-terminal-exec (Ghostty in dakota)
+    install -Dm644 06-dakota-keybindings \
+      "%{install-root}%{sysconfdir}/dconf/db/distro.d/06-dakota-keybindings"
   - |
     %{install-extra}

--- a/files/dconf/06-dakota-keybindings
+++ b/files/dconf/06-dakota-keybindings
@@ -1,0 +1,14 @@
+# Dakota keybinding overrides
+# bluefin-common's 02-bluefin-keybindings sets custom0/custom1 to /usr/bin/ptyxis
+# which is not installed in dakota. Override to use xdg-terminal-exec (Ghostty).
+# See: https://github.com/projectbluefin/common/pull/265
+
+[org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0]
+binding='<Control><Alt>t'
+command='xdg-terminal-exec'
+name='Terminal'
+
+[org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1]
+binding='<Control><Alt>Return'
+command='xdg-terminal-exec'
+name='Terminal Alt'

--- a/files/dconf/06-dakota-keybindings
+++ b/files/dconf/06-dakota-keybindings
@@ -5,10 +5,10 @@
 
 [org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0]
 binding='<Control><Alt>t'
-command='xdg-terminal-exec'
+command='/usr/bin/xdg-terminal-exec'
 name='Terminal'
 
 [org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1]
 binding='<Control><Alt>Return'
-command='xdg-terminal-exec'
+command='/usr/bin/xdg-terminal-exec'
 name='Terminal Alt'


### PR DESCRIPTION
This is inprogress fix in projectbluefin/common but fixing it here for now. 