### PR TITLE
Remove command-order from 05-dakota-custom-command-menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,20 @@ Some ISOs are duds, so here's an archive:
 <!-- iso-table-start -->
 | Date | ISO | Checksum |
 |------|-----|----------|
-| 2026-04-16 | [dakota-live-20260416-a7cd634.iso](https://projectbluefin.dev/dakota-live-20260416-a7cd634.iso) | [checksum](https://projectbluefin.dev/dakota-live-20260416-a7cd634.iso-CHECKSUM) |
-| 2026-04-16 | [dakota-live-20260416-fa525c1.iso](https://projectbluefin.dev/dakota-live-20260416-fa525c1.iso) | [checksum](https://projectbluefin.dev/dakota-live-20260416-fa525c1.iso-CHECKSUM) |
-| 2026-04-15 | [dakota-live-20260415-fa525c1.iso](https://projectbluefin.dev/dakota-live-20260415-fa525c1.iso) | [checksum](https://projectbluefin.dev/dakota-live-20260415-fa525c1.iso-CHECKSUM) |
-| 2026-04-15 | [dakota-live-20260415-c28ffaf.iso](https://projectbluefin.dev/dakota-live-20260415-c28ffaf.iso) | [checksum](https://projectbluefin.dev/dakota-live-20260415-c28ffaf.iso-CHECKSUM) |
-| 2026-04-14 | [dakota-live-20260414-c28ffaf.iso](https://projectbluefin.dev/dakota-live-20260414-c28ffaf.iso) | [checksum](https://projectbluefin.dev/dakota-live-20260414-c28ffaf.iso-CHECKSUM) |
-| 2026-04-13 | [dakota-live-20260413-c28ffaf.iso](https://projectbluefin.dev/dakota-live-20260413-c28ffaf.iso) | [checksum](https://projectbluefin.dev/dakota-live-20260413-c28ffaf.iso-CHECKSUM) |
-| 2026-04-13 | [dakota-live-20260413-9b9756e.iso](https://projectbluefin.dev/dakota-live-20260413-9b9756e.iso) | [checksum](https://projectbluefin.dev/dakota-live-20260413-9b9756e.iso-CHECKSUM) |
+| 2026-05-09 | [dakota-nvidia-live-20260509-3059a71.iso](https://projectbluefin.dev/dakota-nvidia-live-20260509-3059a71.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260509-3059a71.iso-CHECKSUM) |
+| 2026-05-08 | [dakota-nvidia-live-20260508-3059a71.iso](https://projectbluefin.dev/dakota-nvidia-live-20260508-3059a71.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260508-3059a71.iso-CHECKSUM) |
+| 2026-05-07 | [dakota-live-20260507-3059a71.iso](https://projectbluefin.dev/dakota-live-20260507-3059a71.iso) | [checksum](https://projectbluefin.dev/dakota-live-20260507-3059a71.iso-CHECKSUM) |
+| 2026-05-07 | [dakota-nvidia-live-20260507-b00fb97.iso](https://projectbluefin.dev/dakota-nvidia-live-20260507-b00fb97.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260507-b00fb97.iso-CHECKSUM) |
+| 2026-05-06 | [dakota-live-20260506-b00fb97.iso](https://projectbluefin.dev/dakota-live-20260506-b00fb97.iso) | [checksum](https://projectbluefin.dev/dakota-live-20260506-b00fb97.iso-CHECKSUM) |
+| 2026-05-05 | [dakota-nvidia-live-20260505-b00fb97.iso](https://projectbluefin.dev/dakota-nvidia-live-20260505-b00fb97.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260505-b00fb97.iso-CHECKSUM) |
+| 2026-05-04 | [dakota-nvidia-live-20260504-b00fb97.iso](https://projectbluefin.dev/dakota-nvidia-live-20260504-b00fb97.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260504-b00fb97.iso-CHECKSUM) |
+| 2026-05-03 | [dakota-nvidia-live-20260503-6661b18.iso](https://projectbluefin.dev/dakota-nvidia-live-20260503-6661b18.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260503-6661b18.iso-CHECKSUM) |
+| 2026-05-02 | [dakota-nvidia-live-20260502-6661b18.iso](https://projectbluefin.dev/dakota-nvidia-live-20260502-6661b18.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260502-6661b18.iso-CHECKSUM) |
+| 2026-05-02 | [dakota-nvidia-live-20260502-029e632.iso](https://projectbluefin.dev/dakota-nvidia-live-20260502-029e632.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260502-029e632.iso-CHECKSUM) |
+| 2026-05-01 | [dakota-nvidia-live-20260501-029e632.iso](https://projectbluefin.dev/dakota-nvidia-live-20260501-029e632.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260501-029e632.iso-CHECKSUM) |
+| 2026-05-01 | [dakota-nvidia-live-20260501-c961e9c.iso](https://projectbluefin.dev/dakota-nvidia-live-20260501-c961e9c.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260501-c961e9c.iso-CHECKSUM) |
+| 2026-04-21 | [dakota-live-20260421-87f2aff.iso](https://projectbluefin.dev/dakota-live-20260421-87f2aff.iso) | [checksum](https://projectbluefin.dev/dakota-live-20260421-87f2aff.iso-CHECKSUM) |
+| 2026-04-20 | [dakota-live-20260420-87f2aff.iso](https://projectbluefin.dev/dakota-live-20260420-87f2aff.iso) | [checksum](https://projectbluefin.dev/dakota-live-20260420-87f2aff.iso-CHECKSUM) |
 <!-- iso-table-end -->
 
 ## Goals

--- a/files/dconf/05-dakota-custom-command-menu
+++ b/files/dconf/05-dakota-custom-command-menu
@@ -14,7 +14,6 @@ menuoptions-setting=2
 menuicon-setting='ublue-logo-symbolic'
 menulocation-setting=1
 menuposition-setting=0
-command-order=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
 command1=('---$(hostname)', '', '', true)
 command2=('About', 'gnome-control-center system about', '', true)
 command3=('System Monitor', '/usr/bin/flatpak run io.missioncenter.MissionCenter', '', true)


### PR DESCRIPTION
This commit https://github.com/projectbluefin/dakota/commit/031b62f90af7cec1574d2b17cea899147e9de4f0 reset `command-order` back to 1-11 reintroducing this issue https://github.com/projectbluefin/dakota/issues/331 where the extension expects `command-order` to contain 99 values (the number of entries allowed by the extension).

Instead of adding 1-99 back to this file, I believe we can just remove `command-order` entirely and allow it to use the default schema values where it is defined as 1-99.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined the custom command menu configuration by removing redundant ordering entries while preserving behavior.

* **Documentation**
  * Updated the README’s ISO Archive table: removed older entries and added new ISO listings (dated early May 2026) with updated checksum links.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/416)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->