### PR TITLE
fix(ci): unblock bst2 CI and add pin consistency gate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,7 @@
   "platformAutomerge": true,
 
   // Don't rebase PRs when main changes -- reduces churn
-  "rebaseWhen": "never",
+  "rebaseWhen": "conflicted",
 
   "customManagers": [
     // ── bst2 container image in CI workflows and Justfile ──
@@ -58,21 +58,6 @@
       ],
       "datasourceTemplate": "docker",
       "currentValueTemplate": "latest"
-    },
-
-    // ── Nerd Fonts GitHub release tarball ──
-    // Matches: url: github_files:ryanoasis/nerd-fonts/releases/download/v<version>/JetBrainsMono.tar.xz
-    //          ref: <sha256>
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/elements/bluefin/jetbrains-mono-nerd-font\\.bst$/"
-      ],
-      "matchStrings": [
-        "url:\\s*github_files:(?<depName>ryanoasis/nerd-fonts)/releases/download/v(?<currentValue>\\d+\\.\\d+\\.\\d+)/JetBrainsMono\\.tar\\.xz\\n\\s+ref:\\s*(?<currentDigest>[a-f0-9]{64})"
-      ],
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.+)$"
     }
   ],
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Check bst2 image pin consistency
+        run: |
+          just_sha="$(grep -oE 'bst2:[a-f0-9]{40}' Justfile | cut -d: -f2)"
+          track_sha="$(grep -oE 'bst2:[a-f0-9]{40}' .github/workflows/track-bst-sources.yml | cut -d: -f2)"
+          if [[ -z "$just_sha" || -z "$track_sha" ]]; then
+            echo "ERROR: could not find bst2 SHA (Justfile: '${just_sha:-missing}', track-bst-sources.yml: '${track_sha:-missing}')"; exit 1
+          fi
+          [[ "$just_sha" == "$track_sha" ]] || { echo "ERROR: bst2 pin drift — Justfile: $just_sha  track-bst-sources.yml: $track_sha"; exit 1; }
+          echo "OK: bst2 pins consistent: $just_sha"
+
       # FIXME: Make the build with JWT work
       # - name: Get JWT token
       #   uses: actions/github-script@v7

--- a/.github/workflows/track-bst-sources.yml
+++ b/.github/workflows/track-bst-sources.yml
@@ -21,7 +21,7 @@ permissions:
   pull-requests: write
 
 env:
-  BST2_IMAGE: registry.gitlab.com/freedesktop-sdk/infrastructure/freedesktop-sdk-docker-images/bst2:f89b4aef847ef040b345acceda15a850219eb8f1
+  BST2_IMAGE: registry.gitlab.com/freedesktop-sdk/infrastructure/freedesktop-sdk-docker-images/bst2:02bfebd4a9f9924ec7a67ba01623331e30e9348f
 
 jobs:
   track:
@@ -131,6 +131,15 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check bst2 image pin consistency
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          just_sha="$(grep -oE 'bst2:[a-f0-9]{40}' Justfile | cut -d: -f2)"
+          track_sha="${BST2_IMAGE##*:}"
+          [[ -n "$just_sha" ]] || { echo "ERROR: could not find bst2 SHA in Justfile"; exit 1; }
+          [[ "$just_sha" == "$track_sha" ]] || { echo "ERROR: bst2 pin drift — Justfile: $just_sha  BST2_IMAGE env: $track_sha"; exit 1; }
+          echo "OK: bst2 pins consistent: $just_sha"
 
       - name: Pull BuildStream container image
         if: steps.gate.outputs.run == 'true'


### PR DESCRIPTION
## Problem

The `bst2` container image tag is pinned in two files that must stay in sync:
- `Justfile` line 13: `bst2_image :=`
- `.github/workflows/track-bst-sources.yml` line 24: `BST2_IMAGE:`

A manual commit updated only the Justfile, leaving `track-bst-sources.yml` on a deleted tag and breaking every CI run. This is the third occurrence of this pattern.

## Changes

- **Justfile + track-bst-sources.yml**: update bst2 tag `f89b4aef` → `02bfebd` (unblocks CI)
- **build.yml**: add `Check bst2 image pin consistency` step — compares the SHA in Justfile against `$BST2_IMAGE` in `track-bst-sources.yml`; fails fast before any expensive build work if they drift
- **track-bst-sources.yml**: same consistency check guards manual workflow dispatch (uses `$BST2_IMAGE` env var already in scope)
- **renovate.json5**: `rebaseWhen: "never"` → `"conflicted"`; remove `jetbrains-mono-nerd-font` custom manager (duplicate of `track-tarballs` job)

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>