### PR TITLE
fix(tailscale): provide defaults for tailscaled service

### DIFF
--- a/elements/bluefin/tailscale.bst
+++ b/elements/bluefin/tailscale.bst
@@ -25,6 +25,8 @@ config:
     sed -e 's|/usr/sbin/tailscaled|/usr/bin/tailscaled|g' \
         -e '/^EnvironmentFile=/d' \
         systemd/tailscaled.service > tailscaled.service.patched
+    sed -i '/^\[Service\]/a Environment=FLAGS=' tailscaled.service.patched
+    sed -i '/^\[Service\]/a Environment=PORT=41641' tailscaled.service.patched
     install -Dm644 -t "%{install-root}%{indep-libdir}/systemd/system" tailscaled.service.patched
     mv "%{install-root}%{indep-libdir}/systemd/system/tailscaled.service.patched" \
        "%{install-root}%{indep-libdir}/systemd/system/tailscaled.service"


### PR DESCRIPTION
Fixes #167.

## Summary
- add default `Environment=PORT=41641` and `Environment=FLAGS=` entries to the generated `tailscaled.service`
- keep the existing `/usr/sbin/tailscaled` to `/usr/bin/tailscaled` rewrite
- keep removing the upstream `EnvironmentFile=` entry that Dakota no longer ships

## Test Plan
- boot a local Dakota VM
- verify `/usr/lib/systemd/system/tailscaled.service` contains `Environment=PORT=41641` and `Environment=FLAGS=`
- verify `tailscaled.service` is `active (running)` and the daemon starts with `--port=41641`