### PR TITLE
feat(kernel): build with x86-64-v3 when project option enabled

### DIFF
--- a/patches/freedesktop-sdk/0013-linux-Build-kernel-with-x86-64-v3-when-option-enabled.patch
+++ b/patches/freedesktop-sdk/0013-linux-Build-kernel-with-x86-64-v3-when-option-enabled.patch
@@ -1,0 +1,29 @@
+From 79dd40d3f07f6ebda096f296cdc0ececdf17efb8 Mon Sep 17 00:00:00 2001
+From: Ahmed Adan <ahmed.adan@gmail.com>
+Date: Thu, 7 May 2026 20:52:05 -0400
+Subject: [PATCH] linux: Build kernel with x86-64-v3 when option enabled
+
+---
+ elements/components/linux.bst | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/elements/components/linux.bst b/elements/components/linux.bst
+index 1e1a755..f76f1a0 100644
+--- a/elements/components/linux.bst
++++ b/elements/components/linux.bst
+@@ -46,6 +46,12 @@ environment:
+   KBUILD_BUILD_TIMESTAMP: 'Thu Nov 10 15:00:00 UTC 2011'
+   KBUILD_BUILD_USER: 'tomjon'
+   MAXJOBS: "%{max-jobs}"
++  # arch/x86/Makefile hardcodes -march=x86-64 -mtune=generic, overriding
++  # gcc's --with-arch_64 default. KCFLAGS is appended after KBUILD_CFLAGS,
++  # so a later -march wins.
++  (?):
++  - x86_64_v3:
++      KCFLAGS: "-march=x86-64-v3 -mtune=skylake"
+ 
+ environment-nocache:
+ - MAXJOBS
+-- 
+2.54.0
+


### PR DESCRIPTION
Patches `freedesktop-sdk/elements/components/linux.bst` to inject `KCFLAGS="-march=x86-64-v3 -mtune=skylake"` into the kernel build environment when Dakota's `x86_64_v3` project option is set.

The x86_64_v3 option already configures GCC's compiled-in default to v3, which is enough for
userspace. But the kernel's arch/x86/Makefile hardcodes `-march=x86-64 -mtune=generic`, overriding GCC's default, so the kernel was being built for baseline x86-64 even when everything else was v3. `KCFLAGS` is appended after `KBUILD_CFLAGS` in the kernel's top-level Makefile, so a later `-march=` wins. While this works I'd like to have a discussion if there are more optimal ways forward than overriding the KFLAGS with a precedence hack.

I verified using `objdump -d vmlinux` on a build with the option enabled shows ~14k BMI2 instructions (`shlx`, `rorx`, `shrx`, `sarx`, `bzhi`, `mulx`, `pext`), and as far as my googlefoo and the clankers tell me these don't exist in baseline x86-64. With the option off, `KCFLAGS` is absent and the kernel reverts to baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added x86-64-v3 build option for Linux kernel compilation, enabling optimized builds for compatible x86-64 processors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->