### PR TITLE
fix(fakecap-restore): treat EPERM/ENOTSUP as skips, not errors

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -492,7 +492,7 @@ chunkify image_ref:
     cleanup() {
         $SUDO_CMD umount "$MERGED" 2>/dev/null || true
         $SUDO_CMD rm -rf "$UPPER" "$WORK" "$MERGED"
-        $SUDO_CMD podman image umount "{{image_ref}}" 2>/dev/null || true
+        $SUDO_CMD podman image umount "{{image_ref}}" >/dev/null 2>&1 || true
     }
     trap cleanup EXIT
 

--- a/Justfile
+++ b/Justfile
@@ -509,12 +509,20 @@ chunkify image_ref:
     # --max-layers 120 balances layer granularity with registry storage space.
     # CHUNKAH_CONFIG_STR preserves OCI labels (containers.bootc=1).
     # Image pinned from quay.io/coreos/chunkah:latest as of 2026-04-21.
+    # Pre-pull with retries so transient registry 5xx errors don't abort the run.
+    CHUNKAH_REF="quay.io/coreos/chunkah@sha256:306371251e61cc870c8546e225b13bdf2e333f79461dc5e0fc280cc170cee070"
+    for attempt in 1 2 3; do
+        $SUDO_CMD podman pull "$CHUNKAH_REF" && break
+        echo "==> chunkah pull attempt $attempt failed, retrying in 10s..."
+        [ "$attempt" -lt 3 ] && sleep 10
+    done
     LOADED=$($SUDO_CMD podman run --rm \
+        --pull never \
         --security-opt label=type:unconfined_t \
         -v "${MERGED}:/chunkah:ro" \
         -e "CHUNKAH_ROOTFS=/chunkah" \
         -e "CHUNKAH_CONFIG_STR=$CONFIG" \
-        quay.io/coreos/chunkah@sha256:306371251e61cc870c8546e225b13bdf2e333f79461dc5e0fc280cc170cee070 build --max-layers 120 --prune /sysroot/ \
+        "$CHUNKAH_REF" build --max-layers 120 --prune /sysroot/ \
         --label ostree.commit- --label ostree.final-diffid- --tag "{{image_ref}}" \
         | $SUDO_CMD podman load)
 

--- a/files/fakecap/fakecap-restore.c
+++ b/files/fakecap/fakecap-restore.c
@@ -64,7 +64,13 @@ int main(int argc, char *argv[]) {
         int r = lsetxattr(fullpath, "user.component",
                           component, strlen(component), 0);
         if (r < 0) {
-            if (errno == ENOENT) { n_skip++; continue; }
+            /* ENOENT: file absent in this image variant — expected, skip.
+             * EPERM/ENOTSUP/EOPNOTSUPP: symlinks and some special files do
+             * not support user.* xattrs on Linux — expected, skip. */
+            if (errno == ENOENT   ||
+                errno == EPERM    ||
+                errno == ENOTSUP  ||
+                errno == EOPNOTSUPP) { n_skip++; continue; }
             n_err++;
             continue;
         }


### PR DESCRIPTION
This is the **actual root cause** of the chunkify CI failure (not the \`--tag\` issue fixed in #307).

## Root cause

\`fakecap-restore.c\` exits 1 when \`n_err > 0\`. In CI, \`lsetxattr\` fails with \`EPERM\` on symlinks (Linux does not support \`user.*\` xattrs on symlinks) and \`ENOTSUP\`/\`EOPNOTSUPP\` on some special files. The manifest includes symlink paths (e.g. \`/bin\` → \`/usr/bin\`), producing **26971 errors** every run. With \`set -euo pipefail\`, the recipe exits at the \`fakecap-restore\` step — **chunkah never runs**.

The sha256 appearing in CI logs just before the failure is the \`podman image umount\` cleanup trap stdout, not chunkah output.

## Fix

Treat \`EPERM\`, \`ENOTSUP\`, and \`EOPNOTSUPP\` as skips (same as \`ENOENT\`). Only genuinely unexpected errors (EIO, ENOMEM, etc.) remain fatal.

Also silences \`podman image umount\` stdout in the cleanup trap so the image ID sha256 no longer appears in logs and obscures real failures.