### PR TITLE
fix(ci): replace broken setup-just with taiki-e/install-action

### DIFF
--- a/.github/workflows/track-bst-sources.yml
+++ b/.github/workflows/track-bst-sources.yml
@@ -121,7 +121,9 @@ jobs:
           fi
 
       - name: Setup Just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+        uses: taiki-e/install-action@481c34c1cf3a84c68b5e46f4eccfc82af798415a # v2
+        with:
+          tool: just
 
       - name: Checkout repository
         if: steps.gate.outputs.run == 'true'
@@ -261,7 +263,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+        uses: taiki-e/install-action@481c34c1cf3a84c68b5e46f4eccfc82af798415a # v2
+        with:
+          tool: just
 
       - name: Configure git
         run: |


### PR DESCRIPTION
extractions/setup-just@v4 is broken; replace both occurrences in track-bst-sources.yml with taiki-e/install-action (pinned SHA) which reliably installs just in GitHub Actions environments.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot