### PR TITLE
fix(deps): restore fwupd dropped by Saturn merge

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -30,6 +30,8 @@ depends:
   - bluefin/xdg-terminal-exec.bst
 
   # Include things missing from the gnomeos base image
+  - gnome-build-meta.bst:core-deps/fwupd.bst
+
   - freedesktop-sdk.bst:components/buildstream2.bst
   - freedesktop-sdk.bst:components/containers-common.bst
   - freedesktop-sdk.bst:components/debuginfod.bst


### PR DESCRIPTION
Commit 6abb604 (`feat(saturn)`) accidentally removed `gnome-build-meta.bst:core-deps/fwupd.bst` from `deps.bst` when merging against a base that predated the fix in PR #279.

This restores the fwupd daemon to the image. The fwupd EFI binary (`fwupd-efi-signed-maybe.bst`) was already present via the gnomeos stack, but the daemon and `fwupdmgr` were missing.

Fixes the regression introduced by Saturn PR #321.