### PR TITLE
chore(coreutils): revert mv, cp, rm to gnu coreutils

### DIFF
--- a/elements/bluefin/uutils-coreutils.bst
+++ b/elements/bluefin/uutils-coreutils.bst
@@ -9,6 +9,11 @@ config:
   - |
     for prog in $(target/release/coreutils --list); do
       ln -sr "%{install-root}/usr/bin/uutils-coreutils" "%{install-root}/usr/bin/uutils-${prog}"
+      # Keep cp/mv/rm from GNU coreutils — uutils has unresolved TOCTOU issues.
+      # See projectbluefin/common#290.
+      case "${prog}" in
+        cp|mv|rm) continue ;;
+      esac
       ln -sr "%{install-root}/usr/bin/uutils-coreutils" "%{install-root}/usr/bin/${prog}"
     done
 
@@ -29,7 +34,6 @@ public:
     - /usr/bin/chroot
     - /usr/bin/cksum
     - /usr/bin/comm
-    - /usr/bin/cp
     - /usr/bin/csplit
     - /usr/bin/cut
     - /usr/bin/date
@@ -65,7 +69,6 @@ public:
     - /usr/bin/mknod
     - /usr/bin/mktemp
     - /usr/bin/more
-    - /usr/bin/mv
     - /usr/bin/nice
     - /usr/bin/nl
     - /usr/bin/nohup
@@ -82,7 +85,6 @@ public:
     - /usr/bin/pwd
     - /usr/bin/readlink
     - /usr/bin/realpath
-    - /usr/bin/rm
     - /usr/bin/rmdir
     - /usr/bin/seq
     - /usr/bin/sha1sum


### PR DESCRIPTION
As per https://discourse.ubuntu.com/t/an-update-on-rust-coreutils/80773

> cp, mv, and rm continue to be provided by GNU coreutils in 26.04. These utilities have remaining open TOCTOU (time-of-check to time-of-use) issues (8 as of Apr 22, 2026) that need to be resolved before we are confident shipping them.

We should make sure the default in https://github.com/projectbluefin/dakota for cp, mv, and rm are from GNU coreutils

Closes https://github.com/projectbluefin/common/issues/290

Did a sanity on my local build:

```
=== unprefixed cp/mv/rm must be GNU ===
/usr/bin/cp -> /usr/bin/cp
  version: cp (GNU coreutils) 9.7
/usr/bin/mv -> /usr/bin/mv
  version: mv (GNU coreutils) 9.7
/usr/bin/rm -> /usr/bin/rm
  version: rm (GNU coreutils) 9.7

=== uutils- prefixed aliases must still exist and be uutils ===
/usr/bin/uutils-cp -> uutils-coreutils
  version: cp (uutils coreutils) 0.8.0
/usr/bin/uutils-mv -> uutils-coreutils
  version: mv (uutils coreutils) 0.8.0
/usr/bin/uutils-rm -> uutils-coreutils
  version: rm (uutils coreutils) 0.8.0

=== sanity: other applets still default to uutils ===
/usr/bin/ls -> /usr/bin/uutils-coreutils
/usr/bin/cat -> /usr/bin/uutils-coreutils
/usr/bin/chmod -> /usr/bin/uutils-coreutils
```