### PR TITLE
chore(renovate): add customManager for chunkah container image

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,6 +46,20 @@
       "versioningTemplate": "pep440"
     },
 
+    // ── chunkah container image in Justfile ──
+    // Matches: CHUNKAH_REF="quay.io/coreos/chunkah@sha256:<digest>"
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^Justfile$/"
+      ],
+      "matchStrings": [
+        "CHUNKAH_REF=\"(?<depName>quay\\.io/coreos/chunkah)@sha256:(?<currentDigest>[a-f0-9]{64})\""
+      ],
+      "datasourceTemplate": "docker",
+      "currentValueTemplate": "latest"
+    },
+
     // ── Nerd Fonts GitHub release tarball ──
     // Matches: url: github_files:ryanoasis/nerd-fonts/releases/download/v<version>/JetBrainsMono.tar.xz
     //          ref: <sha256>


### PR DESCRIPTION
## Problem

`CHUNKAH_REF` in the Justfile was pinned by digest (`quay.io/coreos/chunkah@sha256:...`) but had no Renovate coverage — new chunkah versions were silently missed.

## Fix

Add a `customManagers` regex entry that matches the `CHUNKAH_REF="quay.io/coreos/chunkah@sha256:<digest>"` pattern in the Justfile. Renovate will now bump the digest automatically when a new `latest` is published, with the same auto-merge behavior as other `custom.regex` entries.