### PR TITLE
linux: enable IPV6_MULTIPLE_TABLES for tailscaled IPv6 routing

### DIFF
--- a/patches/freedesktop-sdk/0009-linux-Enable-IPv6-policy-routing.patch
+++ b/patches/freedesktop-sdk/0009-linux-Enable-IPv6-policy-routing.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000001 Mon Sep 17 00:00:00 2001
+From: James Reilly <hanthor@users.noreply.github.com>
+Date: Wed, 22 Apr 2026 16:30:00 +0530
+Subject: [PATCH 9/9] linux: Enable IPv6 policy routing (IPV6_MULTIPLE_TABLES)
+
+Without CONFIG_IPV6_MULTIPLE_TABLES, `ip -6 rule` fails entirely and
+tailscaled cannot install its IPv6 routing rules. This causes tailscaled
+to fall back to using fe80:: link-local IPv6 paths for LAN peers, which
+are sticky and do not recover cleanly after sleep/wake cycles. The result
+is silent WireGuard data loss: disco pings continue to work (different
+code path) while all WireGuard data packets time out.
+
+The Fedora kernel has had IPV6_MULTIPLE_TABLES enabled for years.
+IPV6_SUBTREES (source-address-based routing) is also enabled here as it
+is a natural companion and is likewise enabled by Fedora.
+
+Symptoms of missing IPV6_MULTIPLE_TABLES:
+  tailscaled log: "router: disabling tunneled IPv6 due to system IPv6
+  config: kernel does not support IPv6 policy routing"
+  `ip -6 rule`: RTNETLINK answers: Address family not supported by protocol
+---
+ files/linux/fdsdk-config.sh | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/files/linux/fdsdk-config.sh b/files/linux/fdsdk-config.sh
+index 1b9465fd9..c23f8b2a1 100644
+--- a/files/linux/fdsdk-config.sh
++++ b/files/linux/fdsdk-config.sh
+@@ -2811,3 +2811,11 @@
+ if has ACPI; then
+   module INPUT_SOC_BUTTON_ARRAY
+ fi
++
++# IPv6 policy routing - required by tailscaled and other tools that use
++# `ip -6 rule`. Without this, tailscaled cannot install its IPv6 routing
++# rules and falls back to link-local paths that break after sleep/wake.
++if has IPV6; then
++  enable IPV6_MULTIPLE_TABLES
++  enable IPV6_SUBTREES
++fi


### PR DESCRIPTION
## Problem

Without `CONFIG_IPV6_MULTIPLE_TABLES`, `ip -6 rule` fails entirely:

```
$ ip -6 rule
RTNETLINK answers: Address family not supported by protocol
```

This causes `tailscaled` to log:

```
router: disabling tunneled IPv6 due to system IPv6 config:
  kernel doesn't support IPv6 policy routing
```

Without the ability to install IPv6 routing rules, tailscaled falls back to `fe80::` link-local IPv6 paths for LAN peers. These paths are sticky and don't recover after sleep/wake — disco pings continue working (different code path) while all WireGuard data times out silently.

The Fedora kernel has had `IPV6_MULTIPLE_TABLES=y` for years. This is a straightforward gap in the Dakota kernel config.

## Fix

Add `IPV6_MULTIPLE_TABLES` and `IPV6_SUBTREES` to `fdsdk-config.sh`. One new patch file, no other changes.

## Testing

Verified on a Dakota alpha install: before the fix `ip -6 rule` errors, tailscaled uses link-local paths that break after sleep. After loading the module, tailscaled installs its fwmark rules and uses stable paths.

Related to #174