### PR TITLE
ci: filter publish workflow_run trigger to main and merge queue branches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
   workflow_run:
     workflows: ["Build Bluefin dakota"]
     types: [completed]
+    branches:
+      - main
+      - 'gh-readonly-queue/main/**'
 
 env:
   IMAGE_NAME: dakota


### PR DESCRIPTION
Publish was firing on every `workflow_run` completion of `Build Bluefin dakota` — including PR validate runs (now frequent since the mergeraptor fix) — resulting in publish jobs that immediately skip on the job-level `if:` condition. All 10 most recent publish runs were `skipped`.

Add a `branches` filter to the `workflow_run` trigger. GitHub evaluates this against the triggering workflow's `head_branch`, so only builds on `main` (nightly schedule) and `gh-readonly-queue/main/**` (merge queue) will fire publish. PR branches never trigger it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to refine deployment trigger conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/442)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->