### PR TITLE
fix(firstboot-date): mkdir -p wants/ before symlink

### DIFF
--- a/elements/bluefin/firstboot-date.bst
+++ b/elements/bluefin/firstboot-date.bst
@@ -19,5 +19,6 @@ config:
   install-commands:
   - install -Dm644 ublue-firstboot-date.service "%{install-root}/usr/lib/systemd/system/ublue-firstboot-date.service"
   - install -Dm644 fastfetch.jsonc "%{install-root}/usr/share/ublue-os/fastfetch.jsonc"
+  - mkdir -p "%{install-root}/usr/lib/systemd/system/multi-user.target.wants/"
   - ln -sf ../ublue-firstboot-date.service "%{install-root}/usr/lib/systemd/system/multi-user.target.wants/ublue-firstboot-date.service"
   - "%{install-extra}"


### PR DESCRIPTION
## Problem

`ln -sf` fails with exit code 1 when the target directory doesn't exist. `multi-user.target.wants/` is not guaranteed to exist in a cold build sandbox — `install -Dm644` only creates the parent of the *destination file*, not sibling directories.

This only surfaces on cold builds (the artifact is cached in CI from prior runs).

## Fix

Add `mkdir -p` before the symlink.

## Diff

```diff
  - install -Dm644 ublue-firstboot-date.service "%{install-root}/usr/lib/systemd/system/ublue-firstboot-date.service"
  - install -Dm644 fastfetch.jsonc "%{install-root}/usr/share/ublue-os/fastfetch.jsonc"
+ - mkdir -p "%{install-root}/usr/lib/systemd/system/multi-user.target.wants/"
  - ln -sf ../ublue-firstboot-date.service "%{install-root}/usr/lib/systemd/system/multi-user.target.wants/ublue-firstboot-date.service"
```

Found during ghost lab cold build of the fdsdk 25.08.12 junction bump (PR #497).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential installation issue by ensuring required system directories are properly created during setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->