### PR TITLE
fix(renovate): use stable PyPI URL format for plugins junctions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,7 +27,7 @@
         '/elements/plugins/.*\\.bst$/',
       ],
       matchStrings: [
-        'url:\\s*pypi:[a-f0-9/]+/(?<depName>buildstream[-_]plugins(?:[-_]community)?)-(?<currentValue>\\d+\\.\\d+\\.\\d+)\\.tar\\.gz\\n\\s+ref:\\s*(?<currentDigest>[a-f0-9]{64})',
+        'url:\\s*pypi:source/[a-z]/[\\w-]+/(?<depName>[\\w_-]+)-(?<currentValue>\\d+\\.\\d+\\.\\d+)\\.tar\\.gz\\n\\s+ref:\\s*(?<currentDigest>[a-f0-9]{64})',
       ],
       datasourceTemplate: 'pypi',
       versioningTemplate: 'pep440',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,7 +27,7 @@
         '/elements/plugins/.*\\.bst$/',
       ],
       matchStrings: [
-        'url:\\s*pypi:source/[a-z]/[\\w-]+/(?<depName>[\\w_-]+)-(?<currentValue>\\d+\\.\\d+\\.\\d+)\\.tar\\.gz\\n\\s+ref:\\s*(?<currentDigest>[a-f0-9]{64})',
+        'url:\\s*pypi:source/[a-z0-9]/[\\w-]+/(?<depName>[\\w_-]+)-(?<currentValue>\\d+\\.\\d+\\.\\d+)\\.tar\\.gz\\n\\s+ref:\\s*(?<currentDigest>[a-f0-9]{64})',
       ],
       datasourceTemplate: 'pypi',
       versioningTemplate: 'pep440',

--- a/elements/plugins/buildstream-plugins-community.bst
+++ b/elements/plugins/buildstream-plugins-community.bst
@@ -2,5 +2,5 @@ kind: junction
 
 sources:
 - kind: tar
-  url: pypi:08/b4/4b5311dd4ea599bdc69d911263f5d3f8b4c14789d69265d7ea2be7e4e120/buildstream_plugins_community-2.3.0.tar.gz
-  ref: cdd3b73ff998e4145d2bb1a1215b961c65b073a4956609417ab747ef8f462c44
+  url: pypi:source/b/buildstream-plugins-community/buildstream_plugins_community-2.3.1.tar.gz
+  ref: 85c2bae9d3a1eb3121c9674f68ef6e87211fddb9c930f3e5057b9a1e66eb41d9

--- a/elements/plugins/buildstream-plugins.bst
+++ b/elements/plugins/buildstream-plugins.bst
@@ -2,5 +2,5 @@ kind: junction
 
 sources:
 - kind: tar
-  url: pypi:53/05/602efa27ee4cc04b489af78d401f7ce9ba96185677e8573b2eb71e2ec211/buildstream-plugins-2.5.0.tar.gz
+  url: pypi:source/b/buildstream-plugins/buildstream-plugins-2.5.0.tar.gz
   ref: 49c57dec88c0b4558f474520c2e29c69ecd42a1e5c07423baae5b29b153e54a6


### PR DESCRIPTION
Renovate's regex manager was producing broken PRs for PyPI-sourced BST elements. The hash-path URL format encodes each tarball's SHA256 in the directory prefix (e.g. pypi:08/b4/4b.../pkg-2.3.0.tar.gz). When Renovate bumps the version it substitutes the filename only — the path prefix is not a named capture group, so it stays stale and the new URL returns HTTP 404.

Switch both plugin junction elements to PyPI's stable source URL format (pypi:source/b/<name>/<file>), which returns a 302 redirect to the correct hash-path URL. BST follows redirects and verifies the content SHA256 via the ref field, so no integrity is lost.

Update the Renovate regex to match the stable URL pattern. Now only the version in the filename and the ref SHA256 need substitution — both of which Renovate handles correctly via its PyPI datasource.

Also bumps buildstream-plugins-community from 2.3.0 to 2.3.1 (the fix that PR #478 failed to apply correctly).

Closes #478

Assisted-by: claude-opus-4-5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated BuildStream plugins community to v2.3.1.
  * Updated BuildStream plugins source references to use revised tarball URLs.
  * Improved Renovate configuration to better detect and match Python source tarballs for plugin dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/482?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->