### PR TITLE
fix(ci): atomic junction tracking + block Renovate from pinning dakot…

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -61,6 +61,14 @@
   ],
 
   "packageRules": [
+    // ── projectbluefin bootstrap images — always :latest, never pin ──
+    // All ghcr.io/projectbluefin/* images are self-referential; digest-pinning is wrong.
+    // This rule must stay first so it is not overridden by the automerge catch-all below.
+    {
+      "matchDepPatterns": ["^ghcr\.io/projectbluefin/"],
+      "enabled": false
+    },
+
     // ── Auto-merge: all dependency updates managed by this repo config ──
     {
       "automerge": true,

--- a/.github/workflows/track-bst-sources.yml
+++ b/.github/workflows/track-bst-sources.yml
@@ -14,6 +14,7 @@ on:
           - all
           - auto-merge
           - manual-merge
+          - core-junctions
           - tarballs
 
 permissions: read-all
@@ -88,15 +89,10 @@ jobs:
             element: bluefin/nautilus-python.bst
             branch: auto/track-nautilus-python
             title: "chore(deps): update nautilus-python"
-          # ── manual-merge: core junctions ──
-          - group: manual-merge
-            element: gnome-build-meta.bst
-            branch: auto/track-gnome-build-meta
-            title: "chore(deps): update gnome-build-meta junction"
-          - group: manual-merge
-            element: freedesktop-sdk.bst
-            branch: auto/track-freedesktop-sdk
-            title: "chore(deps): update freedesktop-sdk junction"
+          # ── manual-merge: non-junction elements ──
+          # Core junctions (freedesktop-sdk + gnome-build-meta) are tracked atomically
+          # by the separate track-core-junctions job. Use group=core-junctions to
+          # trigger that job manually.
           - group: manual-merge
             element: gnomeos-deps/bootc.bst
             branch: auto/track-bootc
@@ -783,3 +779,62 @@ jobs:
             PR_URL=$(gh pr create --base main --head "$BRANCH" --title "$TITLE" --body-file /tmp/pr-body.md)
           fi
           echo "PR: $PR_URL"
+
+  # ── Atomic co-tracking of core junctions ──────────────────────────────────
+  # freedesktop-sdk.bst overrides reference gnome-build-meta.bst elements directly.
+  # Both must land in one commit. No auto-merge — requires human review.
+  track-core-junctions:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    if: >-
+      github.event.inputs.group == 'all' ||
+      github.event.inputs.group == 'core-junctions' ||
+      github.event_name == 'schedule'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Just
+        uses: taiki-e/install-action@ec28e287910af896fd98e04056d31fa68607e7ad # v2
+        with:
+          tool: just
+
+      - name: Pull BuildStream container image
+        run: podman pull "$BST2_IMAGE"
+
+      - name: Track both core junctions
+        run: |
+          just bst --no-interactive source track gnome-build-meta.bst
+          just bst --no-interactive source track freedesktop-sdk.bst
+
+      - name: Create or update PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git diff --quiet && { echo "No junction updates"; exit 0; }
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B auto/track-core-junctions origin/main
+          git add elements/gnome-build-meta.bst elements/freedesktop-sdk.bst
+          git commit -m "chore(deps): update core junctions (gnome-build-meta + freedesktop-sdk)"
+          git push --force-with-lease origin auto/track-core-junctions
+
+          EXISTING=$(gh pr list --head auto/track-core-junctions --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$EXISTING" ]; then
+            PR_URL=$(gh pr view "$EXISTING" --json url --jq '.url')
+            echo "Existing PR: $PR_URL"
+          else
+            PR_URL=$(gh pr create \
+              --base main \
+              --head auto/track-core-junctions \
+              --title "chore(deps): update core junctions (gnome-build-meta + freedesktop-sdk)" \
+              --body "Updates \`gnome-build-meta.bst\` and \`freedesktop-sdk.bst\` atomically. Manual review required — junction bumps can break downstream elements.")
+            echo "PR: $PR_URL"
+          fi


### PR DESCRIPTION
…a image

- track-bst-sources: remove separate gnome-build-meta and freedesktop-sdk matrix rows; add track-core-junctions job that tracks both in one run step and commits them atomically to auto/track-core-junctions
- renovate: disable updates for ghcr.io/projectbluefin/* images; the Containerfile FROM is self-referential and must stay :latest

Assisted-by: claude-sonnet-4-5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to disable automatic updates for dependencies under a specific registry.
  * Modified build source tracking workflow to separate core junction tracking into a dedicated job that requires manual review instead of automatic merging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/425)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->