### PR TITLE
ci: add validate job, move full build off PRs, drop Blacksmith

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,27 +22,81 @@ env:
   IMAGE_NAME: dakota
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
-# Concurrency: serialize builds to avoid saturating cache.projectbluefin.io.
-# - PR builds all share one global slot ("pr") so only one PR build runs at
-#   a time; additional PR builds queue and run in order. Running builds are
-#   never cancelled (cancel-in-progress: false), so every PR completes its
-#   checks. A pending-but-not-yet-started run is replaced if a new one arrives.
-# - Scheduled/merge_group/dispatch use per-ref isolation so concurrent runs
-#   for the same ref queue rather than stomp each other.
+# Concurrency: per-ref isolation for all events.
+# - PRs: each PR gets its own slot (validate job only — no AX102-U usage).
+#   cancel-in-progress: true on the validate job cancels stale runs on push.
+# - merge_group / schedule / dispatch: per-ref queuing, never cancelled, so
+#   every build that enters the merge queue completes its check.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && 'pr' || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  build:
+  # ── Fast PR validation ───────────────────────────────────────────────────
+  # Fires only on pull_request. Runs bst show on the full element graph for
+  # both variants. Zero remote-execution — does not touch cache.projectbluefin.io.
+  # Expected runtime: <15 min (BST cache hit), <30 min (cold start).
+  validate:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
-    # Variant matrix: the default Bluefin image and the NVIDIA variant build
-    # in parallel for scheduled/merge_group/dispatch. On pull_request, run
-    # sequentially (max-parallel: 1) so only one BST session at a time uses
-    # the remote execution server.
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    concurrency:
+      group: ${{ github.workflow }}-validate-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check bst2 image pin consistency
+        run: |
+          just_sha="$(grep -oE 'bst2:[a-f0-9]{40}' Justfile | cut -d: -f2)"
+          track_sha="$(grep -oE 'bst2:[a-f0-9]{40}' .github/workflows/track-bst-sources.yml | cut -d: -f2)"
+          if [[ -z "$just_sha" || -z "$track_sha" ]]; then
+            echo "ERROR: could not find bst2 SHA (Justfile: '${just_sha:-missing}', track-bst-sources.yml: '${track_sha:-missing}')"; exit 1
+          fi
+          [[ "$just_sha" == "$track_sha" ]] || { echo "ERROR: bst2 pin drift — Justfile: $just_sha  track-bst-sources.yml: $track_sha"; exit 1; }
+          echo "OK: bst2 pins consistent: $just_sha"
+
+      - name: Setup Just
+        uses: taiki-e/install-action@e1c4cd42111751368541a7cb5db3522bd1f846a4 # v2
+        with:
+          tool: just
+
+      # Cache the BST workspace (junction git sources + bst2 container layers).
+      # Key includes junction element refs so junction bumps start fresh.
+      # Without this, bst show must clone gnome-build-meta + freedesktop-sdk
+      # from scratch on every PR run (~15-25 min extra).
+      - name: Restore BST cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/buildstream
+          key: bst-show-${{ hashFiles('elements/gnome-build-meta.bst', 'elements/freedesktop-sdk.bst', 'Justfile') }}
+          restore-keys: bst-show-
+
+      - name: Validate BST element graph (default)
+        env:
+          BST_FLAGS: -o x86_64_v3 true --no-interactive
+        run: just bst show --deps all oci/bluefin.bst
+
+      - name: Validate BST element graph (nvidia)
+        env:
+          BST_FLAGS: -o x86_64_v3 true --no-interactive
+        run: just bst show --deps all oci/bluefin-nvidia.bst
+
+  # ── Full OCI build ────────────────────────────────────────────────────────
+  # Fires on merge_group, schedule, and workflow_dispatch — NOT on pull_request.
+  # PRs are validated by the validate job above; the full build is the
+  # merge-queue gate. This keeps cache.projectbluefin.io free from PR traffic.
+  build:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    # Both variants build in parallel. NVIDIA is continue-on-error so its
+    # failure does not block the default image's merge or publication.
     strategy:
       fail-fast: false
-      max-parallel: ${{ github.event_name == 'pull_request' && 1 || 2 }}
+      max-parallel: 2
       matrix:
         include:
           - variant: default
@@ -116,7 +170,6 @@ jobs:
       #
       - name: Generate BuildStream CI config
         env:
-          EVENT_NAME: ${{ github.event_name }}
           CASD_CLIENT_CERT: ${{ vars.CASD_CLIENT_CERT }}
           CASD_CLIENT_KEY: ${{ secrets.CASD_CLIENT_KEY }}
         run: |
@@ -145,14 +198,8 @@ jobs:
             cat >> buildstream-ci.conf <<'BSTCONFPUSH'
           build:
             retry-failed: True
+            max-jobs: 32
           BSTCONFPUSH
-            # Limit remote-exec parallelism on PRs: one PR build at a time on
-            # the buildbox, so use 8 jobs instead of 32 to leave headroom.
-            if [[ "$EVENT_NAME" == "pull_request" ]]; then
-              echo "  max-jobs: 8" >> buildstream-ci.conf
-            else
-              echo "  max-jobs: 32" >> buildstream-ci.conf
-            fi
           else
             cat >> buildstream-ci.conf <<'BSTCONFNOPUSH'
           build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,8 @@ concurrency:
 
 jobs:
   publish:
-    runs-on: ${{ (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'schedule') && 'ubuntu-24.04' || 'blacksmith-4vcpu-ubuntu-2404' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
     # Variant matrix: default and NVIDIA publish in parallel from the shared
     # BST artifact cache. NVIDIA is `continue-on-error: true` so its failure
     # does not block default publication.


### PR DESCRIPTION
Ok let's just validate on PR because what we have now sucks. I like the idea of reviewers just building the PRs locally before approval. 

Agent notes:

- Add validate job (pull_request only): bst show --deps all on both variants inside bst2 container. Zero remote-execution — no AX102-U usage on PR events. BST cache keyed on junction element refs avoids cold junction git clones on most runs.

- Move full build off pull_request: build job now fires only on merge_group, schedule, and workflow_dispatch. merge_group is the correct gate for the AX102-U-backed full build.

- Remove PR-specific dead code: EVENT_NAME env var, max-jobs: 8 vs 32 ternary, max-parallel: 1 vs 2 ternary. All three were only needed to protect the buildbox from PR saturation — now unnecessary.

- Simplify workflow concurrency: drop pull_request && 'pr' ternary. Each ref gets its own slot. validate job uses cancel-in-progress: true so stale PR runs are cancelled on new pushes.

- publish.yml: drop Blacksmith runner (blacksmith-4vcpu-ubuntu-2404) in favour of ubuntu-24.04 free runners. Publish is network-bound (CAS fetch, GHCR push, cosign, oras) — no heavy compute. The schedule path already runs successfully on ubuntu-24.04. Add timeout-minutes: 90 (no ceiling existed before).

Assisted-by: claude-sonnet-4-5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* **CI/CD Improvements**
  * Updated GitHub Actions workflows to improve build and publish reliability.
  * Pull requests now execute a dedicated validation step with dependency checking.
  * Build jobs now have optimized parallelism settings and clearer execution paths.
  * Publish job now runs on consistent infrastructure with explicit timeout configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/437)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->