### PR TITLE
Add nautilus python

### DIFF
--- a/.github/workflows/track-bst-sources.yml
+++ b/.github/workflows/track-bst-sources.yml
@@ -87,6 +87,10 @@ jobs:
             element: bluefin/xdg-terminal-exec.bst
             branch: auto/track-xdg-terminal-exec
             title: "chore(deps): update xdg-terminal-exec"
+          - group: auto-merge
+            element: bluefin/nautilus-python.bst
+            branch: auto/track-nautilus-python
+            title: "chore(deps): update nautilus-python"
           # ── manual-merge: core junctions ──
           - group: manual-merge
             element: gnome-build-meta.bst

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -29,6 +29,7 @@ depends:
   - bluefin/sudo-rs.bst
   - bluefin/efibootmgr.bst
   - bluefin/xdg-terminal-exec.bst
+  - bluefin/nautilus-python.bst
   - bluefin/network.bst
 
   # Include things missing from the gnomeos base image

--- a/elements/bluefin/nautilus-python.bst
+++ b/elements/bluefin/nautilus-python.bst
@@ -1,0 +1,20 @@
+kind: meson
+
+sources:
+- kind: git_repo
+  url: gnome:nautilus-python.git
+  track: "master"
+  ref: 4.1.0-0-g52fe5a0339065aa5461075c53002b1534b590188
+
+variables:
+  conf-flags: >-
+    -Dgtk_doc=false
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+- freedesktop-sdk.bst:components/python3.bst
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+- gnome-build-meta.bst:core/nautilus.bst
+- freedesktop-sdk.bst:components/pygobject.bst


### PR DESCRIPTION
For nautilus plugins.

For exemple we we need it for Ghostty, GSConnect, xdg-terminal-nautilus or custom scripts users want to run.