### PR TITLE
fix(ci): use --merge instead of --squash for merge queue compatibility

### DIFF
--- a/.github/workflows/track-bst-sources.yml
+++ b/.github/workflows/track-bst-sources.yml
@@ -259,7 +259,9 @@ jobs:
 
           if [ "${{ matrix.group }}" = "auto-merge" ]; then
             echo "Enabling auto-merge..."
-            gh pr merge "$PR_URL" --auto --squash || echo "::warning::Could not enable auto-merge"
+            # Use --merge to match the merge queue's required merge_method=MERGE.
+            # --squash conflicts with the merge queue ruleset and prevents auto-queuing.
+            gh pr merge "$PR_URL" --auto --merge || echo "::warning::Could not enable auto-merge"
           fi
 
   track-tarballs:


### PR DESCRIPTION
The branch ruleset configures merge_method=MERGE for the merge queue. Using --squash causes a method mismatch that prevents PRs from being automatically queued even when all conditions (CI pass + approval) are met.

Fixes: auto-track PRs stalling in CLEAN/APPROVED state without entering queue.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request merge workflow configuration to align with merge queue requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->