### PR TITLE
ci: re-enable aarch64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,10 +268,9 @@ jobs:
   # ── aarch64 native build ──────────────────────────────────────────────────
   # Mirrors the x86_64 build job. ARM failures do not fail the workflow or
   # block x86_64 publication — this is an experimental parallel build.
-  # Disabled: webkit cold-builds OOM/timeout the ARM runner. Re-enable once
-  # the webkit artifacts are cached in cache.projectbluefin.io.
+  # WebKit aarch64 artifacts are available from gbm.gnome.org (gnome-build-meta
+  # builds aarch64 natively), so cold-build OOM/timeout should no longer occur.
   build-aarch64:
-    if: false
     runs-on: ubuntu-24.04-arm
     continue-on-error: true
     outputs:


### PR DESCRIPTION
## Summary

- Removes `if: false` from the `build-aarch64` job
- The job was disabled because webkit cold-builds were OOM/timing out the ARM runner
- WebKit aarch64 artifacts should now be available from `gbm.gnome.org` (gnome-build-meta builds aarch64 natively and pushes there), so the first run should pull from cache rather than build from source
- `continue-on-error: true` is retained, so any failure here cannot block x86_64 publication or the multi-arch manifest

## Test plan

- [ ] Watch the first scheduled or dispatched run — confirm `build-aarch64` completes without OOM/timeout
- [ ] If it fails, check logs for webkit build vs. cache hit to determine if the assumption about `gbm.gnome.org` aarch64 cache is correct
- [ ] On success, verify `:aarch64` tag is published to GHCR and `create-manifest` produces a multi-arch `:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)