### PR TITLE
fix(release): add full SBOM diff tables to release notes

### DIFF
--- a/.github/scripts/render_card.py
+++ b/.github/scripts/render_card.py
@@ -376,12 +376,66 @@ def build_release_notes(
         diff_line = "First automated release — no previous baseline."
 
     # Notable versions table
-    rows = "\n".join(
+    notable_rows = "\n".join(
         f"| {p['name']} | `{p['version']}`"
         + (f" | `{p['prev']}` → `{p['version']}`" if p.get("changed") and p.get("prev") else " | —")
         + " |"
         for p in versions["notable"]
     )
+
+    # Full diff sections — only when we have a previous baseline
+    full_diff_section: list[str] = []
+    if has_prev:
+        # Updated
+        if diff["changed"]:
+            changed_rows = "\n".join(
+                f"| {c['name']} | `{c['prev']}` | `{c['curr']}` |"
+                for c in diff["changed"]
+            )
+            full_diff_section += [
+                f"<details><summary>↑ {diff['changed_count']} updated packages</summary>",
+                "",
+                "| Package | From | To |",
+                "|---|---|---|",
+                *changed_rows.splitlines(),
+                "",
+                "</details>",
+                "",
+            ]
+        # Added
+        if diff["added"]:
+            added_rows = "\n".join(
+                f"| {a['name']} | `{a['version']}` |"
+                for a in diff["added"]
+            )
+            full_diff_section += [
+                f"<details><summary>+ {diff['added_count']} added packages</summary>",
+                "",
+                "| Package | Version |",
+                "|---|---|",
+                *added_rows.splitlines(),
+                "",
+                "</details>",
+                "",
+            ]
+        # Removed
+        if diff["removed"]:
+            removed_rows = "\n".join(
+                f"| {r['name']} | `{r['version']}` |"
+                for r in diff["removed"]
+            )
+            full_diff_section += [
+                f"<details><summary>− {diff['removed_count']} removed packages</summary>",
+                "",
+                "| Package | Last version |",
+                "|---|---|",
+                *removed_rows.splitlines(),
+                "",
+                "</details>",
+                "",
+            ]
+        if not full_diff_section:
+            full_diff_section = ["No package changes since last release.", ""]
 
     # Build lines with no leading whitespace — 4-space indent renders as code in GitHub MD
     L = [
@@ -393,8 +447,9 @@ def build_release_notes(
         "",
         "| Component | Version | Change |",
         "|---|---|---|",
-        *rows.splitlines(),
+        *notable_rows.splitlines(),
         "",
+        *((["## All package changes", ""] + full_diff_section) if has_prev else []),
         "## Images",
         "",
         "```",


### PR DESCRIPTION
## What

Each GitHub release now includes an **All package changes** section with three collapsible tables covering every package in the SBOM diff — not just the notable chips shown on the card.

| Table | Contents |
|---|---|
| ↑ N updated | Every package whose version changed, with from/to |
| + N added | Packages new since the last release |
| − N removed | Packages that disappeared |

The section is omitted entirely on the first release (no baseline) and when there are genuinely no changes.

## Why

The notable chips on the release card are intentionally selective. Users and downstream maintainers tracking specific packages (e.g. tailscale, uupd, individual GNOME components) had no way to see whether something changed without diffing the SBOM files manually.

## Backfill

The four existing releases have already been updated directly via `backfill_release_notes.py` (also included here for future use). No release assets were touched — only the release body text.

## Changes

- `render_card.py`: `build_release_notes()` now renders the three collapsible diff tables from the `versions["diff"]` data that `sbom_diff.py` was already computing but not surfacing in the notes
- `backfill_release_notes.py`: one-shot script that walks all releases oldest-first, downloads each SBOM, diffs against the previous, and patches the release body via `gh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to backfill release notes for prior releases with comprehensive package change history.
  * Enhanced release notes now include detailed "All package changes" section showing added, changed, and removed packages when comparing against previous releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/455?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->