### PR TITLE
fix: move Dakota wallpaper month selection to runtime

### DIFF
--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -34,7 +34,7 @@ config:
     #   - install -Dm644 -t "%{install-root}%{sysconfdir}/" etc/*
     #   - install -Dm644 -t "%{install-root}%{sysconfdir}/" etc/*
   - |
-    sed -i "s|file:///usr/share/backgrounds/bluefin/12-bluefin.xml|file:///var/lib/bluefin/backgrounds/current-bluefin.xml|g" "system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override"
+    sed -i "s#file:///usr/share/backgrounds/bluefin/12-bluefin.xml#file:///var/lib/ublue-os/current-bluefin.xml#g" "system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override"
 
     cp -r system_files/bluefin/usr/./ "%{install-root}%{prefix}/"
     cp -r system_files/shared/usr/./ "%{install-root}%{prefix}/"

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -23,6 +23,7 @@ depends:
   - bluefin/just-overrides.bst
   - bluefin/motd.bst
   - bluefin/firstboot-date.bst
+  - bluefin/wallpaper-month.bst
   - bluefin/bootc-install-config.bst
   - bluefin/composefs-loop-udisks-ignore.bst
   - bluefin/gnome-epub-thumbnailer.bst

--- a/elements/bluefin/wallpaper-month.bst
+++ b/elements/bluefin/wallpaper-month.bst
@@ -1,0 +1,18 @@
+kind: manual
+
+sources:
+- kind: local
+  path: files/firstboot
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - install -Dm644 ublue-wallpaper-month.service "%{install-root}/usr/lib/systemd/system/ublue-wallpaper-month.service"
+  - install -d "%{install-root}/usr/lib/systemd/system/multi-user.target.wants"
+  - ln -sf ../ublue-wallpaper-month.service "%{install-root}/usr/lib/systemd/system/multi-user.target.wants/ublue-wallpaper-month.service"
+  - "%{install-extra}"

--- a/files/firstboot/ublue-wallpaper-month.service
+++ b/files/firstboot/ublue-wallpaper-month.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Point Dakota wallpaper at the current month
+After=local-fs.target
+Before=display-manager.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c 'mkdir -p /var/lib/ublue-os; month="$(date +%%m)"; target="/usr/share/backgrounds/bluefin/${month}-bluefin.xml"; [ -e "$target" ] || target="/usr/share/backgrounds/bluefin/12-bluefin.xml"; ln -sfn "$target" /var/lib/ublue-os/current-bluefin.xml'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- remove build-time month substitution from `elements/bluefin/common.bst`
- point the default background schema at a stable runtime path under `/var/lib/ublue-os/`
- add a boot-time service and dedicated element that refresh the wallpaper symlink to the current month XML

## Testing
- [x] `BST_FLAGS='-o x86_64_v3 true --no-interactive' just bst show --deps all oci/bluefin.bst`

Closes #504


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic monthly wallpaper rotation that runs at system boot, dynamically selecting the current month's wallpaper with a fallback option.

* **Chores**
  * Reorganized wallpaper storage location and updated build system dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/526?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->