### PR TITLE
feat(ci): split build/publish workflows, add SBOM+signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,6 @@ concurrency:
 jobs:
   build:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    permissions:
-      contents: read
-      packages: write
     # Variant matrix: the default Bluefin image and the NVIDIA variant build
     # in parallel. They share the BST artifact cache via cache.projectbluefin.io,
     # so whichever runs first warms the closure for the other. NVIDIA is
@@ -52,6 +49,8 @@ jobs:
             publish: true
             continue: true
     continue-on-error: ${{ matrix.continue }}
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -74,18 +73,6 @@ jobs:
       #       const fs = require('fs');
       #       const token = await core.getIDToken('cache.projectbluefin.io')
       #       fs.writeFileSync('bluefin.token', token, { mode: 0o600 });
-
-      - name: Mount BTRFS for podman storage
-        id: container-storage
-        uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6
-        continue-on-error: true
-        with:
-          target-dir: /var/lib/containers
-          mount-opts: compress-force=zstd:2
-          loopback-free: '1'
-
-      - name: Remove unwanted software
-        uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
 
       - name: Setup Just
         uses: taiki-e/install-action@just
@@ -221,42 +208,6 @@ jobs:
           just bst build ${{ matrix.element }}
         timeout-minutes: 420
 
-      # ── Export OCI image ──────────────────────────────────────────────
-      # Uses the Justfile's `export` recipe: checks out the OCI image
-      # layout from BuildStream, loads it into podman via skopeo, and
-      # applies the /usr/etc bootc fixup. Same logic as local builds.
-      # Creates image with local name (dakota:latest) to avoid registry
-      # lookups during validation.
-
-      - name: Export OCI image from BuildStream
-        id: export
-        env:
-          BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf
-          BUILD_IMAGE_NAME: ${{ env.IMAGE_NAME }}
-          OCI_IMAGE_CREATED: ${{ steps.timestamp.outputs.created }}
-          OCI_IMAGE_REVISION: ${{ github.sha }}
-          OCI_IMAGE_VERSION: latest
-        run: |
-          just export ${{ matrix.variant }}
-          echo "image_ref=${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}:latest" >> "$GITHUB_OUTPUT"
-
-      - name: Verify image loaded
-        run: sudo podman images
-
-      # ── Validation ────────────────────────────────────────────────────
-
-      - name: Validate with bootc container lint
-        env:
-          BUILD_IMAGE_NAME: ${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
-        run: |
-           just lint
-
-      # Delete jwt token just in case
-      # FIXME: Make the build with JWT work
-      # - name: Delete token
-      #   if: always()
-      #   run: rm -f bluefin.token
-
       # ── Upload build logs ─────────────────────────────────────────────
       # Always upload, even on failure, so build failures can be diagnosed.
 
@@ -268,47 +219,6 @@ jobs:
           path: logs/
           retention-days: 7
           if-no-files-found: ignore
-
-      - name: Login to GHCR
-        if: >-
-          matrix.publish &&
-          (github.event_name == 'merge_group' ||
-           github.event_name == 'schedule' ||
-           github.event_name == 'workflow_dispatch')
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | \
-            sudo podman login ghcr.io --username ${{ github.actor }} --password-stdin
-
-      - name: Tag image for GHCR
-        if: >-
-          matrix.publish &&
-          (github.event_name == 'merge_group' ||
-           github.event_name == 'schedule' ||
-           github.event_name == 'workflow_dispatch')
-        run: |
-          sudo podman tag "localhost/${{ steps.export.outputs.image_ref }}" \
-            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}:latest"
-          sudo podman tag "localhost/${{ steps.export.outputs.image_ref }}" \
-            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}:${{ github.sha }}"
-
-      - name: Push to GHCR
-        if: >-
-          matrix.publish &&
-          (github.event_name == 'merge_group' ||
-           github.event_name == 'schedule' ||
-           github.event_name == 'workflow_dispatch')
-        run: |
-          for tag in latest "${{ github.sha }}"; do
-            for i in 1 2 3; do
-              # Plain zstd required: bootc composefs-oci cannot consume zstd:chunked blobs.
-              # After chunkah rechunking, blobs are fresh uncompressed — explicit flag
-              # prevents GHCR from negotiating zstd:chunked regardless of podman defaults.
-              sudo podman push --compression-format=zstd \
-                "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}:${tag}" && break
-              echo "Push attempt $i failed for tag ${tag}, retrying..."
-              sleep 5
-            done
-          done
 
   # ── aarch64 native build ──────────────────────────────────────────────────
   # Mirrors the x86_64 build job. ARM failures do not fail the workflow or

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,279 @@
+name: Publish Bluefin dakota
+
+on:
+  workflow_run:
+    workflows: ["Build Bluefin dakota"]
+    types: [completed]
+    # NO branches: filter — merge_group runs on gh-readonly-queue/main/... refs, not 'main'.
+    # Job guard below handles PR exclusion.
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: dakota
+  IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+
+# Queue concurrent publishes — never cancel. Prevents :latest race and SBOM/signature conflicts.
+concurrency:
+  group: publish-main
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    # NOTE for projectbluefin/dakota production: change runner to blacksmith-8vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      packages: write
+      id-token: write          # cosign OIDC + actions/attest
+      attestations: write      # actions/attest
+      artifact-metadata: write # SLSA — requires org-level token; personal forks show startup_failure (expected)
+    # Fire on: schedule builds, merge_group builds, workflow_dispatch from main.
+    # Block on: pull_request builds; workflow_dispatch from non-main branches.
+    # Note: merge_group head_branch is 'gh-readonly-queue/main/pr-NNN-<sha>', NOT 'main'.
+    # Must use startsWith to match queue branches targeting main.
+    if: >-
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event != 'pull_request' &&
+       (github.event.workflow_run.head_branch == 'main' ||
+        startsWith(github.event.workflow_run.head_branch, 'gh-readonly-queue/main/')))
+    steps:
+      - name: Resolve SHA and trigger event
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "BUILD_SHA=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_ENV"
+            echo "TRIGGER_EVENT=${{ github.event.workflow_run.event }}" >> "$GITHUB_ENV"
+          else
+            echo "BUILD_SHA=${{ github.sha }}" >> "$GITHUB_ENV"
+            echo "TRIGGER_EVENT=workflow_dispatch" >> "$GITHUB_ENV"
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.BUILD_SHA }}
+
+      - name: Setup Just
+        uses: taiki-e/install-action@just
+
+      - name: Mount BTRFS for podman storage
+        id: container-storage
+        uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6
+        continue-on-error: true
+        with:
+          target-dir: /var/lib/containers
+          mount-opts: compress-force=zstd:2
+          loopback-free: '1'
+
+      - name: Remove unwanted software
+        uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
+
+      - name: Capture build timestamp
+        id: timestamp
+        run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
+      - name: Generate BuildStream CI config
+        env:
+          CASD_CLIENT_CERT: ${{ vars.CASD_CLIENT_CERT }}
+          CASD_CLIENT_KEY: ${{ secrets.CASD_CLIENT_KEY }}
+        run: |
+          mkdir -p logs
+
+          echo "$CASD_CLIENT_CERT" > client.crt
+          echo "$CASD_CLIENT_KEY" > client.key
+          cat > buildstream-ci.conf <<'BSTCONF'
+          scheduler:
+            on-error: continue
+            fetchers: 32
+            builders: 4
+            network-retries: 3
+
+          logging:
+            message-format: '[%{wallclock}][%{elapsed}][%{key}][%{element}] %{action} %{message}'
+            error-lines: 80
+
+          cachedir: /root/.cache/buildstream
+          logdir: /src/logs
+
+          build:
+            retry-failed: True
+
+          BSTCONF
+
+          if [[ -n "$CASD_CLIENT_CERT" ]] && [[ -n "$CASD_CLIENT_KEY" ]]; then
+            cat >> buildstream-ci.conf <<'BSTCONFPUSH'
+          artifacts:
+            servers:
+            - url: https://cache.projectbluefin.io:11002
+              push: false
+              connection-config:
+                keepalive-time: 60
+                retry-limit: 5
+                retry-delay: 1000
+                request-timeout: 180
+              auth:
+                client-key: /src/client.key
+                client-cert: /src/client.crt
+
+          source-caches:
+            servers:
+            - url: https://cache.projectbluefin.io:11002
+              push: false
+              connection-config:
+                keepalive-time: 60
+                retry-limit: 5
+                retry-delay: 1000
+                request-timeout: 180
+              auth:
+                client-key: /src/client.key
+                client-cert: /src/client.crt
+
+          cache:
+            storage-service:
+              url: https://cache.projectbluefin.io:11002
+              connection-config:
+                keepalive-time: 60
+                retry-limit: 5
+                retry-delay: 1000
+                request-timeout: 180
+              auth:
+                client-key: /src/client.key
+                client-cert: /src/client.crt
+
+          remote-execution:
+            execution-service:
+              url: https://cache.projectbluefin.io:11002
+              connection-config:
+                keepalive-time: 60
+                retry-limit: 5
+                retry-delay: 1000
+                request-timeout: 180
+              auth:
+                client-key: /src/client.key
+                client-cert: /src/client.crt
+            action-cache-service:
+              url: https://cache.projectbluefin.io:11002
+              connection-config:
+                keepalive-time: 60
+                retry-limit: 5
+                retry-delay: 1000
+                request-timeout: 180
+              auth:
+                client-key: /src/client.key
+                client-cert: /src/client.crt
+          BSTCONFPUSH
+          fi
+
+          echo "=== BuildStream CI config ==="
+          cat buildstream-ci.conf
+
+      - name: Export OCI image from BuildStream
+        id: export
+        env:
+          BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf
+          BUILD_IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          OCI_IMAGE_CREATED: ${{ steps.timestamp.outputs.created }}
+          OCI_IMAGE_REVISION: ${{ env.BUILD_SHA }}
+          OCI_IMAGE_VERSION: latest
+        run: |
+          just export
+          echo "image_ref=${{ env.IMAGE_NAME }}:latest" >> "$GITHUB_OUTPUT"
+
+      - name: Validate with bootc container lint
+        run: just lint
+
+      - name: Login to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            sudo podman login ghcr.io --username ${{ github.actor }} --password-stdin
+
+      - name: Push :$BUILD_SHA and capture digest
+        id: push-sha
+        run: |
+          sudo podman tag "localhost/${{ steps.export.outputs.image_ref }}" \
+            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BUILD_SHA }}"
+          rm -f /tmp/digest.txt
+          for i in 1 2 3; do
+            sudo podman push --compression-format=zstd \
+              --digestfile /tmp/digest.txt \
+              "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BUILD_SHA }}" && break
+            if [ "$i" -eq 3 ]; then
+              echo "Push failed for :${{ env.BUILD_SHA }} after ${i} attempts" >&2
+              exit 1
+            fi
+            echo "Push attempt $i failed, retrying..."
+            sleep 5
+          done
+          echo "digest=$(cat /tmp/digest.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Push :latest
+        # Only on nightly schedule or manual dispatch — never on merge_group re-runs.
+        # TRIGGER_EVENT is 'schedule' for nightly, 'workflow_dispatch' for manual.
+        # Checking TRIGGER_EVENT (not github.event_name) because inside publish.yml,
+        # github.event_name is always 'workflow_run' — checking event_name == 'schedule' is always false.
+        if: env.TRIGGER_EVENT == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: |
+          sudo podman tag "localhost/${{ steps.export.outputs.image_ref }}" \
+            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          for i in 1 2 3; do
+            sudo podman push --compression-format=zstd \
+              "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest" && break
+            if [ "$i" -eq 3 ]; then
+              echo "Push failed for :latest after ${i} attempts" >&2
+              exit 1
+            fi
+            echo "Push attempt $i failed, retrying..."
+            sleep 5
+          done
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.9.0
+
+      - name: Install oras
+        uses: oras-project/setup-oras@v1
+
+      - name: Generate SBOM
+        env:
+          BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf
+        run: just sbom
+
+      - name: Sign image
+        env:
+          DIGEST: ${{ steps.push-sha.outputs.digest }}
+        run: |
+          cosign sign -y \
+            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"
+
+      - name: Attach SBOM as OCI referrer
+        id: sbom-attach
+        env:
+          DIGEST: ${{ steps.push-sha.outputs.digest }}
+        run: |
+          SBOM_DIGEST=$(oras attach \
+            --artifact-type application/vnd.spdx+json \
+            --format go-template='{{.Digest}}' \
+            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}" \
+            dakota.spdx.json:application/vnd.spdx+json)
+          echo "sbom_digest=${SBOM_DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign SBOM referrer
+        env:
+          SBOM_DIGEST: ${{ steps.sbom-attach.outputs.sbom_digest }}
+        run: |
+          cosign sign -y \
+            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${SBOM_DIGEST}"
+
+      - name: SLSA attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push-sha.outputs.digest }}
+
+      - name: Upload publish logs
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: publish-logs
+          path: logs/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/Justfile
+++ b/Justfile
@@ -32,6 +32,11 @@ bst *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p "${HOME}/.cache/buildstream"
+    # Persist generated source plugin state (snakeoil secureboot keys from
+    # gnome-build-meta's generated.py plugin). Without this mount the keys
+    # regenerate on every container invocation, printing to stdout and
+    # breaking any tool (e.g. buildstream-sbom) that pipes bst show output.
+    mkdir -p "${HOME}/.config/buildstream-generate"
     # BST_FLAGS env var allows CI to inject --no-interactive, --config, etc.
     # Word-splitting is intentional here (flags are space-separated).
     # shellcheck disable=SC2086
@@ -41,6 +46,7 @@ bst *ARGS:
         --network=host \
         -v "{{justfile_directory()}}:/src:rw" \
         -v "${HOME}/.cache/buildstream:/root/.cache/buildstream:rw" \
+        -v "${HOME}/.config/buildstream-generate:/root/.config/buildstream-generate:rw" \
         -w /src \
         "{{bst2_image}}" \
         bash -c 'bst --colors "$@"' -- ${BST_FLAGS:-} {{ARGS}}
@@ -651,6 +657,129 @@ inspect: _ensure-bcvk
     fi
 
     $SUDO_CMD bcvk images list
+
+# ── SBOM ─────────────────────────────────────────────────────────────
+# Generate a BST-native SBOM (SPDX 2.3) using buildstream-sbom.
+# Reads directly from BST element metadata — captures all ~1100+ elements
+# including GNOME/GTK/systemd from junctions (unlike syft which can only
+# fingerprint binaries in the rootfs and misses source-built packages).
+# Does NOT require a pre-built image — just the BST project files.
+# Output: dakota.spdx.json in repo root.
+#
+# Local testing:
+#   just sbom                                # generate SBOM
+#   jq '.spdxVersion' dakota.spdx.json      # verify SPDX-2.3
+#   jq '.packages | length' dakota.spdx.json  # expect ~1100+
+#   jq -r '.packages[].name' dakota.spdx.json | grep -i "gnome\|gtk\|systemd"
+[group('test')]
+sbom:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Persist the snakeoil key cache so bst show runs silently (see bst recipe).
+    mkdir -p "${HOME}/.config/buildstream-generate"
+    GIT_SHA="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+    # Prime the generated source plugin cache (snakeoil secureboot keys).
+    # The gnome-build-meta generated.py plugin runs `make` on first use and
+    # caches the result. If the cache is cold, the make output pollutes stdout
+    # and breaks buildstream-sbom's bst show pipe. Priming here ensures the
+    # cache is warm before buildstream-sbom runs.
+    echo "==> Priming BST generated source cache..."
+    podman run --rm \
+        --privileged \
+        --device /dev/fuse \
+        --network=host \
+        -v "{{justfile_directory()}}:/src:rw" \
+        -v "${HOME}/.cache/buildstream:/root/.cache/buildstream:rw" \
+        -v "${HOME}/.config/buildstream-generate:/root/.config/buildstream-generate:rw" \
+        -w /src \
+        "{{bst2_image}}" \
+        bash -c 'bst --no-colors show --deps none --format "%{name}" oci/bluefin.bst' \
+        2>/dev/null || true
+
+    echo "==> Generating BST-native SBOM with buildstream-sbom..."
+    # Pinned to commit 0706fec3 (2026-04-01) — latest main, includes element
+    # names in SPDX output (issue #9 fix). Switch to a versioned PyPI release
+    # once the project publishes one.
+    podman run --rm \
+        --privileged \
+        --device /dev/fuse \
+        --network=host \
+        -v "{{justfile_directory()}}:/src:rw" \
+        -v "${HOME}/.cache/buildstream:/root/.cache/buildstream:rw" \
+        -v "${HOME}/.config/buildstream-generate:/root/.config/buildstream-generate:rw" \
+        -w /src \
+        "{{bst2_image}}" \
+        bash -c "
+            for attempt in 1 2 3; do
+                pip install --quiet \
+                    git+https://gitlab.com/BuildStream/buildstream-sbom.git@0706fec3bedf6f73bd9d2fed32c2aed585feef8d \
+                    && break
+                echo \"buildstream-sbom install failed (attempt \${attempt}/3); retrying in 5s...\"
+                [ \"\${attempt}\" -lt 3 ] && sleep 5
+            done
+            buildstream-sbom oci/bluefin.bst \
+                --spdx-name dakota \
+                --spdx-namespace https://github.com/projectbluefin/dakota/sbom/${GIT_SHA} \
+                --spdx-creator 'Tool: buildstream-sbom' \
+                --spdx-creator 'Organization: projectbluefin' \
+                --deps all \
+                --output /src/dakota.spdx.json
+        "
+    echo ""
+    echo "==> SBOM written to: $(pwd)/dakota.spdx.json"
+    du -sh dakota.spdx.json
+    echo ""
+    echo "==> Package count:"
+    jq '.packages | length' dakota.spdx.json
+
+# ── Verify supply-chain signatures ───────────────────────────────────
+# Verify cosign signature + SBOM referrer + SLSA attestation for a
+# pushed image. Requires: cosign, oras, gh CLI.
+# Usage: just verify                           (uses IMAGE_REGISTRY/IMAGE_NAME:latest)
+#        just verify ghcr.io/projectbluefin/dakota:latest
+[group('test')]
+verify image_ref="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    IMAGE="{{image_ref}}"
+    [ -z "$IMAGE" ] && IMAGE="ghcr.io/projectbluefin/dakota:latest"
+
+    echo "==> Verifying supply-chain security for: ${IMAGE}"
+    echo ""
+    STATUS=0
+
+    # 1. Cosign keyless signature
+    echo "── Cosign signature (keyless / Sigstore OIDC) ──"
+    if ! command -v cosign &>/dev/null; then
+        echo "SKIP: cosign not installed"
+    else
+        cosign verify \
+            --certificate-identity \
+                'https://github.com/projectbluefin/dakota/.github/workflows/publish.yml@refs/heads/main' \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "${IMAGE}" && echo "PASS: signature valid" || { echo "FAIL: signature check failed"; STATUS=1; }
+    fi
+    echo ""
+
+    # 2. SBOM referrer
+    echo "── SBOM OCI referrer ──"
+    if ! command -v oras &>/dev/null; then
+        echo "SKIP: oras not installed"
+    else
+        oras discover "${IMAGE}" && echo "PASS: referrers listed above" || { echo "FAIL: oras discover failed"; STATUS=1; }
+    fi
+    echo ""
+
+    # 3. SLSA attestation
+    echo "── SLSA build provenance (actions/attest) ──"
+    if ! command -v gh &>/dev/null; then
+        echo "SKIP: gh not installed"
+    else
+        gh attestation verify "oci://${IMAGE}" \
+            --repo projectbluefin/dakota && echo "PASS: attestation valid" || { echo "FAIL: attestation check failed"; STATUS=1; }
+    fi
+    exit "${STATUS}"
 
 # ── Lint ─────────────────────────────────────────────────────────────
 [group('test')]


### PR DESCRIPTION
Let's use blacksmith for the slow IO chunkah part. 



Split the monolithic build.yml into two focused workflows:

build.yml — BST build + log upload only (all triggers including PRs).
  Runs on every PR, merge_group, schedule, and workflow_dispatch.
  No export, no lint, no GHCR push. Fast feedback for developers.

publish.yml — export + rechunk + sign + SBOM (main-only via workflow_run).
  Triggered by workflow_run on build.yml success, non-PR events only.
  Standard runner on castrojo fork; blacksmith-8vcpu-ubuntu-2404 on upstream.

Key design decisions:
- workflow_run has NO branches filter: merge_group runs use gh-readonly-queue/main/... refs which do not match 'branches: [main]'
- :latest only pushed on schedule/workflow_dispatch (TRIGGER_EVENT env var), never on merge_group re-runs — prevents backward :latest roll
- Digest captured via --digestfile (not podman inspect on local tag)
- cosign keyless signing + ORAS SBOM referrer + SLSA attestation
- Supersedes PR #187 (sbom/verify Justfile additions included here)

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Published images include cryptographic signatures, SBOMs, and SLSA provenance attestations.
  * Added a local verification command to check image signatures, SBOM referrers, and provenance.
  * Added an SBOM generation command for the release image.

* **Chores**
  * Separated build and publish into distinct workflows with serialized publish runs and stricter publish controls.
  * Build workflow now runs with reduced permissions and proceeds directly to uploading build logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->