### PR TITLE
revert: "chore(deps): update gnome-build-meta junction: 50.1-9 -> 50.1-11"

### DIFF
--- a/elements/gnome-build-meta.bst
+++ b/elements/gnome-build-meta.bst
@@ -4,7 +4,7 @@ sources:
 - kind: git_repo
   url: gnome:gnome-build-meta.git
   track: gnome-50
-  ref: 50.1-11-gc374cf8b52f648dfbdeadf53f1e842a482846994
+  ref: 50.1-9-g57d59abc449d1e160fb6797c02f2c1b8ab04d241
 - kind: patch_queue
   path: patches/gnome-build-meta
 


### PR DESCRIPTION
Reverts projectbluefin/dakota#382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated upstream component tracking reference to point to a newer revision, ensuring the build system sources the correct version of upstream dependencies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/422)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->