### PR TITLE
ci: inline export in publish with correct BST_FLAGS

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,113 +1,126 @@
 name: Publish Bluefin dakota
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: ["Build Bluefin dakota"]
     types: [completed]
-    # NO branches: filter — merge_group runs on gh-readonly-queue/main/... refs, not 'main'.
-    # Job guard below handles PR exclusion.
-  workflow_dispatch:
-    inputs:
-      build_run_id:
-        description: 'Build workflow run ID (leave empty to auto-detect from HEAD SHA)'
-        required: false
-        type: string
-      build_sha:
-        description: 'Git SHA to publish (defaults to HEAD of main if empty)'
-        required: false
-        type: string
 
 env:
   IMAGE_NAME: dakota
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
-# Merge queue publishes get a per-SHA concurrency group — they only write :$BUILD_SHA
-# (no conflict possible). Everything else (schedule, dispatch, manual build dispatch)
-# stays on publish-main to prevent :latest races. Default-to-main ensures new triggers
-# are safe without explicit opt-in.
 concurrency:
-  group: >-
-    ${{ github.event_name == 'workflow_run' && github.event.workflow_run.event == 'merge_group'
-        && format('publish-{0}', github.event.workflow_run.head_sha)
-        || 'publish-main' }}
+  group: publish-main
   cancel-in-progress: false
 
 jobs:
   publish:
-    # Scheduled (overnight) runs use standard runners — slow is fine, we're asleep.
-    # merge_group and workflow_dispatch runs use Blacksmith for fast GHCR push throughput.
-    # BST, chunkah, and SBOM have moved to build.yml; publish now only loads+pushes+signs.
-    runs-on: ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'schedule') && 'ubuntu-24.04' || 'blacksmith-4vcpu-ubuntu-2404' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       packages: write
-      id-token: write          # cosign OIDC + actions/attest
-      attestations: write      # actions/attest
-      artifact-metadata: write # SLSA — requires org-level token; personal forks show startup_failure (expected)
-      actions: read            # cross-run artifact download (download-artifact with run-id)
-    # Fire on: schedule builds, merge_group builds, workflow_dispatch from main.
-    # Block on: pull_request builds; workflow_dispatch from non-main branches.
-    # Note: merge_group head_branch is 'gh-readonly-queue/main/pr-NNN-<sha>', NOT 'main'.
-    # Must use startsWith to match queue branches targeting main.
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+      actions: read
     if: >-
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event != 'pull_request' &&
        (github.event.workflow_run.head_branch == 'main' ||
         startsWith(github.event.workflow_run.head_branch, 'gh-readonly-queue/main/')))
     steps:
-      - name: Resolve SHA and trigger event
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Just
+        uses: taiki-e/install-action@just
+
+      - name: Capture build timestamp
+        id: timestamp
+        run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
+      - name: Remove unwanted software
+        uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9
+
+      - name: Mount BTRFS for podman storage
+        uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6
+        continue-on-error: true
+        with:
+          target-dir: /var/lib/containers
+          mount-opts: compress-force=zstd:2
+          loopback-free: '1'
+
+      # Fetch-only BST config — pull artifact from remote CAS, no build/push
+      - name: Generate BST fetch config
+        env:
+          CASD_CLIENT_CERT: ${{ vars.CASD_CLIENT_CERT }}
+          CASD_CLIENT_KEY: ${{ secrets.CASD_CLIENT_KEY }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            # Triggered by a completed build run — run ID is known directly.
-            echo "BUILD_SHA=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_ENV"
-            echo "BUILD_RUN_ID=${{ github.event.workflow_run.id }}" >> "$GITHUB_ENV"
-            echo "TRIGGER_EVENT=${{ github.event.workflow_run.event }}" >> "$GITHUB_ENV"
-          elif [ -n "${{ inputs.build_run_id }}" ]; then
-            # Manual dispatch with explicit run ID — derive SHA from the run.
-            RUN_SHA=$(gh api \
-              "repos/${{ github.repository }}/actions/runs/${{ inputs.build_run_id }}" \
-              --jq '.head_sha')
-            echo "BUILD_SHA=${RUN_SHA}" >> "$GITHUB_ENV"
-            echo "BUILD_RUN_ID=${{ inputs.build_run_id }}" >> "$GITHUB_ENV"
-            echo "TRIGGER_EVENT=workflow_dispatch" >> "$GITHUB_ENV"
-          else
-            # Manual dispatch without run ID — look up latest successful build for SHA.
-            # If build is still running, this returns null and we fail fast with a clear error.
-            TARGET_SHA="${{ inputs.build_sha || github.sha }}"
-            echo "BUILD_SHA=${TARGET_SHA}" >> "$GITHUB_ENV"
-            echo "TRIGGER_EVENT=workflow_dispatch" >> "$GITHUB_ENV"
-            RUN_ID=$(gh api \
-              "repos/${{ github.repository }}/actions/workflows/build.yml/runs?head_sha=${TARGET_SHA}&status=success&per_page=1" \
-              --jq '.workflow_runs[0].id')
-            if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
-              echo "::error::No successful build run found for SHA ${TARGET_SHA}." \
-                   "If the build is still running, wait for it to finish and re-dispatch," \
-                   "or provide build_run_id explicitly." >&2
-              exit 1
-            fi
-            echo "BUILD_RUN_ID=${RUN_ID}" >> "$GITHUB_ENV"
+          mkdir -p logs
+          echo "$CASD_CLIENT_CERT" > client.crt
+          echo "$CASD_CLIENT_KEY" > client.key
+          cat > buildstream-ci.conf <<'BSTCONF'
+          scheduler:
+            on-error: continue
+            fetchers: 32
+            builders: 4
+            network-retries: 3
+
+          logging:
+            message-format: '[%{wallclock}][%{elapsed}][%{key}][%{element}] %{action} %{message}'
+            error-lines: 80
+
+          cachedir: /root/.cache/buildstream
+          logdir: /src/logs
+
+          BSTCONF
+
+          if [[ -n "$CASD_CLIENT_CERT" ]] && [[ -n "$CASD_CLIENT_KEY" ]]; then
+            cat >> buildstream-ci.conf <<'BSTCONFFETCH'
+          artifacts:
+            servers:
+            - url: https://cache.projectbluefin.io:11002
+              push: false
+              connection-config:
+                keepalive-time: 180
+                retry-limit: 5
+                retry-delay: 1000
+                request-timeout: 180
+              auth:
+                client-key: /src/client.key
+                client-cert: /src/client.crt
+
+          source-caches:
+            servers:
+            - url: https://cache.projectbluefin.io:11002
+              push: false
+              connection-config:
+                keepalive-time: 180
+                retry-limit: 5
+                retry-delay: 1000
+                request-timeout: 180
+              auth:
+                client-key: /src/client.key
+                client-cert: /src/client.crt
+          BSTCONFFETCH
           fi
 
-      - name: Download OCI and SBOM artifacts
-        # Artifact was uploaded by build.yml after export+chunkify+sbom.
-        # Uses cross-run download — requires actions: read permission.
-        # Fails immediately if artifact doesn't exist (missing = build state is bad;
-        # do not retry, re-run build.yml first then re-dispatch publish).
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: dakota-oci-${{ env.BUILD_SHA }}
-          run-id: ${{ env.BUILD_RUN_ID }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: /tmp/artifacts
+      - name: Export OCI image from BuildStream
+        id: export
+        env:
+          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
+          BUILD_IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          OCI_IMAGE_CREATED: ${{ steps.timestamp.outputs.created }}
+          OCI_IMAGE_REVISION: ${{ github.sha }}
+          OCI_IMAGE_VERSION: latest
+        run: just export
 
-      - name: Load OCI archive into podman
-        id: load
-        run: |
-          sudo podman load -i /tmp/artifacts/dakota.oci.tar
-          # Copy SBOM to workspace for oras attach (expects relative path)
-          cp /tmp/artifacts/dakota.spdx.json ./dakota.spdx.json
-          echo "image_ref=${{ env.IMAGE_NAME }}:latest" >> "$GITHUB_OUTPUT"
+      - name: Generate SBOM
+        env:
+          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
+        run: just sbom
 
       - name: Login to GHCR
         env:
@@ -119,44 +132,15 @@ jobs:
           echo "$GH_TOKEN" | podman login ghcr.io --username "$GH_ACTOR" --password-stdin \
             --compat-auth-file ~/.docker/config.json
 
-      - name: Push :$BUILD_SHA and capture digest
-        id: push-sha
+      - name: Push to GHCR and capture digest
+        id: push
         run: |
-          sudo podman tag "localhost/${{ steps.load.outputs.image_ref }}" \
-            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BUILD_SHA }}"
-          rm -f /tmp/digest.txt
-          for i in 1 2 3; do
-            sudo podman push --compression-format=zstd \
-              --digestfile /tmp/digest.txt \
-              "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BUILD_SHA }}" && break
-            if [ "$i" -eq 3 ]; then
-              echo "Push failed for :${{ env.BUILD_SHA }} after ${i} attempts" >&2
-              exit 1
-            fi
-            echo "Push attempt $i failed, retrying..."
-            sleep 5
-          done
-          echo "digest=$(cat /tmp/digest.txt)" >> "$GITHUB_OUTPUT"
-
-      - name: Push :latest
-        # Only on nightly schedule or manual dispatch — never on merge_group re-runs.
-        # TRIGGER_EVENT is 'schedule' for nightly, 'workflow_dispatch' for manual.
-        # Checking TRIGGER_EVENT (not github.event_name) because inside publish.yml,
-        # github.event_name is always 'workflow_run' — checking event_name == 'schedule' is always false.
-        if: env.TRIGGER_EVENT == 'schedule' || github.event_name == 'workflow_dispatch'
-        run: |
-          sudo podman tag "localhost/${{ steps.load.outputs.image_ref }}" \
+          sudo podman tag "localhost/${{ env.IMAGE_NAME }}:latest" \
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
-          for i in 1 2 3; do
-            sudo podman push --compression-format=zstd \
-              "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest" && break
-            if [ "$i" -eq 3 ]; then
-              echo "Push failed for :latest after ${i} attempts" >&2
-              exit 1
-            fi
-            echo "Push attempt $i failed, retrying..."
-            sleep 5
-          done
+          sudo podman push --compression-format=zstd \
+            --digestfile /tmp/digest.txt \
+            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          echo "digest=$(cat /tmp/digest.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
@@ -166,15 +150,15 @@ jobs:
 
       - name: Sign image
         env:
-          DIGEST: ${{ steps.push-sha.outputs.digest }}
+          DIGEST: ${{ steps.push.outputs.digest }}
         run: |
           cosign sign -y \
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"
 
-      - name: Attach SBOM as OCI referrer
+      - name: Attach SBOM
         id: sbom-attach
         env:
-          DIGEST: ${{ steps.push-sha.outputs.digest }}
+          DIGEST: ${{ steps.push.outputs.digest }}
         run: |
           SBOM_DIGEST=$(oras attach \
             --artifact-type application/vnd.spdx+json \
@@ -183,7 +167,7 @@ jobs:
             dakota.spdx.json:application/vnd.spdx+json)
           echo "sbom_digest=${SBOM_DIGEST}" >> "$GITHUB_OUTPUT"
 
-      - name: Sign SBOM referrer
+      - name: Sign SBOM
         env:
           SBOM_DIGEST: ${{ steps.sbom-attach.outputs.sbom_digest }}
         run: |
@@ -194,13 +178,4 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.push-sha.outputs.digest }}
-
-      - name: Upload publish logs
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: publish-logs
-          path: logs/
-          retention-days: 7
-          if-no-files-found: ignore
+          subject-digest: ${{ steps.push.outputs.digest }}


### PR DESCRIPTION
Inline export directly in publish.yml. BST_FLAGS includes -o x86_64_v3 true matching the build job cache key. concurrency cancel-in-progress: false prevents scheduled runs from clobbering an in-progress publish.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the automated publish workflow by removing manual input parameters
  * Streamlined image publishing and signing operations to a single consolidated process
  * Optimized workflow concurrency and runner configuration for improved efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->