### PR TITLE
fix(renovate): include sha256: prefix in chunkah currentDigest capture

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -54,7 +54,7 @@
         "/^Justfile$/"
       ],
       "matchStrings": [
-        "CHUNKAH_REF=\"(?<depName>quay\\.io/coreos/chunkah)@sha256:(?<currentDigest>[a-f0-9]{64})\""
+        "CHUNKAH_REF=\"(?<depName>quay\\.io/coreos/chunkah)@(?<currentDigest>sha256:[a-f0-9]{64})\""
       ],
       "datasourceTemplate": "docker",
       "currentValueTemplate": "latest"


### PR DESCRIPTION
Renovate's Docker datasource requires currentDigest to include the 'sha256:' prefix. The previous regex stripped it, causing Renovate to silently discard the match without adding chunkah to detected dependencies.