### PR TITLE
feat(extension): Add and enable gradia capture extension

### DIFF
--- a/elements/bluefin/gnome-shell-extensions.bst
+++ b/elements/bluefin/gnome-shell-extensions.bst
@@ -6,6 +6,7 @@ depends:
   - bluefin/shell-extensions/bazaar-companion.bst
   - bluefin/shell-extensions/blur-my-shell.bst
   - bluefin/shell-extensions/dash-to-dock.bst
+  - bluefin/shell-extensions/gradia-capture.bst
   - bluefin/shell-extensions/gsconnect.bst
   - bluefin/shell-extensions/custom-command-menu.bst
   - bluefin/shell-extensions/caffeine.bst

--- a/elements/bluefin/shell-extensions/disable-ext-validator.bst
+++ b/elements/bluefin/shell-extensions/disable-ext-validator.bst
@@ -14,7 +14,7 @@ config:
       cat <<EOF > "%{install-root}%{datadir}/glib-2.0/schemas/zz3-bluefin-unsupported-stuff.gschema.override"
       [org.gnome.shell]
       disable-extension-version-validation=true
-      enabled-extensions=['caffeine@patapon.info', 'appindicatorsupport@rgcjonas.gmail.com', 'bazaar-integration@kolunmi.github.io', 'blur-my-shell@aunetx', 'dash-to-dock@micxgx.gmail.com', 'gsconnect@andyholmes.github.io', 'custom-command-list@storageb.github.com', 'search-light@icedman.github.com']
+      enabled-extensions=['caffeine@patapon.info', 'appindicatorsupport@rgcjonas.gmail.com', 'bazaar-integration@kolunmi.github.io', 'blur-my-shell@aunetx', 'dash-to-dock@micxgx.gmail.com', 'gradia-integration@alexandervanhee.github.io', 'gsconnect@andyholmes.github.io', 'custom-command-list@storageb.github.com', 'search-light@icedman.github.com']
       EOF
 
     - "%{install-extra}"

--- a/elements/bluefin/shell-extensions/gradia-capture.bst
+++ b/elements/bluefin/shell-extensions/gradia-capture.bst
@@ -22,6 +22,7 @@ config:
   - |
     _uuid="$(jq -r .uuid src/metadata.json)"
     _dest="%{install-root}%{datadir}/gnome-shell/extensions/${_uuid}"
+    install -d "${_dest}"
 
     cp -R src/* "${_dest}/"
     cp -R icons "${_dest}/icons"

--- a/elements/bluefin/shell-extensions/gradia-capture.bst
+++ b/elements/bluefin/shell-extensions/gradia-capture.bst
@@ -1,0 +1,37 @@
+kind: manual
+
+sources:
+- kind: git_repo
+  url: github:AlexanderVanhee/gradia-capture.git
+  track: master
+  ref: 9e441493a132e9f38d3a7fdf5d7f0d55a0a36369
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+- freedesktop-sdk.bst:components/jq.bst
+
+depends:
+- gnome-build-meta.bst:sdk/glib.bst
+- gnome-build-meta.bst:core/gnome-shell.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    _uuid="$(jq -r .uuid src/metadata.json)"
+    _dest="%{install-root}%{datadir}/gnome-shell/extensions/${_uuid}"
+
+    cp -R src/* "${_dest}/"
+    cp -R icons "${_dest}/icons"
+
+    install -Dm644 LICENSE "${_dest}/LICENSE"
+    install -Dm644 README.md "${_dest}/README.md"
+
+    install -d "${_dest}/schemas"
+    install -Dm644 schemas/org.gnome.shell.extensions.gradia-companion.gschema.xml \
+      "${_dest}/schemas/org.gnome.shell.extensions.gradia-companion.gschema.xml"
+    glib-compile-schemas --strict "${_dest}/schemas"
+  - |
+    %{install-extra}


### PR DESCRIPTION
Ported from https://github.com/projectbluefin/common/pull/335 and https://github.com/ublue-os/bluefin/pull/4651

Need to add Gradia flatpak to the iso next

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the Gradia Capture GNOME Shell extension, enabling enhanced screen capture capabilities and improved desktop interaction options.
  * Improved GNOME Shell extension system architecture and configuration management, allowing better support for multiple shell extensions with refined compatibility handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->