### PR TITLE
fix(renovate): rename managerFilePatterns to fileMatch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,7 +19,7 @@
     // Matches: bst2_image := env("BST2_IMAGE", "registry.../bst2:<sha>")  (Justfile)
     {
       "customType": "regex",
-      "managerFilePatterns": [
+      "fileMatch": [
         "/\\.github/workflows/build\\.yml$/",
         "/\\.github/workflows/track-bst-sources\\.yml$/",
         "/^Justfile$/"
@@ -36,7 +36,7 @@
     //          ref: <sha256>
     {
       "customType": "regex",
-      "managerFilePatterns": [
+      "fileMatch": [
         "/elements/plugins/.*\\.bst$/"
       ],
       "matchStrings": [
@@ -50,7 +50,7 @@
     // Matches: CHUNKAH_REF="quay.io/coreos/chunkah@sha256:<digest>"
     {
       "customType": "regex",
-      "managerFilePatterns": [
+      "fileMatch": [
         "/^Justfile$/"
       ],
       "matchStrings": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,7 +19,7 @@
     // Matches: bst2_image := env("BST2_IMAGE", "registry.../bst2:<sha>")  (Justfile)
     {
       "customType": "regex",
-      "fileMatch": [
+      "managerFilePatterns": [
         "/\\.github/workflows/build\\.yml$/",
         "/\\.github/workflows/track-bst-sources\\.yml$/",
         "/^Justfile$/"
@@ -36,7 +36,7 @@
     //          ref: <sha256>
     {
       "customType": "regex",
-      "fileMatch": [
+      "managerFilePatterns": [
         "/elements/plugins/.*\\.bst$/"
       ],
       "matchStrings": [
@@ -50,7 +50,7 @@
     // Matches: CHUNKAH_REF="quay.io/coreos/chunkah@sha256:<digest>"
     {
       "customType": "regex",
-      "fileMatch": [
+      "managerFilePatterns": [
         "/^Justfile$/"
       ],
       "matchStrings": [

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -18,6 +18,4 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Validate Renovate config
-        uses: suzuki-shunsuke/github-action-renovate-config-validator@ca480cb7ec89a9e1cd8c214ad33bda1617184027 # v2.0.0
-        with:
-          config_file_path: .github/renovate.json5
+        run: npx --yes --package renovate -- renovate-config-validator --strict


### PR DESCRIPTION
Renovate v37+ dropped `managerFilePatterns` in favour of `fileMatch`. All three `customManagers` were using the old field name, causing Renovate to halt with a config validation error (issue 325).

Validated with `renovate-config-validator`:
```
INFO: Config validated successfully
```

Closes #325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workflow validation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->