### PR TITLE
ci: re-enable aarch64 build on cron/dispatch only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,10 +312,12 @@ jobs:
   # ── aarch64 native build ──────────────────────────────────────────────────
   # Mirrors the x86_64 build job. ARM failures do not fail the workflow or
   # block x86_64 publication — this is an experimental parallel build.
-  # Disabled: webkit cold-builds OOM/timeout the ARM runner. Re-enable once
-  # the webkit artifacts are cached in cache.projectbluefin.io.
+  # Only runs on the daily cron and manual dispatch — not on PRs or merge
+  # queue — to avoid burning ARM runner time on code that nobody is using yet.
+  # WebKit aarch64 artifacts are available from gbm.gnome.org (gnome-build-meta
+  # builds aarch64 natively), so cold-build OOM/timeout should no longer occur.
   build-aarch64:
-    if: false
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04-arm
     continue-on-error: true
     outputs:


### PR DESCRIPTION
Remove the 'if: false' gate that was blocking all aarch64 builds. Limit the job to schedule and workflow_dispatch — not PRs or merge queue — so ARM runner time is only spent on production builds.

WebKit aarch64 artifacts are now available from gbm.gnome.org (gnome-build-meta builds aarch64 natively), so the cold-build OOM/timeout that caused the original disable should no longer occur. continue-on-error: true is retained as a safety net.

Supersedes projectbluefin/dakota#452.

Assisted-by: claude-opus-4-5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to enable architecture-specific builds for scheduled and manual triggers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->