### PR TITLE
fix(bluefin/network): disable binary stripping for text-only element

### DIFF
--- a/elements/bluefin/network.bst
+++ b/elements/bluefin/network.bst
@@ -4,6 +4,9 @@ kind: manual
 build-depends:
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
+variables:
+  strip-binaries: ""
+
 config:
   install-commands:
   - |
@@ -19,5 +22,3 @@ config:
     127.0.0.1   localhost
     ::1         localhost
     EOF
-
-


### PR DESCRIPTION
## Problem

`bluefin/network.bst` fails in CI with `freedesktop-sdk-stripper: command not found` (exit 127).

## Root Cause

Dakota's `project.conf` includes `runtime.yml` project-wide, which pulls in `strip.yml`. That file defines `strip-binaries` as a script calling `freedesktop-sdk-stripper`, which BST runs via `strip-commands` automatically after `install-commands` for every element.

`network.bst` uses `build-depends: freedesktop-sdk.bst:public-stacks/runtime-minimal.bst` — a minimal runtime sandbox that does **not** include `freedesktop-sdk-stripper` in PATH.

## Fix

Add `variables: strip-binaries: ""` to disable the strip step for this text-only element. This is identical to the pattern used by `common.bst`, `brew.bst`, and other elements with no binaries to strip. Setting `strip-binaries` to empty string makes `strip-commands` a no-op (`sh -c -e $'\n'`), so the stripper binary is never invoked.

## Verification

Tested locally on ghost with `just bst build bluefin/network.bst`:
```
Build Queue: processed 1, skipped 16, failed 0
```
Build log confirms only the two `install` commands and an empty strip step run — `freedesktop-sdk-stripper` is not called.

Note: PR #328 (merged earlier) removed `%{install-extra}` — that was the wrong fix. `%{install-extra}` expands to the license-copying script, not the stripper. This PR adds the correct fix on top.