### PR TITLE
fix(ci): update scorecard-action to verified commit SHA

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Problem

The scorecard workflow was failing with:

```
workflow verification failed: imposter commit: 99c09fe975337306107572b4fdf4db224cf8e2f2 does not belong to ossf/scorecard-action
```

The SHA `99c09fe975337306107572b4fdf4db224cf8e2f2` is an **annotated tag object** SHA, not an actual commit SHA. The scorecard service validates that pinned SHAs are real commits in `ossf/scorecard-action` — tag objects fail this check.

## Fix

Replace the tag-object SHA with the actual commit SHA that `v2.4.3` points to:

- **Before:** `ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2` (tag object)
- **After:** `ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a` (verified commit)

Both reference the same `v2.4.3` release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to ensure compatibility with the latest available versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->