### PR TITLE
fix(ci): per-SHA concurrency for merge_queue publishes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,15 @@ env:
   IMAGE_NAME: dakota
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
-# Queue concurrent publishes — never cancel. Prevents :latest race and SBOM/signature conflicts.
+# Merge queue publishes get a per-SHA concurrency group — they only write :$BUILD_SHA
+# (no conflict possible). Everything else (schedule, dispatch, manual build dispatch)
+# stays on publish-main to prevent :latest races. Default-to-main ensures new triggers
+# are safe without explicit opt-in.
 concurrency:
-  group: publish-main
+  group: >-
+    ${{ github.event_name == 'workflow_run' && github.event.workflow_run.event == 'merge_group'
+        && format('publish-{0}', github.event.workflow_run.head_sha)
+        || 'publish-main' }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
When a long merge queue lands N PRs in rapid succession, N publish runs fire via workflow_run. They all share publish-main with cancel-in-progress: false, so GitHub can only hold one pending run — each new arrival cancels the previous pending run. Jobs 2 through N-1 are launched and immediately cancelled in succession.

Root cause: publish-main serializes ALL publishes, but only schedule and dispatch runs need serialization (they push :latest, which races). Merge queue publishes only push :BUILD_SHA — each SHA is unique, no conflicts.

Fix: merge_group triggers get publish-{sha} concurrency (each runs independently). Everything else stays on publish-main (protects :latest). Expression defaults to publish-main so new triggers are safe by default.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved publishing workflow concurrency handling to prevent conflicts during merge queue operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->