### PR TITLE
fix(ci): disable arm build until webkit is cached

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,7 +264,10 @@ jobs:
   # ── aarch64 native build ──────────────────────────────────────────────────
   # Mirrors the x86_64 build job. ARM failures do not fail the workflow or
   # block x86_64 publication — this is an experimental parallel build.
+  # Disabled: webkit cold-builds OOM/timeout the ARM runner. Re-enable once
+  # the webkit artifacts are cached in cache.projectbluefin.io.
   build-aarch64:
+    if: false
     runs-on: ubuntu-24.04-arm
     continue-on-error: true
     outputs:


### PR DESCRIPTION
webkit2gtk-4.1 and webkitgtk-6.0 are not cached in `cache.projectbluefin.io` or `gbm.gnome.org`. Cold builds OOM the ARM runner and eventually cancel/timeout the x86 job too, preventing any push to the registry.

## Root Cause

The April 19 13:25 UTC build failed because:
- `build-aarch64`: ran OOM building `webkit2gtk-4.1.bst` from source → failure
- `build` (x86): was building both `webkit2gtk-4.1.bst` and `webkitgtk-6.0.bst` cold → eventually cancelled

Neither artifact hash (`abca8f45`, `5db2184a`) was cached in `cache.projectbluefin.io` or `gbm.gnome.org` at build time.

## Fix

Add `if: false` to the `build-aarch64` job until the webkit artifacts are cached. X86 builds will succeed and push to the registry unblocked.

Re-enable once `webkit2gtk-4.1` and `webkitgtk-6.0` artifacts are warm in the remote cache.