### PR TITLE
fix(storage): hide composefs loop from UDisks

### DIFF
--- a/elements/bluefin/composefs-loop-udisks-ignore.bst
+++ b/elements/bluefin/composefs-loop-udisks-ignore.bst
@@ -1,0 +1,16 @@
+kind: manual
+
+sources:
+  - kind: local
+    path: files/udev
+
+build-depends:
+  - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+    - install -Dm644 90-hide-composefs-loop.rules "%{install-root}/usr/lib/udev/rules.d/90-hide-composefs-loop.rules"
+    - "%{install-extra}"

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -19,6 +19,7 @@ depends:
   - bluefin/fzf.bst
 
   - bluefin/common.bst
+  - bluefin/composefs-loop-udisks-ignore.bst
   - bluefin/wallpapers.bst
 
   - bluefin/jetbrains-mono.bst

--- a/elements/bluefin/network.bst
+++ b/elements/bluefin/network.bst
@@ -4,9 +4,6 @@ kind: manual
 build-depends:
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
-variables:
-  strip-binaries: ""
-
 config:
   install-commands:
   - |

--- a/elements/bluefin/network.bst
+++ b/elements/bluefin/network.bst
@@ -4,6 +4,9 @@ kind: manual
 build-depends:
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
+variables:
+  strip-binaries: ""
+
 config:
   install-commands:
   - |

--- a/files/udev/90-hide-composefs-loop.rules
+++ b/files/udev/90-hide-composefs-loop.rules
@@ -1,0 +1,3 @@
+# Hide the internal composefs metadata loop from UDisks clients such as Nautilus.
+# Keep the match narrow so user-created loop devices remain visible.
+SUBSYSTEM=="block", ACTION=="add|change|move|bind", KERNEL=="loop*", ENV{ID_FS_TYPE}=="erofs", ATTR{loop/backing_file}=="/sysroot/composefs/objects/*", ENV{UDISKS_IGNORE}="1"


### PR DESCRIPTION
## Summary
- add a dedicated `bluefin/composefs-loop-udisks-ignore.bst` element that installs a narrow udev rule for the internal composefs metadata loop
- include that element in `elements/bluefin/deps.bst` so the rule lands in the image
- keep the scope limited to issue `#245` by hiding only the confirmed internal composefs-backed loop device shape

## Why issue #245 happens
Fixes #245.

Dakota's VM install path explicitly uses:

- `bootc install to-disk --composefs-backend`

That means the installed system uses the composefs-backed bootc layout. In the reproduced Dakota VM, an internal system metadata volume is surfaced as `/dev/loop0` and UDisks presents it to GUI clients such as Nautilus.

The observed device shape was:
- `KERNEL=loop*`
- `ID_FS_TYPE=erofs`
- `loop/backing_file=/sysroot/composefs/objects/...`
- mounted content matching immutable system-image metadata rather than user storage

So the visible volume is not a user disk and not fundamentally a Nautilus bug. It is an internal composefs-backed system volume that UDisks currently treats like an ordinary block device.

## GNOME OS style / upstream context
Dakota is built on GNOME OS and already inherits GNOME OS upstream UDisks-hiding behavior from `gnome-build-meta`.

That matters because GNOME OS already solves this class of problem at the storage-discovery layer:
- internal OS storage is hidden from UDisks with udev rules
- the fix is not in Nautilus
- the fix is not broad device suppression

However, the inherited GNOME OS rules do not match the exact device shape reproduced here. Dakota already gets the upstream internal-storage hide rules, but `/dev/loop0` still shows up because this composefs metadata loop is a different presentation from the dm-verity/root/usr cases those rules already cover.

So this PR follows the same GNOME OS style, but extends it narrowly for the confirmed Dakota VM case.

## Why this is the smallest correct fix
This PR does **not**:
- patch Nautilus
- change bootc or composefs behavior
- hide all loop devices
- affect legitimate user-created loop mounts or disk-image workflows

It only sets `UDISKS_IGNORE=1` for the internal composefs-backed `erofs` loop device shape observed during reproduction:

```udev
SUBSYSTEM=="block", ACTION=="add|change|move|bind", KERNEL=="loop*", ENV{ID_FS_TYPE}=="erofs", ATTR{loop/backing_file}=="/sysroot/composefs/objects/*", ENV{UDISKS_IGNORE}="1"
```

That keeps the change aligned with GNOME OS's existing strategy while avoiding overreach.

## Verification
- verified the built artifact installs `/usr/lib/udev/rules.d/90-hide-composefs-loop.rules`
- local full build succeeded
- VM verification no longer reproduces the visible internal composefs loop issue

## Follow-up
If the same loop-device exposure can be reproduced in plain GNOME OS, the longer-term upstream home could be `gnome-build-meta`'s internal-storage UDisks rules. For the currently confirmed Dakota-specific repro, this repo-local rule is the smallest safe fix.