### PR TITLE
ci: fix timeout ceiling, cancel-on-push, redundant step guard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,13 +23,13 @@ env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 # Concurrency: per-ref isolation for all events.
-# - PRs: each PR gets its own slot (validate job only — no AX102-U usage).
-#   cancel-in-progress: true on the validate job cancels stale runs on push.
-# - merge_group / schedule / dispatch: per-ref queuing, never cancelled, so
-#   every build that enters the merge queue completes its check.
+# - PRs: cancel-in-progress: true drops stale validate runs when a new
+#   push arrives. Safe for other events — merge_group/schedule/dispatch
+#   each use distinct refs and are unaffected by this flag.
+# - merge_group / schedule / dispatch: per-ref queuing, never cancelled.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # ── Fast PR validation ───────────────────────────────────────────────────
@@ -92,6 +92,7 @@ jobs:
   build:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
+    timeout-minutes: 360
     # Both variants build in parallel. NVIDIA is continue-on-error so its
     # failure does not block the default image's merge or publication.
     strategy:
@@ -284,14 +285,13 @@ jobs:
           BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
         run: |
           just bst build ${{ matrix.element }}
-        timeout-minutes: 420
+        timeout-minutes: 330
 
       # Push the built artifact to the remote CAS so the export job can pull it.
       # Remote execution may populate the artifact cache implicitly, but an
       # explicit push guarantees the artifact is there regardless of BST internals.
       # Push both variants so publish.yml can fetch each from CAS.
       - name: Push OCI artifact to remote CAS
-        if: github.event_name != 'pull_request'
         env:
           BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
         run: |


### PR DESCRIPTION
Three QA-audit findings from post-merge review of #437.

## Changes

**1. Job-level `timeout-minutes: 360` on `build` job (Critical)**
GitHub's hard maximum for hosted runners is 6 hours (360 min). The previous step-level `timeout-minutes: 420` was unreachable — GitHub terminates the job first with a generic `exceeded maximum execution time` message. Step timeout reduced to 330 min to leave headroom for setup steps within the 6-hour ceiling.

**2. `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` (Warning)**
Workflow-level `cancel-in-progress: false` prevented the `validate` job's own `cancel-in-progress: true` from ever firing — two jobs in the same concurrency group can only be simultaneous if the workflow-level gate allows it. The expression guards non-PR events: `merge_group` and `schedule` use different refs and are unaffected.

**3. Remove redundant step-level `if` on `Push OCI artifact to remote CAS` (Warning)**
The containing `build` job already has `if: github.event_name != 'pull_request'`. The step condition was always true and implied protective guarding that wasn't there.

## Not in scope
Latent bugs in disabled `build-aarch64` (`if: false`) are tracked separately — wrong BTRFS/remove-unwanted-software step order and missing bst2 pin check. These will need fixing before ARM builds are re-enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to optimize job timeout settings and refine concurrency behavior for pull request runs.

*Note: This release contains no user-facing changes.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/438)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->