### PR TITLE
ci: fix 10 audit issues — SHA resolution, cosign bump, retry, pins, e…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,9 @@ jobs:
       #       fs.writeFileSync('bluefin.token', token, { mode: 0o600 });
 
       - name: Setup Just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
+        with:
+          tool: just
 
       - name: Capture build timestamp
         id: timestamp
@@ -246,149 +248,6 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-  # ── Export, chunkify, SBOM, and artifact upload ──────────────────────────
-  # Separate job so this runs on a FRESH runner with an empty local BST cache.
-  # Root cause: `bst build` with remote execution registers the artifact key in
-  # the local BST DB but does NOT download the blobs. On the same runner,
-  # `bst artifact checkout` finds the key, skips the pull stage (thinks it's
-  # local), then fails staging with "No artifacts to stage". A fresh runner has
-  # no local BST state so BST genuinely pulls from remote CAS before checkout.
-  #
-  # Config uses push: false (artifact fetch-only, no remote-execution section)
-  # so BST operates in pure client/fetch mode — same pattern as the old
-  # standalone publish.yml that worked correctly.
-  #
-  # chunkah runs inside `just export` (see Justfile:154); produces 120
-  # plain-zstd layers ready for `podman push --compression-format=zstd`.
-  export:
-    runs-on: ubuntu-24.04
-    needs: build
-    if: github.event_name != 'pull_request'
-    permissions:
-      contents: read
-      actions: write    # for artifact upload
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Setup Just
-        uses: taiki-e/install-action@just
-
-      - name: Capture build timestamp
-        id: timestamp
-        run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
-
-      # Storage setup must precede all podman calls (BST uses rootful podman).
-      - name: Remove unwanted software
-        uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9
-
-      - name: Mount BTRFS for podman storage
-        id: container-storage
-        uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6
-        continue-on-error: true
-        with:
-          target-dir: /var/lib/containers
-          mount-opts: compress-force=zstd:2
-          loopback-free: '1'
-
-      # Fetch-only BST config: push: false on all servers, no remote-execution.
-      # This is the critical difference from the build job — BST will pull
-      # artifact blobs from the remote CAS instead of treating them as "local".
-      - name: Generate BST fetch config
-        env:
-          CASD_CLIENT_CERT: ${{ vars.CASD_CLIENT_CERT }}
-          CASD_CLIENT_KEY: ${{ secrets.CASD_CLIENT_KEY }}
-        run: |
-          mkdir -p logs
-          echo "$CASD_CLIENT_CERT" > client.crt
-          echo "$CASD_CLIENT_KEY" > client.key
-          cat > buildstream-ci.conf <<'BSTCONF'
-          scheduler:
-            on-error: continue
-            fetchers: 32
-            builders: 4
-            network-retries: 3
-
-          logging:
-            message-format: '[%{wallclock}][%{elapsed}][%{key}][%{element}] %{action} %{message}'
-            error-lines: 80
-
-          cachedir: /root/.cache/buildstream
-          logdir: /src/logs
-
-          BSTCONF
-
-          if [[ -n "$CASD_CLIENT_CERT" ]] && [[ -n "$CASD_CLIENT_KEY" ]]; then
-            cat >> buildstream-ci.conf <<'BSTCONFFETCH'
-          artifacts:
-            servers:
-            - url: https://cache.projectbluefin.io:11002
-              push: false
-              connection-config:
-                keepalive-time: 180
-                retry-limit: 5
-                retry-delay: 1000
-                request-timeout: 180
-              auth:
-                client-key: /src/client.key
-                client-cert: /src/client.crt
-
-          source-caches:
-            servers:
-            - url: https://cache.projectbluefin.io:11002
-              push: false
-              connection-config:
-                keepalive-time: 180
-                retry-limit: 5
-                retry-delay: 1000
-                request-timeout: 180
-              auth:
-                client-key: /src/client.key
-                client-cert: /src/client.crt
-          BSTCONFFETCH
-          fi
-
-          echo "=== BST fetch config ==="
-          cat buildstream-ci.conf
-
-      - name: Export OCI image from BuildStream
-        id: export
-        env:
-          # CRITICAL: must match the build job's BST_FLAGS exactly.
-          # -o x86_64_v3 true affects the cache key — omitting it resolves
-          # a different artifact hash that was never pushed to the remote CAS.
-          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
-          BUILD_IMAGE_NAME: ${{ env.IMAGE_NAME }}
-          OCI_IMAGE_CREATED: ${{ steps.timestamp.outputs.created }}
-          OCI_IMAGE_REVISION: ${{ github.sha }}
-          OCI_IMAGE_VERSION: latest
-        run: just export
-
-      - name: Validate with bootc container lint
-        run: just lint
-
-      - name: Generate SBOM
-        env:
-          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
-        run: just sbom
-
-      # Save OCI archive to BTRFS volume; compression happens at push time.
-      - name: Save OCI archive
-        run: |
-          sudo podman save --format oci-archive \
-            -o /var/lib/containers/dakota.oci.tar \
-            "${{ env.IMAGE_NAME }}:latest"
-
-      - name: Upload OCI and SBOM artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: dakota-oci-${{ github.sha }}
-          path: |
-            /var/lib/containers/dakota.oci.tar
-            dakota.spdx.json
-          retention-days: 3
-          if-no-files-found: error
-
   # ── aarch64 native build ──────────────────────────────────────────────────
   # Mirrors the x86_64 build job. ARM failures do not fail the workflow or
   # block x86_64 publication — this is an experimental parallel build.
@@ -420,7 +279,9 @@ jobs:
         uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9
 
       - name: Setup Just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
+        with:
+          tool: just
 
       - name: Capture build timestamp
         id: timestamp
@@ -532,7 +393,7 @@ jobs:
 
       - name: Upload build logs
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: buildstream-logs-aarch64
           path: logs/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   publish:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'schedule') && 'ubuntu-24.04' || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
       packages: write
@@ -31,11 +31,26 @@ jobs:
        (github.event.workflow_run.head_branch == 'main' ||
         startsWith(github.event.workflow_run.head_branch, 'gh-readonly-queue/main/')))
     steps:
+      - name: Resolve build SHA and trigger event
+        id: context
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            echo "sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+            echo "event=${{ github.event.workflow_run.event }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            echo "event=${{ github.event_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.context.outputs.sha }}
 
       - name: Setup Just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
+        with:
+          tool: just
 
       - name: Capture build timestamp
         id: timestamp
@@ -113,9 +128,12 @@ jobs:
           BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
           BUILD_IMAGE_NAME: ${{ env.IMAGE_NAME }}
           OCI_IMAGE_CREATED: ${{ steps.timestamp.outputs.created }}
-          OCI_IMAGE_REVISION: ${{ github.sha }}
+          OCI_IMAGE_REVISION: ${{ steps.context.outputs.sha }}
           OCI_IMAGE_VERSION: latest
         run: just export
+
+      - name: Validate with bootc container lint
+        run: just lint
 
       - name: Generate SBOM
         env:
@@ -132,18 +150,46 @@ jobs:
           echo "$GH_TOKEN" | podman login ghcr.io --username "$GH_ACTOR" --password-stdin \
             --compat-auth-file ~/.docker/config.json
 
-      - name: Push to GHCR and capture digest
+      - name: Push to GHCR
         id: push
+        env:
+          BUILD_SHA: ${{ steps.context.outputs.sha }}
+          TRIGGER_EVENT: ${{ steps.context.outputs.event }}
         run: |
-          sudo podman tag "localhost/${{ env.IMAGE_NAME }}:latest" \
-            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
-          sudo podman push --compression-format=zstd \
-            --digestfile /tmp/digest.txt \
-            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          IMAGE="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}"
+
+          # Always tag and push :$BUILD_SHA
+          sudo podman tag "localhost/${{ env.IMAGE_NAME }}:latest" "${IMAGE}:${BUILD_SHA}"
+
+          PUSH_OK=false
+          for attempt in 1 2 3; do
+            sudo podman push --compression-format=zstd \
+              --digestfile /tmp/digest.txt \
+              "${IMAGE}:${BUILD_SHA}" && { PUSH_OK=true; break; }
+            echo "Push attempt ${attempt} failed for :${BUILD_SHA}, retrying in 5s..."
+            [ "$attempt" -lt 3 ] && sleep 5
+          done
+          $PUSH_OK || { echo "ERROR: all push attempts failed for :${BUILD_SHA}"; exit 1; }
+
+          # Push :latest on schedule or workflow_dispatch (including downstream from build.yml dispatch)
+          if [[ "$TRIGGER_EVENT" == "schedule" || "$TRIGGER_EVENT" == "workflow_dispatch" ]]; then
+            sudo podman tag "localhost/${{ env.IMAGE_NAME }}:latest" "${IMAGE}:latest"
+            PUSH_OK=false
+            for attempt in 1 2 3; do
+              sudo podman push --compression-format=zstd \
+                "${IMAGE}:latest" && { PUSH_OK=true; break; }
+              echo "Push attempt ${attempt} failed for :latest, retrying in 5s..."
+              [ "$attempt" -lt 3 ] && sleep 5
+            done
+            $PUSH_OK || { echo "ERROR: all push attempts failed for :latest"; exit 1; }
+          fi
+
           echo "digest=$(cat /tmp/digest.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        with:
+          cosign-release: v3.0.6
 
       - name: Install oras
         uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
@@ -160,12 +206,17 @@ jobs:
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
         run: |
+          set -o pipefail
           SBOM_DIGEST=$(oras attach \
             --artifact-type application/vnd.spdx+json \
             --format json \
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}" \
             dakota.spdx.json:application/vnd.spdx+json \
-            | python3 -c "import json,sys; print(json.load(sys.stdin)['digest'])")
+            | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['digest'])")
+          if [[ -z "$SBOM_DIGEST" || "$SBOM_DIGEST" == "None" ]]; then
+            echo "ERROR: Failed to capture SBOM digest from oras attach"
+            exit 1
+          fi
           echo "sbom_digest=${SBOM_DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: Sign SBOM

--- a/.github/workflows/track-bst-sources.yml
+++ b/.github/workflows/track-bst-sources.yml
@@ -125,7 +125,7 @@ jobs:
           fi
 
       - name: Setup Just
-        uses: taiki-e/install-action@481c34c1cf3a84c68b5e46f4eccfc82af798415a # v2
+        uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
         with:
           tool: just
 
@@ -278,7 +278,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Just
-        uses: taiki-e/install-action@481c34c1cf3a84c68b5e46f4eccfc82af798415a # v2
+        uses: taiki-e/install-action@51cd0b8c0499559d9a4d75c0f5c67bec3a894ec8 # v2
         with:
           tool: just
 

--- a/Justfile
+++ b/Justfile
@@ -558,9 +558,9 @@ chunkify image_ref:
     # Run chunkah against the overlay (bind-mounted read-only).
     # --max-layers 120 balances layer granularity with registry storage space.
     # CHUNKAH_CONFIG_STR preserves OCI labels (containers.bootc=1).
-    # Image pinned from quay.io/coreos/chunkah:latest as of 2026-04-21.
+    # Image pinned from quay.io/coreos/chunkah:v0.4.0 (2026-05-02).
     # Pre-pull with retries so transient registry 5xx errors don't abort the run.
-    CHUNKAH_REF="quay.io/coreos/chunkah@sha256:306371251e61cc870c8546e225b13bdf2e333f79461dc5e0fc280cc170cee070"
+    CHUNKAH_REF="quay.io/coreos/chunkah@sha256:faa8209f267fd1b384f3f4008a27ac0603333aab0d206bb146faf326282c64b4"
     for attempt in 1 2 3; do
         $SUDO_CMD podman pull "$CHUNKAH_REF" && break
         echo "==> chunkah pull attempt $attempt failed, retrying in 10s..."
@@ -755,8 +755,8 @@ verify image_ref="":
         echo "SKIP: cosign not installed"
     else
         cosign verify \
-            --certificate-identity \
-                'https://github.com/projectbluefin/dakota/.github/workflows/publish.yml@refs/heads/main' \
+            --certificate-identity-regexp \
+                '^https://github\.com/projectbluefin/dakota/\.github/workflows/publish\.yml@refs/heads/(main|gh-readonly-queue/main/.+)$' \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             "${IMAGE}" && echo "PASS: signature valid" || { echo "FAIL: signature check failed"; STATUS=1; }
     fi


### PR DESCRIPTION
…xport cleanup

publish.yml:
- Fix checkout SHA for workflow_run (use head_sha, not github.sha) [#174]
- Add robust error handling for oras SBOM digest capture [#175]
- Pin cosign binary to v3.0.6 (fixes GHSA-w6c6-c85g-mmv6) [#176]
- Push SHA-tagged image alongside :latest [#178]
- Dynamic runner: ubuntu-24.04 for schedule, Blacksmith for interactive [#182]
- Add 3-attempt retry with hard failure on podman push [#183]
- Add bootc lint step before publish

build.yml:
- Remove redundant export job (artifacts never consumed) [#179]
- Pin taiki-e/install-action to SHA with version comment
- Normalize upload-artifact SHA in aarch64 job

track-bst-sources.yml:
- Update taiki-e/install-action SHA to current v2

Justfile:
- cosign verify: use --certificate-identity-regexp with anchored regex [#177]
- Update chunkah pin to v0.4.0 [#180]

Assisted-by: Claude Opus 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved CI/CD pipeline stability by pinning action versions and updating dependencies.
  * Enhanced publishing workflow with conditional logic and strengthened validation checks.
  * Updated build system tool references for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->