### PR TITLE
ci: add docker login so cosign can authenticate to GHCR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -190,9 +190,14 @@ jobs:
         run: just lint
 
       - name: Login to GHCR
+        env:
+          GH_ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | \
-            sudo podman login ghcr.io --username ${{ github.actor }} --password-stdin
+          echo "$GH_TOKEN" | sudo podman login ghcr.io --username "$GH_ACTOR" --password-stdin
+          mkdir -p ~/.docker
+          echo "$GH_TOKEN" | podman login ghcr.io --username "$GH_ACTOR" --password-stdin \
+            --compat-auth-file ~/.docker/config.json
 
       - name: Push :$BUILD_SHA and capture digest
         id: push-sha


### PR DESCRIPTION
cosign runs as the non-root runner user and looks for credentials in ~/.docker/config.json. The existing sudo podman login stores credentials as root, which cosign cannot access. Adding docker login (without sudo) provides cosign the auth it needs to push signatures.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment pipeline configuration to improve system reliability and deployment security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->