### PR TITLE
ci: fix BST_FLAGS key mismatch in export and add explicit artifact push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,6 +223,17 @@ jobs:
           just bst build ${{ matrix.element }}
         timeout-minutes: 420
 
+      # Push the built artifact to the remote CAS so the export job can pull it.
+      # Remote execution may populate the artifact cache implicitly, but an
+      # explicit push guarantees the artifact is there regardless of BST internals.
+      # Only push for the default variant (export job only handles default).
+      - name: Push OCI artifact to remote CAS
+        if: github.event_name != 'pull_request' && matrix.variant == 'default'
+        env:
+          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
+        run: |
+          just bst artifact push --deps none ${{ matrix.element }}
+
       # ── Upload build logs ─────────────────────────────────────────────
       # Always upload, even on failure, so build failures can be diagnosed.
 
@@ -343,7 +354,10 @@ jobs:
       - name: Export OCI image from BuildStream
         id: export
         env:
-          BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf
+          # CRITICAL: must match the build job's BST_FLAGS exactly.
+          # -o x86_64_v3 true affects the cache key — omitting it resolves
+          # a different artifact hash that was never pushed to the remote CAS.
+          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
           BUILD_IMAGE_NAME: ${{ env.IMAGE_NAME }}
           OCI_IMAGE_CREATED: ${{ steps.timestamp.outputs.created }}
           OCI_IMAGE_REVISION: ${{ github.sha }}
@@ -355,7 +369,7 @@ jobs:
 
       - name: Generate SBOM
         env:
-          BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf
+          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
         run: just sbom
 
       # Save OCI archive to BTRFS volume; compression happens at push time.


### PR DESCRIPTION
## Root cause (identified by BST log analysis)

The export job was resolving artifact key `16d5ff76` (without `-o x86_64_v3 true`) while the build job computed key `77cc7ccb` (with it). The remote CAS at `cache.projectbluefin.io` only holds `77cc7ccb`, so every export attempt got:

```
Remote (https://cache.projectbluefin.io:11002) does not have artifact 16d5ff76 cached
Remote (https://cache.projectbluefin.io:11001) does not have artifact 16d5ff76 cached
```

## Fix 1 — BST_FLAGS consistency

Add `-o x86_64_v3 true` to the `export` and `sbom` steps so they compute the same cache key as the `build` step.

## Fix 2 — explicit artifact push  

Add `bst artifact push --deps none` after the build step for the `default` variant to guarantee the top-level OCI artifact is in the remote CAS regardless of remote-execution implicit push behaviour.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced continuous integration pipeline with improved artifact handling for production deployments
  * Optimized build configuration for better processor architecture compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->