### PR TITLE
fix(ci): suppress phantom PRs when bst source track only normalizes r…

### DIFF
--- a/.github/workflows/track-bst-sources.yml
+++ b/.github/workflows/track-bst-sources.yml
@@ -143,13 +143,26 @@ jobs:
         if: steps.gate.outputs.run == 'true'
         id: changes
         run: |
+          BST_PATH="elements/${{ matrix.element }}"
           if git diff --quiet; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "No changes detected for ${{ matrix.element }}"
           else
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-            echo "Changes detected:"
-            git diff --stat
+            # bst source track can normalize ref format without changing the underlying
+            # commit (e.g. plain SHA -> git-describe "v0.2.13-0-g<sha>").
+            # Compare the set of terminal 40-char hex SHAs from ref: lines in both
+            # the old (HEAD) and new (working tree) file states.  If the sets are
+            # identical, only formatting changed — no real update, skip the PR.
+            OLD_SHAS=$(git show "HEAD:$BST_PATH" | grep -oP '^\s*ref:\s+\K\S+' | grep -oP '[0-9a-f]{40}$' | sort)
+            NEW_SHAS=$(grep -oP '^\s*ref:\s+\K\S+' "$BST_PATH" | grep -oP '[0-9a-f]{40}$' | sort)
+            if [ -n "$OLD_SHAS" ] && [ "$OLD_SHAS" = "$NEW_SHAS" ]; then
+              echo "has_changes=false" >> "$GITHUB_OUTPUT"
+              echo "Ref format normalized but same underlying commit(s) — no update, skipping PR"
+            else
+              echo "has_changes=true" >> "$GITHUB_OUTPUT"
+              echo "Changes detected:"
+              git diff --stat
+            fi
           fi
 
       - name: Create PR


### PR DESCRIPTION
…ef format

bst source track rewrites plain SHA refs to git-describe format (e.g. 965cd7b9... -> v0.2.13-0-g965cd7b9...) even when the underlying commit has not changed. This caused the daily bot to open PRs like #312 and #311 where old and new SHAs were identical.

Fix: after detecting a git diff, compare the set of terminal 40-char hex SHAs extracted from ref: lines in the old file state (HEAD) vs the new (working tree). If the sets are identical and non-empty, it is a format-only normalization — set has_changes=false and skip PR creation.

Using file-state comparison (not diff-hunk parsing) correctly handles multi-ref elements such as common.bst (git_repo + git_module).


Assisted-by: Claude Sonnet 4.6 via GitHub Copilot