### PR TITLE
ci: disable aarch64 build temporarily

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -317,7 +317,7 @@ jobs:
   # WebKit aarch64 artifacts are available from gbm.gnome.org (gnome-build-meta
   # builds aarch64 natively), so cold-build OOM/timeout should no longer occur.
   build-aarch64:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: false  # temporarily disabled — aarch64 needs further investigation
     runs-on: ubuntu-24.04-arm
     continue-on-error: true
     outputs:


### PR DESCRIPTION
Assisted-by: Claude Sonnet 4.5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Temporarily disabled aarch64 native build pipeline in CI/CD workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/499?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->