### PR TITLE
hotfix: install nvidia driver libs into multiarch libdir

### DIFF
--- a/elements/bluefin-nvidia/deps.bst
+++ b/elements/bluefin-nvidia/deps.bst
@@ -6,3 +6,5 @@ depends:
   - bluefin-nvidia/nvidia-egl-wayland.bst
   - bluefin-nvidia/nvidia-kargs.bst
   - bluefin-nvidia/nvidia-modprobe-config.bst
+  - bluefin-nvidia/nvidia-container-toolkit.bst
+  - bluefin-nvidia/nvidia-container-toolkit-preset.bst

--- a/elements/bluefin-nvidia/nvidia-container-toolkit-preset.bst
+++ b/elements/bluefin-nvidia/nvidia-container-toolkit-preset.bst
@@ -1,0 +1,20 @@
+kind: manual
+description: |
+  Enable upstream's nvidia-cdi-refresh.{path,service} (shipped by
+  bluefin-nvidia/nvidia-container-toolkit.bst) so the CDI spec at
+  /var/run/cdi/nvidia.yaml is generated at boot and refreshed whenever
+  the driver or toolkit binaries change.
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ''
+
+config:
+  install-commands:
+  - |
+    install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/systemd/system-preset/80-nvidia-container-toolkit.preset" <<'PRESET'
+    enable nvidia-cdi-refresh.path
+    enable nvidia-cdi-refresh.service
+    PRESET

--- a/elements/bluefin-nvidia/nvidia-container-toolkit.bst
+++ b/elements/bluefin-nvidia/nvidia-container-toolkit.bst
@@ -1,0 +1,40 @@
+kind: manual
+description: |
+  NVIDIA Container Toolkit: nvidia-ctk + nvidia-cdi-hook for podman GPU
+  passthrough via CDI. This is mirrored from and element in gnomeos-deps from
+  gnome-build-meta this is from their master branch, not yet on the gnome-50 
+  branch we junction. it is vendored inline here until we can pull it directly.
+
+  We do not ship nvidia-container-runtime or libnvidia-container.
+  Podman reads /var/run/cdi/nvidia.yaml natively; the upstream-provided
+  nvidia-cdi-refresh.path watches /lib/modules/*/modules.dep and
+  /usr/bin/nvidia-ctk and re-runs `nvidia-ctk cdi generate` on driver or
+  toolkit changes.
+
+sources:
+- kind: git_repo
+  url: github:NVIDIA/nvidia-container-toolkit.git
+  track: v*.*.*
+  exclude:
+  - "*rc*"
+  ref: v1.19.0-0-gec7b4e2fa2caecad6d89be4a26029b831fe7503a
+
+build-depends:
+- freedesktop-sdk.bst:components/go.bst
+- freedesktop-sdk.bst:public-stacks/buildsystem-make.bst
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  local_ldflags: -Wl,-z,lazy
+
+config:
+  build-commands:
+  - go build ./cmd/nvidia-ctk
+  - go build ./cmd/nvidia-cdi-hook
+  install-commands:
+  - install -Dt %{install-root}%{bindir} -m755 nvidia-ctk nvidia-cdi-hook
+  - |
+    install -Dt %{install-root}%{indep-libdir}/systemd/system -m644 \
+            deployments/systemd/nvidia-cdi-refresh.{service,path}

--- a/elements/bluefin-nvidia/nvidia-drivers.bst
+++ b/elements/bluefin-nvidia/nvidia-drivers.bst
@@ -115,7 +115,7 @@ config:
   - |
     set -euo pipefail
     cd extracted
-    LIBDIR="%{install-root}/usr/lib/%{abi}"
+    LIBDIR="%{install-root}%{libdir}"
     install -d "$LIBDIR" "$LIBDIR/vdpau"
 
     for lib in \


### PR DESCRIPTION
Closes #373 
Closes #376 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NVIDIA Container Toolkit support to enable Podman GPU/CDI workflows
  * Added a systemd preset to enable NVIDIA container refresh services by default

* **Bug Fixes**
  * Fixed library installation path handling in NVIDIA driver installation to use the correct architecture-specific libdir
<!-- end of auto-generated comment: release notes by coderabbit.ai -->