### PR TITLE
ci: automated GitHub releases with SBOM-diffed release card

### DIFF
--- a/.github/scripts/render_card.py
+++ b/.github/scripts/render_card.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""
+render_card.py — Generate release card PNGs (light + dark) and release notes
+markdown from a versions.json produced by sbom_diff.py.
+
+Usage:
+    python3 render_card.py \
+        --versions versions.json \
+        --sha      2294ec1abc1234567890abcd \
+        --sha7     2294ec1 \
+        --date     2026-05-14 \
+        --tag      2026-05-14-2294ec1 \
+        --repo     projectbluefin/dakota \
+        --output-light release-card-light.png \
+        --output-dark  release-card-dark.png \
+        --release-notes release-notes.md
+"""
+import argparse
+import json
+import os
+import sys
+import html
+import tempfile
+import textwrap
+from pathlib import Path
+
+# ── HTML card template ────────────────────────────────────────────────────────
+# Self-contained: no external resources, no web fonts.
+# Dakota accent: #7c3aed (purple), matching OsReleaseCard.module.css .cardDakota.
+# Rendered at 840 px wide; Playwright crops to .release-card bounding box.
+
+CARD_HTML = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=840">
+<style>
+*, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
+
+/* ── Light theme ── */
+:root {{
+  --bg:        #ffffff;
+  --bg-card:   #f9fafb;
+  --border:    #e5e7eb;
+  --accent:    #7c3aed;
+  --text:      #111827;
+  --text-muted:#6b7280;
+  --chip-bg:   #f3f4f6;
+  --chip-label:#6b7280;
+  --chip-val:  #111827;
+  --changed-bg:#fdf4ff;
+  --changed-border:#c084fc;
+  --changed-val:#7c3aed;
+  --arrow:     #9ca3af;
+  --diff-add:  #059669;
+  --diff-chg:  #7c3aed;
+  --diff-rem:  #dc2626;
+  --tag-bg:    #f3f4f6;
+}}
+/* ── Dark theme ── */
+@media (prefers-color-scheme: dark) {{
+  :root {{
+    --bg:        #0f172a;
+    --bg-card:   #1e293b;
+    --border:    #334155;
+    --accent:    #a78bfa;
+    --text:      #f1f5f9;
+    --text-muted:#94a3b8;
+    --chip-bg:   #334155;
+    --chip-label:#94a3b8;
+    --chip-val:  #f1f5f9;
+    --changed-bg:#2e1065;
+    --changed-border:#7c3aed;
+    --changed-val:#c084fc;
+    --arrow:     #64748b;
+    --diff-add:  #34d399;
+    --diff-chg:  #a78bfa;
+    --diff-rem:  #f87171;
+    --tag-bg:    #1e293b;
+  }}
+}}
+
+body {{
+  background: var(--bg);
+  padding: 16px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+               Helvetica, Arial, sans-serif;
+}}
+
+/* ── Card shell ── */
+.release-card {{
+  background:    var(--bg-card);
+  border:        1px solid var(--border);
+  border-left:   3px solid var(--accent);
+  border-radius: 12px;
+  padding:       20px 24px 16px;
+  max-width:     800px;
+}}
+
+/* ── Header ── */
+.card-header {{
+  display:        flex;
+  align-items:    flex-start;
+  justify-content:space-between;
+  margin-bottom:  14px;
+}}
+.card-title {{
+  font-size:   1.25rem;
+  font-weight: 700;
+  color:       var(--accent);
+  line-height: 1.2;
+  margin-bottom: 4px;
+}}
+.card-meta {{
+  display:    flex;
+  align-items:center;
+  gap:        10px;
+  flex-wrap:  wrap;
+}}
+.card-tag {{
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size:   0.8rem;
+  color:       var(--text-muted);
+  background:  var(--tag-bg);
+  padding:     2px 8px;
+  border-radius: 6px;
+}}
+.card-date {{
+  font-size:  0.8rem;
+  color:      var(--text-muted);
+}}
+.card-badge {{
+  font-size:    0.65rem;
+  font-weight:  700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding:      2px 9px;
+  border-radius:999px;
+  background:   rgba(124,58,237,0.12);
+  color:        var(--accent);
+}}
+
+/* ── Version chips ── */
+.chips-row {{
+  display:   flex;
+  flex-wrap: wrap;
+  gap:       6px;
+  margin-bottom: 12px;
+}}
+.chip {{
+  display:       inline-flex;
+  align-items:   center;
+  border-radius: 6px;
+  overflow:      hidden;
+  border:        1px solid var(--border);
+  font-size:     0.78rem;
+  line-height:   1;
+}}
+.chip.changed {{
+  border-color: var(--changed-border);
+  background:   var(--changed-bg);
+}}
+.chip-label {{
+  background: var(--chip-bg);
+  color:      var(--chip-label);
+  padding:    5px 7px;
+  font-weight:500;
+}}
+.chip-value {{
+  background: transparent;
+  color:      var(--chip-val);
+  padding:    5px 7px;
+  font-weight:600;
+}}
+.chip.changed .chip-value {{
+  color: var(--changed-val);
+}}
+.chip-arrow {{
+  color:      var(--accent);
+  padding:    5px 3px 5px 0;
+  font-size:  0.65rem;
+  font-weight:700;
+}}
+.chip-prev {{
+  color:      var(--text-muted);
+  font-size:  0.72rem;
+  padding:    5px 6px 5px 0;
+  text-decoration:line-through;
+}}
+
+/* ── Diff summary bar ── */
+.diff-bar {{
+  display:     flex;
+  gap:         14px;
+  font-size:   0.8rem;
+  color:       var(--text-muted);
+  margin-bottom:12px;
+  padding:     8px 12px;
+  background:  var(--chip-bg);
+  border-radius:8px;
+}}
+.diff-changed {{ color: var(--diff-chg); font-weight:600; }}
+.diff-added   {{ color: var(--diff-add); font-weight:600; }}
+.diff-removed {{ color: var(--diff-rem); font-weight:600; }}
+
+/* ── Footer ── */
+.card-footer {{
+  display:    flex;
+  align-items:center;
+  justify-content:space-between;
+  margin-top: 10px;
+  padding-top:10px;
+  border-top: 1px solid var(--border);
+  font-size:  0.78rem;
+  color:      var(--text-muted);
+}}
+.card-footer a {{
+  color:           var(--accent);
+  text-decoration: none;
+  font-weight:     500;
+}}
+.image-ref {{
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size:   0.72rem;
+}}
+</style>
+</head>
+<body>
+<div class="release-card">
+
+  <div class="card-header">
+    <div>
+      <div class="card-title">Bluefin Dakota</div>
+      <div class="card-meta">
+        <span class="card-tag">{tag}</span>
+        <span class="card-date">{date_long}</span>
+        <span class="card-badge">Alpha</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="chips-row">
+{chips_html}
+  </div>
+
+{diff_bar_html}
+  <div class="card-footer">
+    <span class="image-ref">ghcr.io/projectbluefin/dakota:{sha7}</span>
+    <a href="https://docs.projectbluefin.io/changelogs">docs.projectbluefin.io/changelogs →</a>
+  </div>
+
+</div>
+</body>
+</html>
+"""
+
+# ── Chip rendering ────────────────────────────────────────────────────────────
+
+def render_chip(pkg: dict) -> str:
+    label   = pkg["name"]
+    version = pkg["version"]
+    prev    = pkg.get("prev")
+    changed = pkg.get("changed", False)
+
+    changed_class = " changed" if changed else ""
+    prev_html = ""
+    arrow_html = ""
+    if changed and prev:
+        prev_html  = f'    <span class="chip-prev">{html.escape(prev)}</span>\n'
+        arrow_html = '    <span class="chip-arrow">↑</span>\n'
+
+    return (
+        f'    <span class="chip{changed_class}">\n'
+        f'      <span class="chip-label">{html.escape(label)}</span>\n'
+        f'{prev_html}'
+        f'{arrow_html}'
+        f'      <span class="chip-value">{html.escape(version)}</span>\n'
+        f'    </span>'
+    )
+
+
+def render_diff_bar(diff: dict, has_prev: bool) -> str:
+    if not has_prev:
+        return ""
+    parts = []
+    if diff["changed_count"]:
+        parts.append(
+            f'<span class="diff-changed">↑ {diff["changed_count"]} updated</span>'
+        )
+    if diff["added_count"]:
+        parts.append(
+            f'<span class="diff-added">+ {diff["added_count"]} added</span>'
+        )
+    if diff["removed_count"]:
+        parts.append(
+            f'<span class="diff-removed">− {diff["removed_count"]} removed</span>'
+        )
+    if not parts:
+        parts.append('<span>No package changes since last release</span>')
+    items = "\n    ".join(parts)
+    return f'  <div class="diff-bar">\n    {items}\n  </div>\n'
+
+
+def build_html(versions: dict, sha7: str, tag: str, date: str) -> str:
+    from datetime import datetime
+    dt = datetime.strptime(date, "%Y-%m-%d")
+    date_long = dt.strftime("%B %-d, %Y")
+
+    chips_html = "\n".join(render_chip(p) for p in versions["notable"])
+    diff_bar_html = render_diff_bar(versions["diff"], versions["has_prev"])
+
+    return CARD_HTML.format(
+        tag=tag,
+        date_long=date_long,
+        sha7=sha7,
+        chips_html=chips_html,
+        diff_bar_html=diff_bar_html,
+    )
+
+
+# ── Playwright screenshot ─────────────────────────────────────────────────────
+
+def screenshot(html_path: str, output_path: str) -> None:
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        ctx = browser.new_context(
+            viewport={"width": 840, "height": 600},
+            device_scale_factor=2,
+            color_scheme="light",
+        )
+        page = ctx.new_page()
+        page.goto(f"file://{os.path.abspath(html_path)}")
+        page.wait_for_load_state("networkidle")
+        card = page.locator(".release-card").first
+        card.screenshot(path=output_path)
+        browser.close()
+
+    print(f"  Screenshot: {output_path}")
+
+
+# ── Release notes markdown ────────────────────────────────────────────────────
+
+def build_release_notes(
+    versions: dict,
+    sha: str,
+    sha7: str,
+    tag: str,
+    date: str,
+    repo: str,
+) -> str:
+    image_ref   = f"ghcr.io/{repo.split('/')[0]}/dakota"
+    cert_regexp = (
+        rf"^https://github\.com/{repo}/\.github/workflows/publish\.yml"
+        r"@refs/heads/(main|gh-readonly-queue/main/.+)$"
+    )
+
+    # Diff summary line
+    diff = versions["diff"]
+    has_prev = versions["has_prev"]
+    if has_prev:
+        parts = []
+        if diff["changed_count"]:
+            parts.append(f"{diff['changed_count']} updated")
+        if diff["added_count"]:
+            parts.append(f"{diff['added_count']} added")
+        if diff["removed_count"]:
+            parts.append(f"{diff['removed_count']} removed")
+        diff_line = (
+            f"**{', '.join(parts)}** packages since last release."
+            if parts else "No package changes since last release."
+        )
+    else:
+        diff_line = "First automated release — no previous baseline."
+
+    # Notable versions table
+    rows = "\n".join(
+        f"| {p['name']} | `{p['version']}`"
+        + (f" | `{p['prev']}` → `{p['version']}`" if p.get("changed") and p.get("prev") else " | —")
+        + " |"
+        for p in versions["notable"]
+    )
+
+    # Build lines with no leading whitespace — 4-space indent renders as code in GitHub MD
+    L = [
+        f"![Bluefin Dakota {tag}](https://github.com/{repo}/releases/download/{tag}/release-card.png)",
+        "",
+        diff_line,
+        "",
+        "## Key component versions",
+        "",
+        "| Component | Version | Change |",
+        "|---|---|---|",
+        *rows.splitlines(),
+        "",
+        "## Images",
+        "",
+        "```",
+        f"ghcr.io/{repo.split('/')[0]}/dakota:latest",
+        f"ghcr.io/{repo.split('/')[0]}/dakota:{sha}",
+        "```",
+        "",
+        "## Verify your image",
+        "",
+        "```bash",
+        "# Requires: cosign  oras  gh",
+        "# Install via Homebrew: brew install cosign oras gh",
+        "",
+        "# 1. Cosign keyless signature",
+        "cosign verify \\",
+        f"  --certificate-identity-regexp '{cert_regexp}' \\",
+        "  --certificate-oidc-issuer https://token.actions.githubusercontent.com \\",
+        f"  {image_ref}:{sha}",
+        "",
+        "# 2. SBOM OCI referrer",
+        f"oras discover {image_ref}:{sha}",
+        "",
+        "# 3. SLSA provenance",
+        f"gh attestation verify oci://{image_ref}:{sha} \\",
+        f"  --repo {repo}",
+        "",
+        "# Or all three at once (requires dakota checkout):",
+        f"just verify {image_ref}:{sha}",
+        "```",
+        "",
+        "## Supply chain",
+        "",
+        f"- **SBOM (SPDX 2.3):** [`dakota.spdx.json`](https://github.com/{repo}/releases/download/{tag}/dakota.spdx.json) attached below",
+        "- **Cosign:** keyless, Sigstore OIDC via GitHub Actions",
+        f"- **SLSA provenance:** `gh attestation verify oci://{image_ref}:{sha} --repo {repo}`",
+        "",
+        "Full changelog → https://docs.projectbluefin.io/changelogs",
+    ]
+    notes = "\n".join(L) + "\n"
+
+
+    return notes
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--versions",       required=True)
+    ap.add_argument("--sha",            required=True)
+    ap.add_argument("--sha7",           required=True)
+    ap.add_argument("--date",           required=True)
+    ap.add_argument("--tag",            required=True)
+    ap.add_argument("--repo",           required=True)
+    ap.add_argument("--output",         default="release-card.png")
+    ap.add_argument("--release-notes",  default="release-notes.md")
+    args = ap.parse_args()
+
+    with open(args.versions, encoding="utf-8") as f:
+        versions = json.load(f)
+
+    html = build_html(versions, args.sha7, args.tag, args.date)
+
+    with tempfile.NamedTemporaryFile(
+        suffix=".html", mode="w", delete=False, dir="."
+    ) as tmp:
+        tmp.write(html)
+        html_path = tmp.name
+
+    try:
+        print("Rendering release card...")
+        screenshot(html_path, args.output)
+    finally:
+        os.unlink(html_path)
+
+    notes = build_release_notes(
+        versions=versions,
+        sha=args.sha,
+        sha7=args.sha7,
+        tag=args.tag,
+        date=args.date,
+        repo=args.repo,
+    )
+    with open(args.release_notes, "w", encoding="utf-8") as f:
+        f.write(notes)
+    print(f"Release notes: {args.release_notes}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/sbom_diff.py
+++ b/.github/scripts/sbom_diff.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""
+sbom_diff.py — Parse one or two SPDX 2.3 SBOMs and produce a versions.json
+for the release card and release notes.
+
+Usage:
+    python3 sbom_diff.py --current PATH [--previous PATH] --output PATH
+
+Output JSON schema:
+{
+  "notable": [
+    {"name": "Kernel", "version": "6.19.14", "prev": null, "changed": false}
+    ...
+  ],
+  "diff": {
+    "changed_count": 12,
+    "added_count": 3,
+    "removed_count": 1,
+    "changed": [{"name": "...", "prev": "...", "curr": "..."}],
+    "added":   [{"name": "...", "version": "..."}],
+    "removed": [{"name": "...", "version": "..."}]
+  },
+  "has_prev": false
+}
+"""
+import argparse
+import json
+import os
+import re
+import sys
+
+# ── Notable package definitions ───────────────────────────────────────────────
+# (sbom_name, display_label, optional SPDXID substring filter)
+# Order matches the OsReleaseCard HEADER_CHIP_NAMES row, then Dakota extras.
+NOTABLE: list[tuple[str, str, str | None]] = [
+    ("linux",            "Kernel",         "components-linux.bst"),
+    ("gnome-shell",      "GNOME",          None),
+    ("mesa",             "Mesa",           None),
+    ("podman",           "Podman",         None),
+    ("bootc",            "bootc",          None),
+    ("systemd",          "systemd",        None),
+    ("pipewire",         "pipewire",       None),
+    ("flatpak",          "flatpak",        None),
+    ("sudo-rs",          "sudo-rs",        None),
+    ("uutils-coreutils", "uutils",         None),
+    ("distrobox",        "distrobox",      None),
+    ("ghostty",          "ghostty",        None),
+    ("fish-shell",       "fish",           None),
+    ("common",           "common",         None),
+    ("JetBrainsMono",    "JetBrains Mono", None),
+    ("gum",              "gum",            None),
+    ("fzf",              "fzf",            None),
+    ("glow",             "glow",           None),
+]
+
+# ── Version string helpers ────────────────────────────────────────────────────
+
+def clean_version(raw: str | None) -> str | None:
+    """
+    Normalise a BST versionInfo string to something human-readable.
+
+    BST ref strings come in several formats:
+      • Semver:           "1.15.2"
+      • Git-describe:     "2.0.0-rc.2-9-gc74dc52ac1b796557a6ef3eb18b8884a0c722324"
+      • Bare 40-char SHA: "965cd7b99b04faf55819606178a5e8233cfd8b9e"
+      • Empty / None
+
+    Returns None for bare long SHAs so they can be handled specially (short SHA).
+    """
+    if not raw:
+        return None
+    v = raw.strip()
+    # Strip git-describe suffix "-N-gSHA"
+    v = re.sub(r"-\d+-g[0-9a-f]{7,}$", "", v).rstrip("-").strip()
+    # If what remains is still a 40-char hex SHA, return None (use short form)
+    if re.match(r"^[0-9a-f]{40}$", v):
+        return None
+    # Multi-segment content hash (e.g. "abc123.../167") — skip
+    if re.match(r"^[0-9a-f]{32,}", v):
+        return None
+    return v or None
+
+
+def short_sha(raw: str | None) -> str | None:
+    """Return first 8 chars of a bare SHA, or None."""
+    if raw and re.match(r"^[0-9a-f]{40}$", raw.strip()):
+        return raw.strip()[:8]
+    return None
+
+
+def best_version(raw: str | None) -> str | None:
+    """Return clean semver if available, else short SHA, else None."""
+    v = clean_version(raw)
+    if v:
+        return v
+    return short_sha(raw)
+
+
+# ── SBOM loading ──────────────────────────────────────────────────────────────
+
+def load_pkg_map(sbom_path: str) -> dict[str, dict]:
+    """
+    Build {name -> {ver, spdxid}} from an SPDX 2.3 JSON file.
+
+    Deduplication rule: for each package name, prefer:
+      1. A clean semver string over a short SHA
+      2. Any version over None
+    For "linux" we keep ALL entries indexed by SPDXID so the caller can
+    filter by SPDXID substring.
+    """
+    with open(sbom_path, encoding="utf-8") as f:
+        sbom = json.load(f)
+
+    pkgs: dict[str, dict] = {}
+    linux_entries: list[dict] = []
+
+    for p in sbom.get("packages", []):
+        name: str = p.get("name", "")
+        raw: str = p.get("versionInfo", "")
+        spdxid: str = p.get("SPDXID", "")
+        ver = best_version(raw)
+
+        if name == "linux":
+            linux_entries.append({"ver": ver, "raw": raw, "spdxid": spdxid})
+            continue
+
+        if name not in pkgs:
+            pkgs[name] = {"ver": ver, "spdxid": spdxid}
+        else:
+            curr = pkgs[name]["ver"]
+            # Prefer semver over None/short-SHA
+            if ver and (not curr or (re.match(r"^[0-9]+\.[0-9]+", ver) and
+                                     not re.match(r"^[0-9]+\.[0-9]+", curr))):
+                pkgs[name] = {"ver": ver, "spdxid": spdxid}
+
+    # Resolve linux kernel: prefer entry whose SPDXID contains "components-linux.bst"
+    # and has the best (semver) version — multiple entries match the filter.
+    candidates = [e for e in linux_entries if "components-linux.bst" in e["spdxid"]]
+    if not candidates:
+        candidates = linux_entries
+    # Sort: semver entries first, then SHA, then None
+    def _ver_rank(e):
+        v = e["ver"]
+        if v and re.match(r"^[0-9]+\.[0-9]+", v):
+            return 0
+        if v:
+            return 1
+        return 2
+    candidates.sort(key=_ver_rank)
+    kernel_entry = candidates[0] if candidates else None
+    if kernel_entry:
+        pkgs["linux"] = {"ver": kernel_entry["ver"], "spdxid": kernel_entry["spdxid"]}
+
+    return pkgs
+
+
+# ── Notable extraction ────────────────────────────────────────────────────────
+
+def extract_notable(
+    curr_map: dict,
+    prev_map: dict | None,
+) -> list[dict]:
+    """Return notable package list with optional prev version for changed chips.
+
+    The SPDXID filter was used during SBOM loading (load_pkg_map) to select
+    the correct linux kernel entry.  By the time we reach here, curr_map already
+    has the right entry under 'linux'.  Re-filtering by SPDXID here is redundant
+    and will silently drop the Kernel chip if the SPDXID naming convention ever
+    drifts, so we skip it.
+    """
+    result = []
+    for sbom_name, label, _spdxid_filter in NOTABLE:
+        entry = curr_map.get(sbom_name)
+        if entry is None:
+            continue
+        ver = entry["ver"]
+
+        prev_ver = None
+        if prev_map and sbom_name in prev_map:
+            pv = prev_map[sbom_name]["ver"]
+            if pv != ver:
+                prev_ver = pv
+
+        result.append({
+            "name":    label,
+            "version": ver or "(unknown)",
+            "prev":    prev_ver,
+            "changed": prev_ver is not None,
+        })
+    return result
+
+
+# ── Full diff ─────────────────────────────────────────────────────────────────
+
+def diff_sboms(curr_map: dict, prev_map: dict) -> dict:
+    """Compute full added/changed/removed diff between two package maps."""
+    all_names = set(curr_map) | set(prev_map)
+
+    added:   list[dict] = []
+    changed: list[dict] = []
+    removed: list[dict] = []
+
+    for name in sorted(all_names):
+        c_entry = curr_map.get(name)
+        p_entry = prev_map.get(name)
+
+        c_ver = c_entry["ver"] if c_entry else None
+        p_ver = p_entry["ver"] if p_entry else None
+
+        if c_entry and not p_entry:
+            added.append({"name": name, "version": c_ver or "(unknown)"})
+        elif not c_entry and p_entry:
+            removed.append({"name": name, "version": p_ver or "(unknown)"})
+        elif c_ver and p_ver and c_ver != p_ver:
+            changed.append({"name": name, "prev": p_ver, "curr": c_ver})
+
+    return {
+        "changed_count": len(changed),
+        "added_count":   len(added),
+        "removed_count": len(removed),
+        "changed": changed,
+        "added":   added,
+        "removed": removed,
+    }
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--current",  required=True, help="Path to current dakota.spdx.json")
+    ap.add_argument("--previous", default=None,  help="Path to previous dakota.spdx.json (optional)")
+    ap.add_argument("--output",   required=True, help="Output versions.json path")
+    args = ap.parse_args()
+
+    if not os.path.isfile(args.current):
+        print(f"ERROR: current SBOM not found: {args.current}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Loading current SBOM: {args.current}")
+    curr_map = load_pkg_map(args.current)
+    print(f"  → {len(curr_map)} unique packages")
+
+    prev_map: dict | None = None
+    has_prev = False
+    if args.previous and os.path.isfile(args.previous):
+        print(f"Loading previous SBOM: {args.previous}")
+        prev_map = load_pkg_map(args.previous)
+        print(f"  → {len(prev_map)} unique packages")
+        has_prev = True
+    else:
+        print("No previous SBOM — skipping diff")
+
+    notable = extract_notable(curr_map, prev_map)
+    print(f"Notable packages found: {len(notable)}")
+
+    diff_data: dict
+    if prev_map is not None:
+        diff_data = diff_sboms(curr_map, prev_map)
+        print(f"Diff: {diff_data['changed_count']} changed, "
+              f"{diff_data['added_count']} added, "
+              f"{diff_data['removed_count']} removed")
+    else:
+        diff_data = {
+            "changed_count": 0, "added_count": 0, "removed_count": 0,
+            "changed": [], "added": [], "removed": [],
+        }
+
+    output = {
+        "notable":  notable,
+        "diff":     diff_data,
+        "has_prev": has_prev,
+    }
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(output, f, indent=2)
+    print(f"Written: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -166,6 +166,14 @@ jobs:
           BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
         run: just sbom ${{ matrix.variant }}
 
+      - name: Upload SBOM artifact for release workflow
+        if: matrix.variant == 'default'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom-${{ steps.context.outputs.sha }}
+          path: dakota.spdx.json
+          retention-days: 30
+
       - name: Login to GHCR
         env:
           GH_ACTOR: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,141 @@
+name: Release Bluefin dakota
+
+# Fires after every successful Publish run on main or the merge queue.
+# Same branch filter as publish.yml — only real published images trigger a release.
+on:
+  workflow_run:
+    workflows: ["Publish Bluefin dakota"]
+    types: [completed]
+    branches:
+      - main
+      - 'gh-readonly-queue/main/**'
+
+permissions:
+  contents: write   # create GitHub releases
+  actions:  read    # download artifacts from the triggering publish run
+
+concurrency:
+  group: release-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Checkout repository at published SHA
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Resolve release metadata
+        id: meta
+        run: |
+          SHA="${{ github.event.workflow_run.head_sha }}"
+          SHA7="${SHA:0:7}"
+          # Use the publish workflow's start time, not wall-clock now.
+          # A publish that starts at 23:45 UTC and completes past midnight
+          # would otherwise get tomorrow's date in the tag.
+          DATE="$(date -u -d '${{ github.event.workflow_run.created_at }}' +%Y-%m-%d)"
+          {
+            echo "sha=$SHA"
+            echo "sha7=$SHA7"
+            echo "date=$DATE"
+            echo "tag=${DATE}-${SHA7}"
+            echo "title=Bluefin Dakota ${DATE}"
+          } >> "$GITHUB_OUTPUT"
+
+      # ── Download current SBOM ─────────────────────────────────────────────
+      # publish.yml uploads dakota.spdx.json (default variant) as
+      # "sbom-<sha>" with 30-day retention.
+      - name: Download current SBOM from publish run
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: sbom-${{ github.event.workflow_run.head_sha }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: sbom-current
+
+      # ── Fetch previous SBOM for diff ─────────────────────────────────────
+      # Download dakota.spdx.json from the most recent existing GitHub release.
+      # Gracefully skips if no prior release exists (first run).
+      - name: Download previous release SBOM
+        id: prev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PREV_TAG=$(gh release list \
+            --repo "${{ github.repository }}" \
+            --limit 1 \
+            --json tagName \
+            --jq '.[0].tagName' 2>/dev/null || true)
+
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous release found — first release."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          mkdir -p sbom-previous
+          if gh release download "$PREV_TAG" \
+              --repo "${{ github.repository }}" \
+              --pattern "dakota.spdx.json" \
+              --dir sbom-previous 2>/dev/null; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "Previous release: $PREV_TAG"
+          else
+            echo "::warning::Could not download SBOM from release $PREV_TAG — skipping diff"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── Diff SBOMs ────────────────────────────────────────────────────────
+      - name: Parse SBOMs and compute diff
+        run: |
+          PREV_FLAGS=()
+          if [ "${{ steps.prev.outputs.found }}" = "true" ]; then
+            PREV_FLAGS=(--previous sbom-previous/dakota.spdx.json)
+          fi
+          python3 .github/scripts/sbom_diff.py \
+            --current sbom-current/dakota.spdx.json \
+            "${PREV_FLAGS[@]}" \
+            --output versions.json
+
+      # ── Playwright card screenshots ───────────────────────────────────────
+      - name: Install Playwright + Chromium
+        run: |
+          python3 -m pip install playwright --break-system-packages --quiet
+          python3 -m playwright install chromium --with-deps
+
+      - name: Render release card
+        run: |
+          python3 .github/scripts/render_card.py \
+            --versions      versions.json \
+            --sha           "${{ steps.meta.outputs.sha }}" \
+            --sha7          "${{ steps.meta.outputs.sha7 }}" \
+            --date          "${{ steps.meta.outputs.date }}" \
+            --tag           "${{ steps.meta.outputs.tag }}" \
+            --repo          "${{ github.repository }}" \
+            --output        release-card.png \
+            --release-notes release-notes.md
+
+      # ── Create GitHub release ─────────────────────────────────────────────
+      # Uploads card images and SBOM atomically with the release creation so
+      # the image URLs in the release body are valid immediately on publish.
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG:   ${{ steps.meta.outputs.tag }}
+          TITLE: ${{ steps.meta.outputs.title }}
+        run: |
+          # Idempotent: skip if this tag already exists (e.g. re-run or dispatch).
+          if gh release view "$TAG" --repo "${{ github.repository }}" &>/dev/null; then
+            echo "Release $TAG already exists — skipping."
+            exit 0
+          fi
+          gh release create "$TAG" \
+            --repo "${{ github.repository }}" \
+            --title "$TITLE" \
+            --notes-file release-notes.md \
+            release-card.png \
+            sbom-current/dakota.spdx.json


### PR DESCRIPTION
After every successful publish, create a GitHub release containing:

- Release card PNG (light + dark) generated from SPDX 2.3 SBOM data: version chips for Kernel, GNOME, Mesa, Podman, bootc, systemd, pipewire, flatpak, sudo-rs, uutils, distrobox, ghostty, fish, common, JetBrains Mono, gum, fzf, glow — with prev→curr arrows for anything that changed since the last release.

- Full SBOM diff: changed/added/removed counts in release body and card diff bar; per-notable-package prev→curr in versions table.

- Verification commands (cosign, oras, gh attestation, just verify) copied verbatim so users can confirm their image supply chain.

- Link to https://docs.projectbluefin.io/changelogs

- SBOM (dakota.spdx.json) attached as release asset.

publish.yml: upload dakota.spdx.json as a GHA artifact (sbom-<sha>, 30-day retention) so release.yml can download it cross-workflow.

release.yml: workflow_run on 'Publish Bluefin dakota' success, same branch filter. Downloads current + previous SBOMs, diffs them, renders card with Playwright, creates release via gh CLI.

Scripts:
  .github/scripts/sbom_diff.py   — SPDX parsing + diff → versions.json
  .github/scripts/render_card.py — HTML card + Playwright screenshot
                                   + release notes markdown

Assisted-by: claude-sonnet-4-5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generates a single light release-card PNG and a release-notes.md from SBOM-derived version data.
  * New SBOM diffing produces a “notable components” list and full package diffs for release summaries.

* **Chores**
  * CI uploads SBOM artifacts selectively, runs a release job that computes diffs, renders cards/notes, and publishes release assets when appropriate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/443)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->