### PR TITLE
fix(oci): correct ldconfig invocation — pass explicit conf path

### DIFF
--- a/elements/oci/bluefin.bst
+++ b/elements/oci/bluefin.bst
@@ -59,7 +59,7 @@ config:
       # Root cause: dri_gbm.so has no RPATH and relied on the linker
       # cache to find libgallium-26.0.6.so, which was not yet in
       # /etc/ld.so.cache on the deployed system.
-      ldconfig -r /layer
+      ldconfig -r /layer -f /layer/etc/ld.so.conf
 
     - |
       cd "%{install-root}"


### PR DESCRIPTION
Followup to #517.

`ldconfig -r ROOT` requires `-f` with an absolute host path to the configuration file. Without it:

```
ldconfig: need absolute file name for configuration file when using -r
```

Fix:
```diff
-ldconfig -r /layer
+ldconfig -r /layer -f /layer/etc/ld.so.conf
```

`/etc/ld.so.conf` is present in the sysroot (confirmed on deployed image). The `-f` path must be absolute on the host filesystem, not relative to ROOT.

## Checklist
- [x] One commit, one file, one line
- [x] No conflicts with main
- [x] Commit has exactly one `Assisted-by:` trailer
- [x] I am using an agent and I take responsibility for this PR