### PR TITLE
fix(network): remove %{install-extra} from text-only element

### DIFF
--- a/elements/bluefin/network.bst
+++ b/elements/bluefin/network.bst
@@ -20,4 +20,4 @@ config:
     ::1         localhost
     EOF
 
-  - "%{install-extra}"
+


### PR DESCRIPTION
## Problem

`bluefin/network.bst` (added in PR #296) includes `"%{install-extra}"` in its `install-commands`. The `%{install-extra}` macro expands to call `freedesktop-sdk-stripper`, a build tool that is **not present** in the `runtime-minimal.bst` sandbox used by this `kind:manual` element.

This caused CI run #308 to fail with:
```
sh: line 11: freedesktop-sdk-stripper: command not found
[FAILURE] bluefin/network.bst: Running commands (exit 127)
```

Ref: https://github.com/projectbluefin/dakota/actions/runs/24918267112/job/72974650971

## Fix

Remove `"%{install-extra}"` from `network.bst`. This element installs only two **inline text files** (a tmpfiles.d rule and `/etc/hosts`) — no compiled binaries, no external sources. There is nothing to strip or license-install, so the call is both unnecessary and broken.