### PR TITLE
fix(custom-menu): set icon display mode and repin to post-v14 cleanup commit

### DIFF
--- a/elements/bluefin/shell-extensions/custom-command-menu.bst
+++ b/elements/bluefin/shell-extensions/custom-command-menu.bst
@@ -4,7 +4,7 @@ sources:
 - kind: git_repo
   url: github:StorageB/custom-command-menu.git
   track: 'v[0-9]*'
-  ref: v14-0-g2c054fc91216f38d3def7fb273461a347494356c
+  ref: v14-3-g8391fe24d069fb983999ad8b6439b855af73e07f
 - kind: local
   path: files/dconf
 

--- a/files/dconf/05-dakota-custom-command-menu
+++ b/files/dconf/05-dakota-custom-command-menu
@@ -5,8 +5,13 @@
 # The extension uses command1-99 keys of type (sssb): (label, command, icon, visible).
 # The upstream common distro db uses stale entryrow* keys not in the schema; this file
 # provides the correct keys so the menu survives dconf reset and fresh installs.
+# menuoptions-setting: 0=text label, 1=custom text, 2=icon. Set to 2 to show icon.
+# upstream common still ships 04-bluefin-logomenu-extension (LogoMenu config) which has
+# no effect on this extension — dakota must own these display settings entirely.
 
 [org/gnome/shell/extensions/custom-command-list]
+menuoptions-setting=2
+menuicon-setting='utilities-terminal-symbolic'
 command-order=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99]
 command1=('---$(hostname)', '', '', true)
 command2=('About', 'gnome-control-center system about', '', true)


### PR DESCRIPTION
## Summary

Two fixes for the custom command menu regression:

### 1. Icon not showing in panel (primary regression)

The panel was showing "Commands" text instead of the icon. Root cause: `menuoptions-setting` was never set in any distro dconf file — `upstream/common` still ships `04-bluefin-logomenu-extension` (dead config for the old LogoMenu extension) which has no effect on custom-command-menu. Dakota must own these display settings entirely.

Fix: add `menuoptions-setting=2` (icon mode) and `menuicon-setting='utilities-terminal-symbolic'` to `05-dakota-custom-command-menu`.

Extension display modes:
- `0` = text label "Commands" (default, broken state)
- `1` = custom text from `menutitle-setting`
- `2` = icon from `menuicon-setting` ✅

### 2. Repin to post-v14 upstream cleanup commit

The tracking bot (`94a1fc5`) downgraded the extension ref from `v14-3-g8391fe24` to `v14-0-g2c054fc` (the exact v14 tag). The 3 post-v14 commits include GNOME Extension Review Guidelines cleanup:

- `GLib.source_remove` → `GLib.Source.remove` in dynamic label timeout code
- Timeout race fix: guard `timeoutId > 0` before removal
- Remove `_pendingTimeouts` array (replaced with local closure var)

These are in upstream main but not yet tagged as v15. Pinned manually until v15 is released and the tracker picks it up.

## Testing

- [ ] Panel shows terminal icon instead of "Commands" text
- [ ] `---$(hostname)` separator resolves to actual hostname
- [ ] Menu commands launch correctly