### PR TITLE
feat: add document thumbnailers

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -21,6 +21,8 @@ depends:
 
   - bluefin/common.bst
   - bluefin/composefs-loop-udisks-ignore.bst
+  - bluefin/gnome-epub-thumbnailer.bst
+  - bluefin/papers-thumbnailer.bst
   - bluefin/wallpapers.bst
 
   - bluefin/jetbrains-mono.bst

--- a/elements/bluefin/gnome-epub-thumbnailer.bst
+++ b/elements/bluefin/gnome-epub-thumbnailer.bst
@@ -1,0 +1,17 @@
+kind: meson
+
+sources:
+- kind: git_repo
+  url: gnome:gnome-epub-thumbnailer.git
+  track: "1.8"
+  ref: 1.8-0-g64912a3a75a9dffd9db107d948336060837cc273
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+
+depends:
+- freedesktop-sdk.bst:components/libarchive.bst
+- freedesktop-sdk.bst:components/libxml2.bst
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+- gnome-build-meta.bst:sdk/gdk-pixbuf.bst
+- gnome-build-meta.bst:sdk/glib.bst

--- a/elements/bluefin/papers-thumbnailer.bst
+++ b/elements/bluefin/papers-thumbnailer.bst
@@ -1,0 +1,49 @@
+kind: manual
+
+build-depends:
+- gnome-build-meta.bst:core/papers.bst
+
+depends:
+- freedesktop-sdk.bst:components/lcms.bst
+- freedesktop-sdk.bst:components/libseccomp.bst
+- freedesktop-sdk.bst:components/poppler.bst
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+- gnome-build-meta.bst:core-deps/exempi.bst
+- gnome-build-meta.bst:core-deps/libspelling.bst
+- gnome-build-meta.bst:sdk/adwaita-icon-theme.bst
+- gnome-build-meta.bst:sdk/cairo.bst
+- gnome-build-meta.bst:sdk/gdk-pixbuf.bst
+- gnome-build-meta.bst:sdk/glib.bst
+- gnome-build-meta.bst:sdk/gtk.bst
+- gnome-build-meta.bst:sdk/libadwaita.bst
+- gnome-build-meta.bst:sdk/libsecret.bst
+- gnome-build-meta.bst:sdk/pango.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    install -Dm755 \
+      "%{bindir}/papers-thumbnailer" \
+      "%{install-root}%{bindir}/papers-thumbnailer"
+
+    install -Dm644 \
+      "%{datadir}/thumbnailers/papers.thumbnailer" \
+      "%{install-root}%{datadir}/thumbnailers/papers.thumbnailer"
+
+    install -Dm644 \
+      "%{mandir}/man1/papers-thumbnailer.1" \
+      "%{install-root}%{mandir}/man1/papers-thumbnailer.1"
+
+    mkdir -p \
+      "%{install-root}%{libdir}" \
+      "%{install-root}%{libdir}/papers/6/backends" \
+      "%{install-root}%{datadir}/metainfo"
+
+    cp -a "%{libdir}"/libppsdocument-4.0.so* "%{install-root}%{libdir}/"
+    cp -a "%{libdir}"/libppsview-4.0.so* "%{install-root}%{libdir}/"
+    cp -a "%{libdir}/papers/6/backends"/libpdfdocument.so "%{install-root}%{libdir}/papers/6/backends/"
+    cp -a "%{libdir}/papers/6/backends"/org.gnome.Papers.PdfDocument.papers-backend "%{install-root}%{libdir}/papers/6/backends/"
+    cp -a "%{datadir}/metainfo"/org.gnome.Papers.PdfDocument.metainfo.xml "%{install-root}%{datadir}/metainfo/"


### PR DESCRIPTION
## Description

Add `papers-thumbnailer` and `gnome-epub-thumbnailer` so Nautilus can generate thumbnails for PDFs and EPUBs.

Close #239

## Changes

- Add `bluefin/papers-thumbnailer.bst` as a split element that reuses GNOME Papers but installs only the host thumbnailer, thumbnailer metadata, and required Papers document libraries/backends. This one is kinda tricky as we ship Papers as flatpak, so I have to split it and only ship `papers-thumbnailer`. Feel free to leave any comments!
- Add `bluefin/gnome-epub-thumbnailer.bst` for EPUB/MOBI cover thumbnails.
- Include both thumbnailer elements in Bluefin dependencies.

## Type of Change

- [x] New feature

## Testing

- [x] `BST_FLAGS=--no-interactive just bst build bluefin/papers-thumbnailer.bst`
- [x] `BST_FLAGS=--no-interactive just bst build bluefin/gnome-epub-thumbnailer.bst`
- [x] `BST_FLAGS=--no-interactive just bst show --deps none bluefin/papers-thumbnailer.bst bluefin/gnome-epub-thumbnailer.bst bluefin/deps.bst core/meta-gnome-core-apps.bst`
- [x] Full image build and VM boot test

Assisted-by: GPT-5.5 via Zed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added thumbnail preview support for EPUB files
  * Added thumbnail preview support for Papers documents

* **Chores**
  * Updated build dependencies to include new thumbnailer components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->