### PR TITLE
fix(chunkify): add --tag so podman load outputs tagged ref

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -515,14 +515,15 @@ chunkify image_ref:
         -e "CHUNKAH_ROOTFS=/chunkah" \
         -e "CHUNKAH_CONFIG_STR=$CONFIG" \
         quay.io/coreos/chunkah@sha256:306371251e61cc870c8546e225b13bdf2e333f79461dc5e0fc280cc170cee070 build --max-layers 120 --prune /sysroot/ \
-        --label ostree.commit- --label ostree.final-diffid- \
+        --label ostree.commit- --label ostree.final-diffid- --tag "{{image_ref}}" \
         | $SUDO_CMD podman load)
 
     echo "$LOADED"
 
     # Parse the loaded image reference
     NEW_REF=$(echo "$LOADED" | grep -oP '(?<=Loaded image: ).*' || \
-              echo "$LOADED" | grep -oP '(?<=Loaded image\(s\): ).*')
+              echo "$LOADED" | grep -oP '(?<=Loaded image\(s\): ).*' || \
+              true)
 
     if [ -n "$NEW_REF" ] && [ "$NEW_REF" != "{{image_ref}}" ]; then
         echo "==> Retagging chunked image to {{image_ref}}..."


### PR DESCRIPTION
Without \`--tag\`, \`podman load\` outputs a bare sha256 hex string rather than \`"Loaded image: name:tag"\`. Both grep patterns in the \`NEW_REF\` assignment require the \`"Loaded image:"\` prefix, so both fail. With \`set -euo pipefail\` the script exits 1 immediately — this is why the first post-merge CI run (run 24754448896) failed at the \`chunkify\` recipe with no visible chunkah output.

**Fix:**
- Pass \`--tag "{{image_ref}}"\` to \`chunkah build\` so \`podman load\` outputs \`"Loaded image: dakota:latest"\`, which the grep matches cleanly
- Add \`|| true\` to the \`NEW_REF\` assignment as a defensive fallback against future \`podman load\` output format changes

The sha256 on CI log line 437 (\`2d90fa1c...\`) was \`echo "$LOADED"\` printing the bare digest from \`podman load\`, then the grep failed and \`set -e\` fired.