### PR TITLE
fix(ffmpeg): enable H.264 and H.265 decoders for host video thumbnailing

### DIFF
--- a/patches/freedesktop-sdk/0016-ffmpeg-Enable-H.264-and-H.265-decoders-for-host-thum.patch
+++ b/patches/freedesktop-sdk/0016-ffmpeg-Enable-H.264-and-H.265-decoders-for-host-thum.patch
@@ -1,0 +1,28 @@
+From 0db5bae982fd9330f1201cd51b9b1e71a41e29de Mon Sep 17 00:00:00 2001
+From: "Jorge O. Castro" <jorge.castro@gmail.com>
+Date: Tue, 19 May 2026 20:55:37 -0400
+Subject: [PATCH] ffmpeg: Enable H.264 and H.265 decoders for host thumbnailing
+
+Remove --disable-decoder="h264,hevc,vc1,vvc" so that gstreamer-libav
+gains avdec_h264 and avdec_h265. Without these, the host
+gst-video-thumbnailer fails on every MP4 file (seeing only the audio
+stream) and GNOME Files cannot generate video thumbnails.
+
+The codecs-extra Flatpak extension already ships an ffmpeg-full with
+all decoders enabled; this change brings the host system to parity.
+---
+ elements/components/ffmpeg.bst | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/elements/components/ffmpeg.bst b/elements/components/ffmpeg.bst
+index 9bd3995..8821e4e 100644
+--- a/elements/components/ffmpeg.bst
++++ b/elements/components/ffmpeg.bst
+@@ -132,4 +132,3 @@ variables:
+   conf-extra: >-
+     --enable-encoder=%{encoders}
+     --enable-decoder=%{decoders}
+-    --disable-decoder="h264,hevc,vc1,vvc"
+-- 
+2.54.0
+


### PR DESCRIPTION
This needs to work, we'll turn it on until someone tells us to turn it off lol. 

The host gst-video-thumbnailer fails on every H.264/H.265 MP4 file because freedesktop-sdk builds FFmpeg with:

  --disable-decoder="h264,hevc,vc1,vvc"

Add a patch_queue entry for freedesktop-sdk that removes that flag, re-enabling H.264 and H.265 decoding in the host FFmpeg build.

Assisted-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * H.264 and H.265 video decoding support enabled for thumbnail generation. The system can now process H.264 and H.265 encoded videos when creating previews, improving media compatibility. Additional video decoders have been enabled alongside H.264 and H.265 support, providing broader codec compatibility and enhancing video format handling capabilities across the platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->