### PR TITLE
fix(chunkah): bump to v0.5.0 and fix Renovate tracking

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -47,17 +47,16 @@
     },
 
     // ── chunkah container image in Justfile ──
-    // Matches: CHUNKAH_REF="quay.io/coreos/chunkah@sha256:<digest>"
+    // Matches: CHUNKAH_REF="quay.io/coreos/chunkah:<tag>@sha256:<digest>"
     {
       "customType": "regex",
       "managerFilePatterns": [
         "/^Justfile$/"
       ],
       "matchStrings": [
-        "CHUNKAH_REF=\"(?<depName>quay\\.io/coreos/chunkah)@(?<currentDigest>sha256:[a-f0-9]{64})\""
+        "CHUNKAH_REF=\"(?<depName>quay\\.io/coreos/chunkah):(?<currentValue>v[^@]+)@(?<currentDigest>sha256:[a-f0-9]{64})\""
       ],
       "datasourceTemplate": "docker",
-      "currentValueTemplate": "latest"
     }
   ],
 

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -17,5 +17,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '24'
+
+      - name: Install renovate
+        run: npm install -g renovate
+
       - name: Validate Renovate config
-        run: npx --yes --package renovate -- renovate-config-validator --strict
+        run: renovate-config-validator --strict

--- a/Justfile
+++ b/Justfile
@@ -558,9 +558,9 @@ chunkify image_ref:
     # Run chunkah against the overlay (bind-mounted read-only).
     # --max-layers 120 balances layer granularity with registry storage space.
     # CHUNKAH_CONFIG_STR preserves OCI labels (containers.bootc=1).
-    # Image pinned from quay.io/coreos/chunkah:v0.4.0 (2026-05-02).
+    # chunkah image pinned by tag+digest for reproducibility
     # Pre-pull with retries so transient registry 5xx errors don't abort the run.
-    CHUNKAH_REF="quay.io/coreos/chunkah@sha256:faa8209f267fd1b384f3f4008a27ac0603333aab0d206bb146faf326282c64b4"
+    CHUNKAH_REF="quay.io/coreos/chunkah:v0.5.0@sha256:352097f3d32186ac11082f8b74cd544678b00388b50c96ba5c8e79503a454fe3"
     for attempt in 1 2 3; do
         $SUDO_CMD podman pull "$CHUNKAH_REF" && break
         echo "==> chunkah pull attempt $attempt failed, retrying in 10s..."


### PR DESCRIPTION
The Renovate regex manager requires a `currentValue` capture group — `currentValueTemplate` alone is silently discarded per [upstream docs](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/custom/regex/readme.md#required-capture-groups).

The previous digest-only format `chunkah@sha256:...` had no tag to capture, so Renovate never detected chunkah as a dependency.

**Changes:**
- `Justfile`: use `image:tag@digest` format (`chunkah:v0.5.0@sha256:...`), bump to v0.5.0
- `renovate.json5`: update `matchStrings` to capture `currentValue` from the semver tag, remove `currentValueTemplate`

After this merges, Renovate will detect chunkah in the Dependency Dashboard and open PRs for future releases automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded chunkah container image to v0.5.0 with an updated SHA256 digest.
  * Renovate configuration enhanced to recognize the newer image reference format and now runs a stricter validation step for configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->