### PR TITLE
bluefin: disable shell motd by default

### DIFF
--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -42,6 +42,12 @@ config:
     cp -r system_files/shared/etc/./ "%{install-root}%{sysconfdir}/"
     cp -r bluefin-branding/system_files/etc/./ "%{install-root}%{sysconfdir}/"
 
+    # Disable Bluefin shell MOTD by default.
+    ENV_FILE="%{install-root}%{sysconfdir}/environment"
+    touch "${ENV_FILE}"
+    sed -i '/^BLUEFIN_SHELL_ENABLE_MOTD=/d' "${ENV_FILE}"
+    printf 'BLUEFIN_SHELL_ENABLE_MOTD=0\n' >> "${ENV_FILE}"
+
     # Generate ujust completions to match the upstream common image.
     install -d \
       "%{install-root}%{datadir}/bash-completion/completions" \

--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -42,11 +42,11 @@ config:
     cp -r system_files/shared/etc/./ "%{install-root}%{sysconfdir}/"
     cp -r bluefin-branding/system_files/etc/./ "%{install-root}%{sysconfdir}/"
 
-    # Disable Bluefin shell MOTD by default.
-    ENV_FILE="%{install-root}%{sysconfdir}/environment"
-    touch "${ENV_FILE}"
-    sed -i '/^BLUEFIN_SHELL_ENABLE_MOTD=/d' "${ENV_FILE}"
-    printf 'BLUEFIN_SHELL_ENABLE_MOTD=0\n' >> "${ENV_FILE}"
+    # Default Bluefin shell MOTD to disabled, while allowing user overrides.
+    install -Dm644 /dev/stdin "%{install-root}%{sysconfdir}/profile.d/bluefin-shell-defaults.sh" <<'EOF'
+    : "${BLUEFIN_SHELL_ENABLE_MOTD:=0}"
+    export BLUEFIN_SHELL_ENABLE_MOTD
+    EOF
 
     # Generate ujust completions to match the upstream common image.
     install -d \


### PR DESCRIPTION
## Summary
- set BLUEFIN_SHELL_ENABLE_MOTD=0 by default in the built image
- write it into /etc/environment from elements/bluefin/common.bst
- remove any pre-existing BLUEFIN_SHELL_ENABLE_MOTD entry before appending

## Why
This makes the Bluefin shell MOTD disabled by default in Dakota images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adds a shell profile defaults script that disables the Bluefin shell MOTD by default.
  * The setting is exported and can be overridden by users if desired.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/446)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->