### PR TITLE
fix(ci): move Blacksmith to publish only, schedule on standard runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     # Variant matrix: the default Bluefin image and the NVIDIA variant build
     # in parallel. They share the BST artifact cache via cache.projectbluefin.io,
     # so whichever runs first warms the closure for the other. NVIDIA is

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,9 @@ concurrency:
 
 jobs:
   publish:
-    runs-on: ubuntu-24.04
-    # NOTE for projectbluefin/dakota production: change runner to blacksmith-8vcpu-ubuntu-2404
+    # Scheduled (overnight) runs use standard runners — slow is fine, we're asleep.
+    # merge_group and workflow_dispatch runs use Blacksmith for the fast I/O (chunkah + SBOM).
+    runs-on: ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'schedule') && 'ubuntu-24.04' || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

Fixes the runner assignments that got swapped in #377.

**Before:**
- `build.yml` (BST build — fires on every PR) → `blacksmith-4vcpu-ubuntu-2404`
- `publish.yml` (chunkah + SBOM — main only) → `ubuntu-24.04`

**After:**
- `build.yml` → `ubuntu-24.04` (BST delegates all work to `cache.projectbluefin.io` RBE; standard runner is fine)
- `publish.yml` → `blacksmith-4vcpu-ubuntu-2404` for merge_group/workflow_dispatch, `ubuntu-24.04` for schedule (overnight runs — slow is OK)

## Effect on Blacksmith usage

| Event | Before | After |
|---|---|---|
| PR push | 2 Blacksmith jobs | 0 Blacksmith jobs |
| schedule (nightly) | 2 Blacksmith jobs | 0 Blacksmith jobs |
| merge_group | 2 Blacksmith jobs | 1 Blacksmith job |
| workflow_dispatch | 2 Blacksmith jobs | 1 Blacksmith job |

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure configuration for improved workflow reliability and performance optimization across different deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->