### PR TITLE
fix: close Dakota Justfile parity gaps

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,14 +12,19 @@
 just bst build oci/bluefin.bst   # full image build (inside bst2 container)
 just build                        # alias for the above
 just export                       # export OCI image from BST into podman
+just push-local                   # push the exported image to a local lab registry
+just validate                     # validate the default + nvidia graphs before building
 just lint                         # bootc container lint (requires exported image)
 just bst show oci/bluefin.bst     # inspect element dependency graph
 ```
 
-Builds run inside the pinned `bst2` container. `BST_FLAGS` env var injects flags:
+Builds run inside the pinned `bst2` container. `just bst` defaults to the same
+`x86_64_v3` + `--no-interactive` profile used by local/lab x86_64 builds, and
+`BST_FLAGS` can still add CI-only overrides such as `--config`:
 
 ```bash
-just bst build oci/bluefin.bst
+just validate
+BST_FLAGS="-o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf" just bst build oci/bluefin.bst
 ```
 
 ## ⚠️ Hard rules (learned from real mistakes)

--- a/Justfile
+++ b/Justfile
@@ -193,14 +193,21 @@ push-local tag="{{image_tag}}" source_ref="{{image_name}}:{{image_tag}}":
     #!/usr/bin/env bash
     set -euo pipefail
 
-    SUDO_CMD=""
-    if [ "$(id -u)" -ne 0 ]; then
-        SUDO_CMD="sudo"
+    PODMAN=(podman)
+    if ! podman image exists "{{source_ref}}" >/dev/null 2>&1; then
+        if [ "$(id -u)" -eq 0 ]; then
+            :
+        elif sudo -n podman image exists "{{source_ref}}" >/dev/null 2>&1; then
+            PODMAN=(sudo podman)
+        else
+            echo "ERROR: {{source_ref}} not found in the rootless podman store, and passwordless sudo is unavailable for the system store." >&2
+            exit 1
+        fi
     fi
 
     TARGET_REF="{{local_registry}}/{{image_name}}:{{tag}}"
     echo "==> Pushing {{source_ref}} -> ${TARGET_REF}"
-    $SUDO_CMD podman push --tls-verify=false "{{source_ref}}" "${TARGET_REF}"
+    "${PODMAN[@]}" push --tls-verify=false "{{source_ref}}" "${TARGET_REF}"
 
 # ── bootc helper ─────────────────────────────────────────────────────
 [group('dev')]

--- a/Justfile
+++ b/Justfile
@@ -8,6 +8,7 @@ export image_name := env("BUILD_IMAGE_NAME", "dakota")
 export image_tag := env("BUILD_IMAGE_TAG", "latest")
 export base_dir := env("BUILD_BASE_DIR", ".")
 export filesystem := env("BUILD_FILESYSTEM", "btrfs")
+export local_registry := env("LOCAL_REGISTRY", "localhost:5000")
 
 # Same bst2 container image CI uses -- pinned by SHA for reproducibility
 export bst2_image := env("BST2_IMAGE", "registry.gitlab.com/freedesktop-sdk/infrastructure/freedesktop-sdk-docker-images/bst2:64eb0b4930d57a92710822898fb73af6cc1ae35d")
@@ -63,8 +64,12 @@ bst *ARGS:
 # Validate BST element graph — mirrors CI validate job.
 [group('dev')]
 validate:
+    #!/usr/bin/env bash
+    set -euo pipefail
     just bst show --deps all oci/bluefin.bst
-    just bst show --deps all oci/bluefin-nvidia.bst
+    if [ "${BUILD_SKIP_NVIDIA:-}" != "1" ]; then
+        just bst show --deps all oci/bluefin-nvidia.bst
+    fi
 
 # ── Build ─────────────────────────────────────────────────────────────
 # Build the OCI image and load it into podman.
@@ -181,6 +186,21 @@ clean:
 [group('build')]
 build-containerfile $image_name=image_name:
     sudo podman build --security-opt label=type:unconfined_t --squash-all -t "${image_name}:latest" .
+
+# Push the exported local image to an insecure lab/dev registry.
+[group('build')]
+push-local tag="{{image_tag}}" source_ref="{{image_name}}:{{image_tag}}":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    SUDO_CMD=""
+    if [ "$(id -u)" -ne 0 ]; then
+        SUDO_CMD="sudo"
+    fi
+
+    TARGET_REF="{{local_registry}}/{{image_name}}:{{tag}}"
+    echo "==> Pushing {{source_ref}} -> ${TARGET_REF}"
+    $SUDO_CMD podman push --tls-verify=false "{{source_ref}}" "${TARGET_REF}"
 
 # ── bootc helper ─────────────────────────────────────────────────────
 [group('dev')]
@@ -523,6 +543,7 @@ show-me-the-future:
 # the overlay + xattr-apply step can be removed. chunkah can then be run
 # with LD_PRELOAD=fakecap.so FAKECAP_MANIFEST=.../fakecap-manifest.tsv.
 # See also: projectbluefin/dakota#231.
+[group('build')]
 chunkify image_ref:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/Justfile
+++ b/Justfile
@@ -205,7 +205,10 @@ push-local tag="{{image_tag}}" source_ref="{{image_name}}:{{image_tag}}":
         fi
     fi
 
-    TARGET_REF="{{local_registry}}/{{image_name}}:{{tag}}"
+    _src_base="{{source_ref}}"
+    _src_base="${_src_base%%:*}"   # strip :tag suffix
+    _src_base="${_src_base##*/}"   # strip registry/org prefix
+    TARGET_REF="{{local_registry}}/${_src_base}:{{tag}}"
     echo "==> Pushing {{source_ref}} -> ${TARGET_REF}"
     "${PODMAN[@]}" push --tls-verify=false "{{source_ref}}" "${TARGET_REF}"
 


### PR DESCRIPTION
## Summary
- add `just validate` and default `just bst` to the x86_64_v3 + `--no-interactive` profile used by local/lab x86_64 builds
- remove implicit local chunkify from `export`, add `push-local`, and group `chunkify` under the build recipes
- make `push-local` prefer the rootless podman store and fall back to the system store only when needed
- make publish chunkify explicit and update Dakota docs/templates to use the new Justfile flow

## Testing
- [x] `just validate`
- [x] `LOCAL_REGISTRY=192.168.1.102:5000 just push-local latest ghcr.io/projectbluefin/dakota:latest`
- [x] `curl -fsSL http://192.168.1.102:5000/v2/dakota/tags/list` includes `latest`
- [ ] `just lint` passes on a built image
- [ ] `just boot-fast` or `just boot-vm` — desktop comes up, no regressions

Closes #506
Closes #511
Closes #512
Closes #513
Closes #514
Part of #510


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `validate` command for graph validation
  * Added `push-local` command for pushing images to local registry

* **Documentation**
  * Updated build command guidance with clarified validation workflow

* **Chores**
  * Simplified PR testing checklist
  * Enhanced publish workflow with automatic image processing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->