### PR TITLE
fix: ship resolv.conf symlink and /etc/hosts via network element

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -28,6 +28,7 @@ depends:
   - bluefin/sudo-rs.bst
   - bluefin/efibootmgr.bst
   - bluefin/xdg-terminal-exec.bst
+  - bluefin/network.bst
 
   # Include things missing from the gnomeos base image
   - freedesktop-sdk.bst:components/buildstream2.bst

--- a/elements/bluefin/network.bst
+++ b/elements/bluefin/network.bst
@@ -1,0 +1,23 @@
+kind: manual
+
+# No external sources - all files are inline.
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+config:
+  install-commands:
+  - |
+    install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/tmpfiles.d/bluefin-network.conf" <<'EOF'
+    # Symlink /etc/resolv.conf to systemd-resolved's stub resolver.
+    # L+ removes any existing file (e.g. the empty placeholder from the base image)
+    # so applications that read resolv.conf directly (Steam, Distrobox, etc.) get DNS.
+    L+ /etc/resolv.conf - - - - /run/systemd/resolve/stub-resolv.conf
+    EOF
+
+  - |
+    install -Dm644 /dev/stdin "%{install-root}%{sysconfdir}/hosts" <<'EOF'
+    127.0.0.1   localhost
+    ::1         localhost
+    EOF
+
+  - "%{install-extra}"


### PR DESCRIPTION
## Problem

`/etc/resolv.conf` and `/etc/hosts` are blank on installed systems, breaking DNS for applications that read `resolv.conf` directly (Steam, Distrobox, etc.).

Closes #294

## Fix

Adds `elements/bluefin/network.bst` — a small inline element that installs:

1. **`/usr/lib/tmpfiles.d/bluefin-network.conf`** — `L+` rule that symlinks `/etc/resolv.conf` → `/run/systemd/resolve/stub-resolv.conf` at boot. `L+` removes any existing blank placeholder before creating the symlink.

2. **`/etc/hosts`** — minimal localhost entries (`127.0.0.1` / `::1`) to replace the blank file from the base image.