### PR TITLE
fix: batch papercut fixes (#304, #352, #456, #465)

### DIFF
--- a/elements/bluefin/bootc-install-config.bst
+++ b/elements/bluefin/bootc-install-config.bst
@@ -1,0 +1,16 @@
+kind: manual
+
+sources:
+- kind: local
+  path: files/bootc-install
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - install -Dm644 00-defaults.toml "%{install-root}/usr/lib/bootc/install/00-defaults.toml"
+  - "%{install-extra}"

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -20,6 +20,9 @@ depends:
   - bluefin/tealdeer.bst
 
   - bluefin/common.bst
+  - bluefin/just-overrides.bst
+  - bluefin/firstboot-date.bst
+  - bluefin/bootc-install-config.bst
   - bluefin/composefs-loop-udisks-ignore.bst
   - bluefin/gnome-epub-thumbnailer.bst
   - bluefin/papers-thumbnailer.bst

--- a/elements/bluefin/firstboot-date.bst
+++ b/elements/bluefin/firstboot-date.bst
@@ -1,0 +1,23 @@
+kind: manual
+
+sources:
+- kind: local
+  path: files/firstboot
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+public:
+  bst:
+    overlap-whitelist:
+    - /usr/share/ublue-os/fastfetch.jsonc
+
+config:
+  install-commands:
+  - install -Dm644 ublue-firstboot-date.service "%{install-root}/usr/lib/systemd/system/ublue-firstboot-date.service"
+  - install -Dm644 fastfetch.jsonc "%{install-root}/usr/share/ublue-os/fastfetch.jsonc"
+  - ln -sf ../ublue-firstboot-date.service "%{install-root}/usr/lib/systemd/system/multi-user.target.wants/ublue-firstboot-date.service"
+  - "%{install-extra}"

--- a/elements/bluefin/just-overrides.bst
+++ b/elements/bluefin/just-overrides.bst
@@ -1,0 +1,23 @@
+kind: manual
+
+sources:
+- kind: local
+  path: files/just-overrides
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+public:
+  bst:
+    overlap-whitelist:
+    - /usr/share/ublue-os/just/default.just
+    - /usr/share/ublue-os/just/changelog.just
+
+config:
+  install-commands:
+  - install -Dm644 default.just "%{install-root}/usr/share/ublue-os/just/default.just"
+  - install -Dm644 changelog.just "%{install-root}/usr/share/ublue-os/just/changelog.just"
+  - "%{install-extra}"

--- a/files/bootc-install/00-defaults.toml
+++ b/files/bootc-install/00-defaults.toml
@@ -1,0 +1,2 @@
+[install]
+bootloader = "systemd"

--- a/files/firstboot/fastfetch.jsonc
+++ b/files/firstboot/fastfetch.jsonc
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json",
+  "display": {
+    "separator": "  ",
+    "color": {
+      "keys": "38;2;87;160;198"
+    }
+  },
+  "modules": [
+    {
+      "type": "title",
+      "key": "",
+      "color": {
+        "user": "38;2;87;160;198",
+        "at": "white",
+        "host": "bright_green"
+      }
+    },
+    "break",
+    {
+      "type": "command",
+      "key": "󱋩",
+      "text": "/usr/bin/ublue-image-info.sh"
+    },
+    {
+      "type": "os",
+      "key": "󱍢",
+      "format": "{pretty-name}"
+    },
+    {
+      "type": "kernel",
+      "key": "",
+      "format": "{1} {2}"
+    },
+    {
+      "type": "uptime",
+      "key": "󰅐"
+    },
+    {
+      "type": "command",
+      "key": "󰔠",
+      "text": "date -d\"$(cat /var/lib/ublue-os/install-date 2>/dev/null || date +%Y-%m-%d)\" +'Forged on %b %d %G'",
+      "shell": "/bin/bash"
+    },
+    "break",
+    {
+      "type": "command",
+      "key": "󱍢",
+      "keyColor": "#0066cc",
+      "text": "cat /usr/share/ublue-os/fastfetch-user-count",
+      "shell": "/bin/bash",
+      "format": "Murder Chickens: {1} (weekly)"
+    },
+    {
+      "type": "command",
+      "key": "",
+      "keyColor": "#ff5c00",
+      "text": "cat /usr/share/ublue-os/bazaar-install-count",
+      "shell": "/bin/bash",
+      "format": "Bazaar Installs: {1} (weekly)"
+    },
+    "break",
+    {
+      "type": "host",
+      "key": "󰾰"
+    },
+    {
+      "type": "cpu",
+      "key": "󰻠"
+    },
+    {
+      "type": "gpu",
+      "key": "󰍛"
+    },
+    {
+      "type": "memory",
+      "key": "󰧑"
+    },
+    {
+      "type": "disk",
+      "key": "",
+      "hideFS": "overlay"
+    },
+    {
+      "type": "display",
+      "key": "󰍹"
+    },
+    {
+      "type": "battery",
+      "key": ""
+    },
+    {
+      "type": "gamepad",
+      "key": "󰖺"
+    },
+    "break",
+    {
+      "type": "de",
+      "key": "󰕮"
+    },
+    {
+      "type": "wm",
+      "key": ""
+    },
+    {
+      "type": "shell",
+      "key": ""
+    },
+    {
+      "type": "terminal",
+      "key": ""
+    },
+    {
+      "type": "packages",
+      "key": "󰏖",
+      "disabled": ["rpm"]
+    },
+    "break",
+    {
+      "type": "colors",
+      "paddingLeft": 2
+    }
+  ]
+}

--- a/files/firstboot/ublue-firstboot-date.service
+++ b/files/firstboot/ublue-firstboot-date.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Record Dakota first-boot installation date
+ConditionPathExists=!/var/lib/ublue-os/install-date
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c 'mkdir -p /var/lib/ublue-os && date +%%Y-%%m-%%d > /var/lib/ublue-os/install-date'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/files/just-overrides/changelog.just
+++ b/files/just-overrides/changelog.just
@@ -1,0 +1,24 @@
+# vim: set ft=make :
+
+alias changelog := changelogs
+
+# Show the changelog
+changelogs:
+    #!/usr/bin/bash
+
+    # Get Image Tag
+    TAG="$(jq -r '.["image-tag"]' < /usr/share/ublue-os/image-info.json)"
+
+    # If stable or gts, get changelogs from Github Releases
+    if [[ "$TAG" =~ gts$|stable$ ]]; then
+        DATE="$(grep -oP "OSTREE_VERSION=.*\d{2}\.\K\d{8}[.0-9]*" /etc/os-release)"
+        CONTENT="$(curl -Ls "https://api.github.com/repos/projectbluefin/dakota/releases" | jq -r ".[] | select(.tag_name==\"${TAG}-${DATE}\") | .body")"
+    fi
+
+    # Display Content with Glow, otherwise fallback to latest Dakota release notes
+    if [[ -n "${CONTENT:-}" ]]; then
+        echo "$CONTENT" | glow -p
+    else
+        echo "WARN: Could not find a release specific to your image"
+        curl -Ls "https://api.github.com/repos/projectbluefin/dakota/releases/latest" | jq -r ".body" | glow -p
+    fi

--- a/files/just-overrides/default.just
+++ b/files/just-overrides/default.just
@@ -1,0 +1,179 @@
+# vim: set ft=make :
+# These are convenience shortcuts, they should not be specific to a desktop, aimed to be rather generic things for both Aurora and Bluefin
+
+uid := `id -u`
+shell := `grep :$(id -u): /etc/passwd | cut -d: -f7`
+
+# Boot into this device's BIOS/UEFI screen
+bios:
+    #!/usr/bin/bash
+    if [ ! -d /sys/firmware/efi ]; then
+      echo "Rebooting to legacy BIOS from OS is not supported."
+      exit 1
+    fi
+
+    if gum confirm "Reboot into BIOS?" ; then
+      systemctl reboot --firmware-setup
+    fi
+
+# Show BIOS info
+bios-info:
+    #!/usr/bin/bash
+    sudo bash <<'EOF'
+    echo "Manufacturer: $(dmidecode -s baseboard-manufacturer)"
+    echo "Product Name: $(dmidecode -s baseboard-product-name)"
+    echo "Version: $(dmidecode -s bios-version)"
+    echo "Release Date: $(dmidecode -s bios-release-date)"
+    EOF
+
+clean-system:
+    #!/usr/bin/bash
+    if gum confirm "Prune all Podman images and volumes?"; then
+        podman image prune -af
+        podman volume prune -f
+    fi
+
+    if command -v docker >/dev/null 2>&1; then
+      if gum confirm "Prune all Docker images and volumes?"; then
+        docker image prune -af
+        docker volume prune -f
+      fi
+    fi
+
+    flatpak uninstall --unused
+    if [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+        brew autoremove
+        brew cleanup
+    fi
+
+# Show all messages from this boot
+logs-this-boot:
+    sudo journalctl --no-hostname -b 0
+
+# Show all messages from last boot
+logs-last-boot:
+    sudo journalctl --no-hostname -b -1
+
+# Enroll Nvidia driver & KMOD signing key for secure boot - Enter password "universalblue" if prompted
+enroll-secure-boot-key:
+    #!/usr/bin/bash
+    ENROLLMENT_PASSWORD="universalblue"
+    sudo bash <<EOF
+    mokutil --timeout -1
+    echo -e "$ENROLLMENT_PASSWORD\n$ENROLLMENT_PASSWORD" | mokutil --import "/etc/pki/akmods/certs/akmods-ublue.der"
+    EOF
+    echo 'At next reboot, the mokutil UEFI menu UI will be displayed (*QWERTY* keyboard input and navigation).\nThen, select "Enroll MOK", and input "universalblue" as the password'
+
+# Toggle display of the user-motd in terminal
+toggle-user-motd:
+    #!/usr/bin/bash
+    if [ -e "${HOME}/.config/no-show-user-motd" ] ; then
+      if gum confirm "Would you like to enable the MOTD?" ; then
+        rm -f "${HOME}/.config/no-show-user-motd"
+        echo "MOTD will now be shown on login."
+        exit 0
+      fi
+    fi
+    if gum confirm "Would you like to disable the MOTD?" ; then
+      mkdir -p "${HOME}/.config"
+      touch "${HOME}/.config/no-show-user-motd"
+      echo "MOTD will not be shown anynow"
+      exit 0
+    fi
+
+# Check for local overrides
+check-local-overrides:
+    #!/usr/bin/bash
+    RESET="\x1b[0m"
+    if [ "${NO_COLOR}" == 1 ]; then
+        BLUE_COLOR=""
+        GREEN_COLOR=""
+        YELLOW_COLOR=""
+    else
+        BLUE_COLOR="${BLUE_COLOR:-\x1b[38;5;117m}"
+        GREEN_COLOR="${GREEN_COLOR:-\x1b[38;5;85m}"
+        YELLOW_COLOR="${YELLOW_COLOR:-\x1b[93m}"
+    fi
+
+    diff -qr \
+      --suppress-common-lines \
+      --color="always" \
+      --exclude "passwd*" \
+      --exclude "group*" \
+      --exclude="subgid*" \
+      --exclude="subuid*" \
+      --exclude="machine-id" \
+      --exclude="adjtime" \
+      --exclude="fstab" \
+      --exclude="system-connections" \
+      --exclude="shadow*" \
+      --exclude="gshadow*" \
+      --exclude="ssh_host*" \
+      --exclude="cmdline" \
+      --exclude="crypttab" \
+      --exclude="hostname" \
+      --exclude="localtime" \
+      --exclude="locale*" \
+      --exclude="*lock" \
+      --exclude=".updated" \
+      --exclude="*LOCK" \
+      --exclude="vconsole*" \
+      --exclude="00-keyboard.conf" \
+      --exclude="grub" \
+      --exclude="system.control*" \
+      --exclude="cdi" \
+      --exclude="default.target" \
+      /usr/etc /etc 2>/dev/null | sed \
+          -e '/Binary\ files\ /d ; /Common subdirectories/d' \
+          -e "/Files/ s/^/${BLUE_COLOR}&/g" \
+          -e "/Files/ s/\$/&${RESET}/g" \
+          -e "/Only in/ s/^/${GREEN_COLOR}&/g" \
+          -e "/Only in/ s/\$/&${RESET}/g" \
+          -e "s/\:.*/${RESET}${YELLOW_COLOR}&${RESET}/g"
+
+# Gather device info to a pastebin
+device-info:
+    #!/usr/bin/bash
+    if ! gum confirm "Submit information to the CentOS pastebin?" ; then
+        exit 0
+    fi
+
+    cat &> /tmp/deviceinfo-out <<EOF
+    --#--# sudo bootc status --verbose:
+    $(sudo bootc status --verbose)
+    --#--# fpaste --sysinfo --printonly:
+    $(fpaste --sysinfo --printonly)
+    --#--# flatpak list --columns=application,version,options:
+    $(flatpak list --columns=application,version,options)
+    EOF
+
+    cat /tmp/deviceinfo-out | fpaste
+
+# Measure Idle Power Draw
+check-idle-power-draw:
+    #!/usr/bin/bash
+    if ! command -v powerstat ; then
+        echo "Powerstat is not available"
+        exit 1
+    fi
+    sudo powerstat -a -r
+
+# Run a one minute system benchmark
+[group('System')]
+benchmark:
+    #!/usr/bin/env bash
+    if ! command -v "stress-ng" ; then
+        if gum confirm "Stress does not seem to be on your path, do you wish to install it?" ; then
+            set -eu
+            brew install stress-ng
+            brew link stress-ng
+            set +eu
+        else
+            exit 0
+        fi
+    fi
+
+    echo "Running a 1 minute benchmark ..."
+    trap popd EXIT
+    pushd "$(mktemp -d)"
+    stress-ng --matrix 0 -t 1m --times


### PR DESCRIPTION
## Summary

- **#304** `ujust clean-system` — removes dead `rpm-ostree cleanup -bm` call; bootc manages its own deployment cleanup
- **#352** `ujust changelog` — updates GitHub API URL from `ublue-os/bluefin` → `projectbluefin/dakota`, drops stale rpm-ostree fallback comment
- **#456** Ships `/usr/lib/bootc/install/00-defaults.toml` declaring `bootloader = "systemd"` so downstream images (e.g. dakota-lts) inherit the preference without reading the Justfile
- **#465** Adds `ublue-firstboot-date.service` (runs once on first boot, writes date to `/var/lib/ublue-os/install-date`) and updates fastfetch to read from that stable file instead of `/var/log` ctime which resets on upgrades

## Implementation

Three new BST elements wired into `bluefin/deps.bst` after `bluefin/common.bst`:
- `bluefin/just-overrides.bst` — overrides `default.just` and `changelog.just` with overlap-whitelist
- `bluefin/bootc-install-config.bst` — installs `00-defaults.toml`
- `bluefin/firstboot-date.bst` — installs systemd service + overrides `fastfetch.jsonc`

## Test plan

- [ ] `ujust clean-system` — completes without `rpm-ostree: command not found`
- [ ] `ujust changelog` — curl hits `api.github.com/repos/projectbluefin/dakota/releases`
- [ ] `cat /usr/lib/bootc/install/00-defaults.toml` → shows `bootloader = "systemd"`
- [ ] After first boot: `cat /var/lib/ublue-os/install-date` → install date present
- [ ] `fastfetch` "Forged on" date matches install date, stable across subsequent upgrades

🤖 Generated with [Claude Code](https://claude.com/claude-code)