### PR TITLE
fix(chunkify): remove --tag flag not supported by pinned chunkah

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -523,15 +523,19 @@ chunkify image_ref:
         -e "CHUNKAH_ROOTFS=/chunkah" \
         -e "CHUNKAH_CONFIG_STR=$CONFIG" \
         "$CHUNKAH_REF" build --max-layers 120 --prune /sysroot/ \
-        --label ostree.commit- --label ostree.final-diffid- --tag "{{image_ref}}" \
+        --label ostree.commit- --label ostree.final-diffid- \
         | $SUDO_CMD podman load)
 
     echo "$LOADED"
 
-    # Parse the loaded image reference
-    NEW_REF=$(echo "$LOADED" | grep -oP '(?<=Loaded image: ).*' || \
-              echo "$LOADED" | grep -oP '(?<=Loaded image\(s\): ).*' || \
-              true)
+    # Parse the loaded image reference. Handles all podman output formats:
+    #   "Loaded image: <ref>"     — podman ≥4 with tagged OCI archive
+    #   "Loaded image(s): <ref>"  — older podman
+    #   bare 64-char hex sha256   — Ubuntu 24.04 podman for untagged archives
+    NEW_REF=$(echo "$LOADED" | sed -n 's/^Loaded image(s): //p; s/^Loaded image: //p' | head -1)
+    if [ -z "$NEW_REF" ]; then
+        NEW_REF=$(echo "$LOADED" | grep -oP '^[0-9a-f]{64}$' | head -1 || true)
+    fi
 
     if [ -n "$NEW_REF" ] && [ "$NEW_REF" != "{{image_ref}}" ]; then
         echo "==> Retagging chunked image to {{image_ref}}..."


### PR DESCRIPTION
## Problem

The chunkah version pinned at `sha256:306371...` does not support `--tag`. This flag was introduced in #307 based on a wrong hypothesis — the actual root cause of the original CI failure (fakecap-restore exiting 1 on EPERM) was fixed separately in #308.

With `--tag` present, CI fails immediately:
```
error: unexpected argument '--tag' found
Usage: chunkah build --rootfs <ROOTFS> --max-layers <MAX_LAYERS> --prune <PATH> --label <KEY=VALUE|KEY-|->
```
podman load then receives empty stdin and also fails.

## Fix

- Remove `--tag "{{image_ref}}"` from the chunkah build command
- Improve `NEW_REF` parsing to robustly handle all podman output formats:
  - `Loaded image: sha256:...` (podman ≥4, no ref annotation in OCI archive)
  - `Loaded image(s): sha256:...` (older podman)
  - bare 64-char hex sha256 (defensive fallback)

## Verification

Tested locally: stripped `org.opencontainers.image.ref.name` annotation from an OCI archive, confirmed podman 5.8.0 outputs `Loaded image: sha256:abc...`, sed pattern captures `sha256:abc...`, and `podman tag sha256:abc... ref:latest` succeeds.