### PR TITLE
ci: move export/chunkify/sbom to build, publish loads artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
       # Both steps must run before any podman call (BST uses rootful podman
       # to pull bst2; storage backend must be stable before first use).
       - name: Remove unwanted software
-        uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
+        uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9
 
       - name: Mount BTRFS for podman storage
         id: container-storage
@@ -319,7 +319,7 @@ jobs:
           loopback-free: '1'
 
       - name: Remove unwanted software
-        uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
+        uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9
 
       - name: Setup Just
         uses: taiki-e/install-action@just

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,21 @@ jobs:
         id: timestamp
         run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
 
+      # ── Disk and storage setup ────────────────────────────────────────
+      # Both steps must run before any podman call (BST uses rootful podman
+      # to pull bst2; storage backend must be stable before first use).
+      - name: Remove unwanted software
+        uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
+
+      - name: Mount BTRFS for podman storage
+        id: container-storage
+        uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6
+        continue-on-error: true
+        with:
+          target-dir: /var/lib/containers
+          mount-opts: compress-force=zstd:2
+          loopback-free: '1'
+
       # ── Generate CI-specific BuildStream config ───────────────────────
       # Tuned per gnome-build-meta CI patterns:
       # - on-error: continue  -> find ALL failures, don't stop at first
@@ -213,12 +228,68 @@ jobs:
 
       - name: Upload build logs
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: buildstream-logs-x86_64-${{ matrix.variant }}
           path: logs/
           retention-days: 7
           if-no-files-found: ignore
+
+      # ── Export, lint, SBOM, and artifact upload ───────────────────────
+      # Only for the default variant on publishable events (merge_group,
+      # schedule, workflow_dispatch). PRs skip this entirely — they only
+      # validate the BST build succeeds, not produce a publishable image.
+      # The nvidia variant has no separate publish path; skip it here.
+      # BST artifacts are in the local cache (just built above), so
+      # `bst artifact checkout` is a fast local read — no CAS download.
+      # chunkah runs inside `just export` (see Justfile:154); the result
+      # is 120 plain-zstd layers ready for `podman push --compression-format=zstd`.
+
+      - name: Export OCI image from BuildStream
+        if: github.event_name != 'pull_request' && matrix.variant == 'default'
+        id: export
+        env:
+          BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf
+          BUILD_IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          OCI_IMAGE_CREATED: ${{ steps.timestamp.outputs.created }}
+          OCI_IMAGE_REVISION: ${{ github.sha }}
+          OCI_IMAGE_VERSION: latest
+        run: |
+          just export
+          echo "image_ref=${{ env.IMAGE_NAME }}:latest" >> "$GITHUB_OUTPUT"
+
+      - name: Validate with bootc container lint
+        if: github.event_name != 'pull_request' && matrix.variant == 'default'
+        run: just lint
+
+      - name: Generate SBOM
+        if: github.event_name != 'pull_request' && matrix.variant == 'default'
+        env:
+          BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf
+        run: just sbom
+
+      # Save OCI archive to the BTRFS volume to keep rootfs pressure low.
+      # podman save produces an uncompressed OCI archive; plain podman push
+      # (--compression-format=zstd) handles compression at push time.
+      # skopeo is intentionally avoided — see memory: plain podman push is
+      # the correct tool for post-chunkah images.
+      - name: Save OCI archive
+        if: github.event_name != 'pull_request' && matrix.variant == 'default'
+        run: |
+          sudo podman save --format oci-archive \
+            -o /var/lib/containers/dakota.oci.tar \
+            "${{ env.IMAGE_NAME }}:latest"
+
+      - name: Upload OCI and SBOM artifacts
+        if: github.event_name != 'pull_request' && matrix.variant == 'default'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dakota-oci-${{ github.sha }}
+          path: |
+            /var/lib/containers/dakota.oci.tar
+            dakota.spdx.json
+          retention-days: 3
+          if-no-files-found: error
 
   # ── aarch64 native build ──────────────────────────────────────────────────
   # Mirrors the x86_64 build job. ARM failures do not fail the workflow or

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,7 +94,7 @@ jobs:
         # Uses cross-run download — requires actions: read permission.
         # Fails immediately if artifact doesn't exist (missing = build state is bad;
         # do not retry, re-run build.yml first then re-dispatch publish).
-        uses: actions/download-artifact@fa0a91b85d4f404e444306234dcc6d4aab00b1c8 # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dakota-oci-${{ env.BUILD_SHA }}
           run-id: ${{ env.BUILD_RUN_ID }}
@@ -159,10 +159,10 @@ jobs:
           done
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3.9.0
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
 
       - name: Install oras
-        uses: oras-project/setup-oras@v1
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
 
       - name: Sign image
         env:
@@ -191,7 +191,7 @@ jobs:
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${SBOM_DIGEST}"
 
       - name: SLSA attestation
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push-sha.outputs.digest }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,15 @@ on:
     # NO branches: filter — merge_group runs on gh-readonly-queue/main/... refs, not 'main'.
     # Job guard below handles PR exclusion.
   workflow_dispatch:
+    inputs:
+      build_run_id:
+        description: 'Build workflow run ID (leave empty to auto-detect from HEAD SHA)'
+        required: false
+        type: string
+      build_sha:
+        description: 'Git SHA to publish (defaults to HEAD of main if empty)'
+        required: false
+        type: string
 
 env:
   IMAGE_NAME: dakota
@@ -26,7 +35,8 @@ concurrency:
 jobs:
   publish:
     # Scheduled (overnight) runs use standard runners — slow is fine, we're asleep.
-    # merge_group and workflow_dispatch runs use Blacksmith for the fast I/O (chunkah + SBOM).
+    # merge_group and workflow_dispatch runs use Blacksmith for fast GHCR push throughput.
+    # BST, chunkah, and SBOM have moved to build.yml; publish now only loads+pushes+signs.
     runs-on: ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'schedule') && 'ubuntu-24.04' || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
@@ -34,6 +44,7 @@ jobs:
       id-token: write          # cosign OIDC + actions/attest
       attestations: write      # actions/attest
       artifact-metadata: write # SLSA — requires org-level token; personal forks show startup_failure (expected)
+      actions: read            # cross-run artifact download (download-artifact with run-id)
     # Fire on: schedule builds, merge_group builds, workflow_dispatch from main.
     # Block on: pull_request builds; workflow_dispatch from non-main branches.
     # Note: merge_group head_branch is 'gh-readonly-queue/main/pr-NNN-<sha>', NOT 'main'.
@@ -48,146 +59,55 @@ jobs:
       - name: Resolve SHA and trigger event
         run: |
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            # Triggered by a completed build run — run ID is known directly.
             echo "BUILD_SHA=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_ENV"
+            echo "BUILD_RUN_ID=${{ github.event.workflow_run.id }}" >> "$GITHUB_ENV"
             echo "TRIGGER_EVENT=${{ github.event.workflow_run.event }}" >> "$GITHUB_ENV"
-          else
-            echo "BUILD_SHA=${{ github.sha }}" >> "$GITHUB_ENV"
+          elif [ -n "${{ inputs.build_run_id }}" ]; then
+            # Manual dispatch with explicit run ID — derive SHA from the run.
+            RUN_SHA=$(gh api \
+              "repos/${{ github.repository }}/actions/runs/${{ inputs.build_run_id }}" \
+              --jq '.head_sha')
+            echo "BUILD_SHA=${RUN_SHA}" >> "$GITHUB_ENV"
+            echo "BUILD_RUN_ID=${{ inputs.build_run_id }}" >> "$GITHUB_ENV"
             echo "TRIGGER_EVENT=workflow_dispatch" >> "$GITHUB_ENV"
+          else
+            # Manual dispatch without run ID — look up latest successful build for SHA.
+            # If build is still running, this returns null and we fail fast with a clear error.
+            TARGET_SHA="${{ inputs.build_sha || github.sha }}"
+            echo "BUILD_SHA=${TARGET_SHA}" >> "$GITHUB_ENV"
+            echo "TRIGGER_EVENT=workflow_dispatch" >> "$GITHUB_ENV"
+            RUN_ID=$(gh api \
+              "repos/${{ github.repository }}/actions/workflows/build.yml/runs?head_sha=${TARGET_SHA}&status=success&per_page=1" \
+              --jq '.workflow_runs[0].id')
+            if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+              echo "::error::No successful build run found for SHA ${TARGET_SHA}." \
+                   "If the build is still running, wait for it to finish and re-dispatch," \
+                   "or provide build_run_id explicitly." >&2
+              exit 1
+            fi
+            echo "BUILD_RUN_ID=${RUN_ID}" >> "$GITHUB_ENV"
           fi
 
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Download OCI and SBOM artifacts
+        # Artifact was uploaded by build.yml after export+chunkify+sbom.
+        # Uses cross-run download — requires actions: read permission.
+        # Fails immediately if artifact doesn't exist (missing = build state is bad;
+        # do not retry, re-run build.yml first then re-dispatch publish).
+        uses: actions/download-artifact@fa0a91b85d4f404e444306234dcc6d4aab00b1c8 # v4.1.8
         with:
-          ref: ${{ env.BUILD_SHA }}
+          name: dakota-oci-${{ env.BUILD_SHA }}
+          run-id: ${{ env.BUILD_RUN_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: /tmp/artifacts
 
-      - name: Setup Just
-        uses: taiki-e/install-action@just
-
-      - name: Mount BTRFS for podman storage
-        id: container-storage
-        uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6
-        continue-on-error: true
-        with:
-          target-dir: /var/lib/containers
-          mount-opts: compress-force=zstd:2
-          loopback-free: '1'
-
-      - name: Remove unwanted software
-        uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
-
-      - name: Capture build timestamp
-        id: timestamp
-        run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
-
-      - name: Generate BuildStream CI config
-        env:
-          CASD_CLIENT_CERT: ${{ vars.CASD_CLIENT_CERT }}
-          CASD_CLIENT_KEY: ${{ secrets.CASD_CLIENT_KEY }}
+      - name: Load OCI archive into podman
+        id: load
         run: |
-          mkdir -p logs
-
-          echo "$CASD_CLIENT_CERT" > client.crt
-          echo "$CASD_CLIENT_KEY" > client.key
-          cat > buildstream-ci.conf <<'BSTCONF'
-          scheduler:
-            on-error: continue
-            fetchers: 32
-            builders: 4
-            network-retries: 3
-
-          logging:
-            message-format: '[%{wallclock}][%{elapsed}][%{key}][%{element}] %{action} %{message}'
-            error-lines: 80
-
-          cachedir: /root/.cache/buildstream
-          logdir: /src/logs
-
-          build:
-            retry-failed: True
-
-          BSTCONF
-
-          if [[ -n "$CASD_CLIENT_CERT" ]] && [[ -n "$CASD_CLIENT_KEY" ]]; then
-            cat >> buildstream-ci.conf <<'BSTCONFPUSH'
-          artifacts:
-            servers:
-            - url: https://cache.projectbluefin.io:11002
-              push: false
-              connection-config:
-                keepalive-time: 60
-                retry-limit: 5
-                retry-delay: 1000
-                request-timeout: 180
-              auth:
-                client-key: /src/client.key
-                client-cert: /src/client.crt
-
-          source-caches:
-            servers:
-            - url: https://cache.projectbluefin.io:11002
-              push: false
-              connection-config:
-                keepalive-time: 60
-                retry-limit: 5
-                retry-delay: 1000
-                request-timeout: 180
-              auth:
-                client-key: /src/client.key
-                client-cert: /src/client.crt
-
-          cache:
-            storage-service:
-              url: https://cache.projectbluefin.io:11002
-              connection-config:
-                keepalive-time: 60
-                retry-limit: 5
-                retry-delay: 1000
-                request-timeout: 180
-              auth:
-                client-key: /src/client.key
-                client-cert: /src/client.crt
-
-          remote-execution:
-            execution-service:
-              url: https://cache.projectbluefin.io:11002
-              connection-config:
-                keepalive-time: 60
-                retry-limit: 5
-                retry-delay: 1000
-                request-timeout: 180
-              auth:
-                client-key: /src/client.key
-                client-cert: /src/client.crt
-            action-cache-service:
-              url: https://cache.projectbluefin.io:11002
-              connection-config:
-                keepalive-time: 60
-                retry-limit: 5
-                retry-delay: 1000
-                request-timeout: 180
-              auth:
-                client-key: /src/client.key
-                client-cert: /src/client.crt
-          BSTCONFPUSH
-          fi
-
-          echo "=== BuildStream CI config ==="
-          cat buildstream-ci.conf
-
-      - name: Export OCI image from BuildStream
-        id: export
-        env:
-          BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf
-          BUILD_IMAGE_NAME: ${{ env.IMAGE_NAME }}
-          OCI_IMAGE_CREATED: ${{ steps.timestamp.outputs.created }}
-          OCI_IMAGE_REVISION: ${{ env.BUILD_SHA }}
-          OCI_IMAGE_VERSION: latest
-        run: |
-          just export
+          sudo podman load -i /tmp/artifacts/dakota.oci.tar
+          # Copy SBOM to workspace for oras attach (expects relative path)
+          cp /tmp/artifacts/dakota.spdx.json ./dakota.spdx.json
           echo "image_ref=${{ env.IMAGE_NAME }}:latest" >> "$GITHUB_OUTPUT"
-
-      - name: Validate with bootc container lint
-        run: just lint
 
       - name: Login to GHCR
         env:
@@ -202,7 +122,7 @@ jobs:
       - name: Push :$BUILD_SHA and capture digest
         id: push-sha
         run: |
-          sudo podman tag "localhost/${{ steps.export.outputs.image_ref }}" \
+          sudo podman tag "localhost/${{ steps.load.outputs.image_ref }}" \
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BUILD_SHA }}"
           rm -f /tmp/digest.txt
           for i in 1 2 3; do
@@ -225,7 +145,7 @@ jobs:
         # github.event_name is always 'workflow_run' — checking event_name == 'schedule' is always false.
         if: env.TRIGGER_EVENT == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
-          sudo podman tag "localhost/${{ steps.export.outputs.image_ref }}" \
+          sudo podman tag "localhost/${{ steps.load.outputs.image_ref }}" \
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
           for i in 1 2 3; do
             sudo podman push --compression-format=zstd \
@@ -243,11 +163,6 @@ jobs:
 
       - name: Install oras
         uses: oras-project/setup-oras@v1
-
-      - name: Generate SBOM
-        env:
-          BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf
-        run: just sbom
 
       - name: Sign image
         env:
@@ -283,7 +198,7 @@ jobs:
 
       - name: Upload publish logs
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: publish-logs
           path: logs/


### PR DESCRIPTION
Build now owns the full OCI pipeline while BST artifacts are hot in local cache: export (includes chunkah rechunking into 120 plain-zstd layers), bootc container lint, SBOM generation, and podman save to a BTRFS-backed path. The post-chunkify OCI archive is uploaded as a GitHub artifact (3-day retention, default variant only, non-PR events).

Publish is stripped to: download artifact, podman load, push, sign. No BST, no CAS download, no chunkify in publish. Blacksmith is still used for non-schedule runs for GHCR push throughput.

Key correctness constraints honoured:
- container-storage-action + remove-unwanted-software run before any podman call in build (BST uses rootful podman for bst2 image pull)
- chunkify runs exactly once (inside just export) — no double-rechunk
- plain podman push --compression-format=zstd (not skopeo, not zstd:chunked)
- actions: read permission added for cross-run artifact download
- workflow_dispatch gains build_run_id/build_sha inputs with null guard for the auto-detect path (fail fast, not silent hang)
- artifact upload gated to matrix.variant == 'default' only
- upload-artifact pin updated to v7.0.1 (043fb46d)

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  - Optimized CI build pipeline with improved storage preparation and artifact handling.
  - Pinned and updated CI actions to more stable versions.
* **New Features**
  - Publish workflow accepts optional manual inputs for targeting specific builds.
  - Build artifacts now include an OCI image export and SBOM that are uploaded and reused for publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->