### PR TITLE
fix(ujust): generate ujust completions

### DIFF
--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -10,6 +10,9 @@ sources:
   path: bluefin-branding
   ref: f5213ca61615bb79a8315fc4c5378a80ca93922e
 
+build-depends:
+- gnome-build-meta.bst:gnomeos-deps/just.bst
+
 depends:
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 - freedesktop-sdk.bst:components/sed.bst
@@ -38,6 +41,15 @@ config:
     cp -r system_files/bluefin/etc/./ "%{install-root}%{sysconfdir}/"
     cp -r system_files/shared/etc/./ "%{install-root}%{sysconfdir}/"
     cp -r bluefin-branding/system_files/etc/./ "%{install-root}%{sysconfdir}/"
+
+    # Generate ujust completions to match the upstream common image.
+    install -d \
+      "%{install-root}%{datadir}/bash-completion/completions" \
+      "%{install-root}%{datadir}/zsh/site-functions" \
+      "%{install-root}%{datadir}/fish/vendor_completions.d"
+    just --completions bash | sed -E 's/([\(_" ])just/\1ujust/g' > "%{install-root}%{datadir}/bash-completion/completions/ujust"
+    just --completions zsh | sed -E 's/([\(_" ])just/\1ujust/g' > "%{install-root}%{datadir}/zsh/site-functions/_ujust"
+    just --completions fish | sed -E 's/([\(_" ])just/\1ujust/g' > "%{install-root}%{datadir}/fish/vendor_completions.d/ujust.fish"
 
     # Map Bluefin icons to GNOME OS expected names
     # About dialog (gnome-control-center reads LOGO=img-logo-icon from os-release,


### PR DESCRIPTION
## Description

Generate `ujust` shell completions in Dakota’s `bluefin/common.bst` install step.

`ujust` itself already ships via the pinned `projectbluefin/common` source tree, but its bash, zsh, and fish completions are generated at build time in `projectbluefin/common`’s `Containerfile`, so Dakota was not picking them up when consuming `common` as a git source.

This mirrors the upstream completion generation step inside Dakota’s BuildStream element so the final image includes `ujust` completions again.

Close #358

## Changes

- **`elements/bluefin/common.bst`**
  - added `gnome-build-meta.bst:gnomeos-deps/just.bst` as a `build-depends`
  - generate bash, zsh, and fish completions for `just`
  - rewrite completion output from `just` to `ujust`
  - install generated completions to:
    - `/usr/share/bash-completion/completions/ujust`
    - `/usr/share/zsh/site-functions/_ujust`
    - `/usr/share/fish/vendor_completions.d/ujust.fish`

## Type of Change

- [x] Bug fix

## Testing

- [x] `just build`
- [x] VM boot test
- [x] Verified `ujust` completions are present/work for bash, fish and zsh

Assisted-by: GPT-5.4 via Zed