### PR TITLE
fix(dconf): set ublue logo and leftmost position for custom-command-menu

### DIFF
--- a/files/dconf/05-dakota-custom-command-menu
+++ b/files/dconf/05-dakota-custom-command-menu
@@ -11,8 +11,10 @@
 
 [org/gnome/shell/extensions/custom-command-list]
 menuoptions-setting=2
-menuicon-setting='utilities-terminal-symbolic'
-command-order=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99]
+menuicon-setting='ublue-logo-symbolic'
+menulocation-setting=1
+menuposition-setting=0
+command-order=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 command1=('---$(hostname)', '', '', true)
 command2=('About', 'gnome-control-center system about', '', true)
 command3=('System Monitor', '/usr/bin/flatpak run io.missioncenter.MissionCenter', '', true)


### PR DESCRIPTION
## Summary

Changes to `files/dconf/05-dakota-custom-command-menu`:

- **Icon**: `menuicon-setting` changed from `utilities-terminal-symbolic` to `ublue-logo-symbolic` — shows the ublue U logo instead of a terminal icon, matching bluefin's LogoMenu behavior.
- **Position**: Added `menulocation-setting=1` + `menuposition-setting=0` — places the menu at the very leftmost position on the panel (location=0 appends after Activities; location=1 with position=0 inserts at index 0, the first item).
- **command-order**: Trimmed from `[1..99]` to `[1..11]` — only the 11 commands actually defined in the keyfile.

## Reference behavior

projectbluefin/common's `04-bluefin-logomenu-extension` used `ublue-logo-symbolic` and was positioned leftmost. Dakota replaces LogoMenu with custom-command-menu; this change matches that established UX pattern.

## Extension JS position logic (confirmed)

```
menulocation-setting=0 → addToStatusArea(..., panel.left.length, 'left')  // appends AFTER Activities
menulocation-setting=1 → addToStatusArea(..., menuposition-setting, 'left')  // position 0 = leftmost
```

## Hardware test

Verified on NUC (192.168.1.247) running dakota x86-64-v3:
- `gsettings get ... menuicon-setting` → `'ublue-logo-symbolic'` ✅
- `gsettings get ... menulocation-setting` → `1` ✅
- `gsettings get ... menuposition-setting` → `0` ✅
- Settings survive `dconf reset -f /org/gnome/shell/extensions/custom-command-list/` ✅
- Menu appears as ublue U at the leftmost panel position ✅

## Note on ostree upgrades from older deployments

Systems upgrading from older dakota images where `/etc/dconf/db/distro.d/05-dakota-custom-command-menu` has significantly different content (pre-`34e4dae`) may see ostree's 3-way merge retain the old `/etc` version. Manual fix if needed:
```bash
sudo cp /usr/share/gnome-shell/extensions/custom-command-list@storageb.github.com/05-dakota-custom-command-menu /etc/dconf/db/distro.d/05-dakota-custom-command-menu
sudo dconf update
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the custom command menu icon
  * Adjusted command list display to show a maximum of 11 items

<!-- end of auto-generated comment: release notes by coderabbit.ai -->