### PR TITLE
ci: fix oras attach digest capture for SBOM signing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -162,9 +162,10 @@ jobs:
         run: |
           SBOM_DIGEST=$(oras attach \
             --artifact-type application/vnd.spdx+json \
-            --format go-template='{{.Digest}}' \
+            --format json \
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}" \
-            dakota.spdx.json:application/vnd.spdx+json)
+            dakota.spdx.json:application/vnd.spdx+json \
+            | python3 -c "import json,sys; print(json.load(sys.stdin)['digest'])")
           echo "sbom_digest=${SBOM_DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: Sign SBOM


### PR DESCRIPTION
Use --format json and parse with python3 instead of go-template which returned <no value>.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the Software Bill of Materials (SBOM) extraction process in the release workflow to improve reliability and accuracy of supply chain documentation for published artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->