### PR TITLE
ci: move export to separate job to fix BST artifact checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,27 +235,112 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-      # ── Export, lint, SBOM, and artifact upload ───────────────────────
-      # Only for the default variant on publishable events (merge_group,
-      # schedule, workflow_dispatch). PRs skip this entirely — they only
-      # validate the BST build succeeds, not produce a publishable image.
-      # The nvidia variant has no separate publish path; skip it here.
-      #
-      # Remote execution note: `bst build` pushes artifacts to remote CAS
-      # but does NOT stage them locally. `bst artifact checkout` (inside
-      # `just export`) needs local blobs. We explicitly pull first to
-      # transfer the artifact from remote CAS → local cache before checkout.
-      # chunkah runs inside `just export` (see Justfile:154); the result
-      # is 120 plain-zstd layers ready for `podman push --compression-format=zstd`.
+  # ── Export, chunkify, SBOM, and artifact upload ──────────────────────────
+  # Separate job so this runs on a FRESH runner with an empty local BST cache.
+  # Root cause: `bst build` with remote execution registers the artifact key in
+  # the local BST DB but does NOT download the blobs. On the same runner,
+  # `bst artifact checkout` finds the key, skips the pull stage (thinks it's
+  # local), then fails staging with "No artifacts to stage". A fresh runner has
+  # no local BST state so BST genuinely pulls from remote CAS before checkout.
+  #
+  # Config uses push: false (artifact fetch-only, no remote-execution section)
+  # so BST operates in pure client/fetch mode — same pattern as the old
+  # standalone publish.yml that worked correctly.
+  #
+  # chunkah runs inside `just export` (see Justfile:154); produces 120
+  # plain-zstd layers ready for `podman push --compression-format=zstd`.
+  export:
+    runs-on: ubuntu-24.04
+    needs: build
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      actions: write    # for artifact upload
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Pull OCI artifact from CAS to local cache
-        if: github.event_name != 'pull_request' && matrix.variant == 'default'
+      - name: Setup Just
+        uses: taiki-e/install-action@just
+
+      - name: Capture build timestamp
+        id: timestamp
+        run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
+      # Storage setup must precede all podman calls (BST uses rootful podman).
+      - name: Remove unwanted software
+        uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9
+
+      - name: Mount BTRFS for podman storage
+        id: container-storage
+        uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6
+        continue-on-error: true
+        with:
+          target-dir: /var/lib/containers
+          mount-opts: compress-force=zstd:2
+          loopback-free: '1'
+
+      # Fetch-only BST config: push: false on all servers, no remote-execution.
+      # This is the critical difference from the build job — BST will pull
+      # artifact blobs from the remote CAS instead of treating them as "local".
+      - name: Generate BST fetch config
         env:
-          BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf
-        run: just bst artifact pull oci/bluefin.bst
+          CASD_CLIENT_CERT: ${{ vars.CASD_CLIENT_CERT }}
+          CASD_CLIENT_KEY: ${{ secrets.CASD_CLIENT_KEY }}
+        run: |
+          mkdir -p logs
+          echo "$CASD_CLIENT_CERT" > client.crt
+          echo "$CASD_CLIENT_KEY" > client.key
+          cat > buildstream-ci.conf <<'BSTCONF'
+          scheduler:
+            on-error: continue
+            fetchers: 32
+            builders: 4
+            network-retries: 3
+
+          logging:
+            message-format: '[%{wallclock}][%{elapsed}][%{key}][%{element}] %{action} %{message}'
+            error-lines: 80
+
+          cachedir: /root/.cache/buildstream
+          logdir: /src/logs
+
+          BSTCONF
+
+          if [[ -n "$CASD_CLIENT_CERT" ]] && [[ -n "$CASD_CLIENT_KEY" ]]; then
+            cat >> buildstream-ci.conf <<'BSTCONFFETCH'
+          artifacts:
+            servers:
+            - url: https://cache.projectbluefin.io:11002
+              push: false
+              connection-config:
+                keepalive-time: 180
+                retry-limit: 5
+                retry-delay: 1000
+                request-timeout: 180
+              auth:
+                client-key: /src/client.key
+                client-cert: /src/client.crt
+
+          source-caches:
+            servers:
+            - url: https://cache.projectbluefin.io:11002
+              push: false
+              connection-config:
+                keepalive-time: 180
+                retry-limit: 5
+                retry-delay: 1000
+                request-timeout: 180
+              auth:
+                client-key: /src/client.key
+                client-cert: /src/client.crt
+          BSTCONFFETCH
+          fi
+
+          echo "=== BST fetch config ==="
+          cat buildstream-ci.conf
 
       - name: Export OCI image from BuildStream
-        if: github.event_name != 'pull_request' && matrix.variant == 'default'
         id: export
         env:
           BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf
@@ -263,34 +348,24 @@ jobs:
           OCI_IMAGE_CREATED: ${{ steps.timestamp.outputs.created }}
           OCI_IMAGE_REVISION: ${{ github.sha }}
           OCI_IMAGE_VERSION: latest
-        run: |
-          just export
-          echo "image_ref=${{ env.IMAGE_NAME }}:latest" >> "$GITHUB_OUTPUT"
+        run: just export
 
       - name: Validate with bootc container lint
-        if: github.event_name != 'pull_request' && matrix.variant == 'default'
         run: just lint
 
       - name: Generate SBOM
-        if: github.event_name != 'pull_request' && matrix.variant == 'default'
         env:
           BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf
         run: just sbom
 
-      # Save OCI archive to the BTRFS volume to keep rootfs pressure low.
-      # podman save produces an uncompressed OCI archive; plain podman push
-      # (--compression-format=zstd) handles compression at push time.
-      # skopeo is intentionally avoided — see memory: plain podman push is
-      # the correct tool for post-chunkah images.
+      # Save OCI archive to BTRFS volume; compression happens at push time.
       - name: Save OCI archive
-        if: github.event_name != 'pull_request' && matrix.variant == 'default'
         run: |
           sudo podman save --format oci-archive \
             -o /var/lib/containers/dakota.oci.tar \
             "${{ env.IMAGE_NAME }}:latest"
 
       - name: Upload OCI and SBOM artifacts
-        if: github.event_name != 'pull_request' && matrix.variant == 'default'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dakota-oci-${{ github.sha }}


### PR DESCRIPTION
## Problem

`bst build` with remote execution registers the artifact key in the local BST database but does NOT download blobs to the runner disk. `bst artifact checkout` (inside `just export`) then finds the key, skips pull ("Pull SKIPPED — Pull Queue: processed 0, skipped 1"), then fails staging:

```
Error while staging dependencies into a sandbox: 'No artifacts to stage'
```

An explicit `bst artifact pull` step (PR #385) also skips for the same reason — BST considers the artifact present because of the remote execution metadata registration.

## Fix

Move export/lint/sbom/save/upload into a dedicated `export` job that runs after `build` succeeds. Fresh runner = empty local BST cache = BST genuinely pulls artifact blobs from remote CAS.

Export job uses fetch-only BST config (`push: false`, no `remote-execution` section) — the same pattern as the original `publish.yml` that worked.

## Pipeline after this change

- `build` matrix job (default + nvidia): BST build → upload logs
- `export` job (needs: build, ubuntu-24.04, non-PR only): BST fetch → export/chunkify → lint → sbom → podman save → upload artifact
- `publish.yml` (workflow_run on build.yml success): download artifact → podman load → push to GHCR → sign

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline workflow by separating build and export processes into distinct jobs for improved efficiency and clearer step organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->