### PR TITLE
ci: pull BST artifact to local cache before export

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,10 +240,19 @@ jobs:
       # schedule, workflow_dispatch). PRs skip this entirely — they only
       # validate the BST build succeeds, not produce a publishable image.
       # The nvidia variant has no separate publish path; skip it here.
-      # BST artifacts are in the local cache (just built above), so
-      # `bst artifact checkout` is a fast local read — no CAS download.
+      #
+      # Remote execution note: `bst build` pushes artifacts to remote CAS
+      # but does NOT stage them locally. `bst artifact checkout` (inside
+      # `just export`) needs local blobs. We explicitly pull first to
+      # transfer the artifact from remote CAS → local cache before checkout.
       # chunkah runs inside `just export` (see Justfile:154); the result
       # is 120 plain-zstd layers ready for `podman push --compression-format=zstd`.
+
+      - name: Pull OCI artifact from CAS to local cache
+        if: github.event_name != 'pull_request' && matrix.variant == 'default'
+        env:
+          BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf
+        run: just bst artifact pull oci/bluefin.bst
 
       - name: Export OCI image from BuildStream
         if: github.event_name != 'pull_request' && matrix.variant == 'default'


### PR DESCRIPTION
## Problem

After `bst build` with remote execution, artifacts are stored in remote CAS but the local runner cache only has metadata. When `just export` calls `bst artifact checkout`, BST sees the artifact key locally, skips the pull stage ("Pull SKIPPED"), then fails staging with:

```
Error while staging dependencies into a sandbox: 'No artifacts to stage'
No artifacts have been cached yet for that element
```

This caused the first build.yml workflow_dispatch run to fail at the Export step.

## Fix

Add an explicit `bst artifact pull oci/bluefin.bst` step between Build and Export. This transfers artifact blobs from remote CAS → local cache before `bst artifact checkout` runs, ensuring staging succeeds.

Also removes the incorrect comment claiming artifacts were already local after `bst build`.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process reliability by ensuring artifacts are properly cached during remote builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->