### PR TITLE
feat: opt-in AI report stash + Dakota-specific MOTD with gum polish

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -21,6 +21,7 @@ depends:
 
   - bluefin/common.bst
   - bluefin/just-overrides.bst
+  - bluefin/motd.bst
   - bluefin/firstboot-date.bst
   - bluefin/bootc-install-config.bst
   - bluefin/composefs-loop-udisks-ignore.bst

--- a/elements/bluefin/motd.bst
+++ b/elements/bluefin/motd.bst
@@ -1,0 +1,31 @@
+kind: manual
+
+sources:
+- kind: local
+  path: files/motd
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+public:
+  bst:
+    overlap-whitelist:
+    - /usr/bin/ublue-motd
+    - /usr/share/ublue-os/motd/template.md
+    - /usr/share/ublue-os/motd/tips/10-tips.md
+    - /etc/profile.d/bluefin-shell-defaults.sh
+
+config:
+  install-commands:
+  - install -Dm755 ublue-motd "%{install-root}%{bindir}/ublue-motd"
+  - install -Dm644 template.md "%{install-root}/usr/share/ublue-os/motd/template.md"
+  - install -Dm644 tips/10-tips.md "%{install-root}/usr/share/ublue-os/motd/tips/10-tips.md"
+  - |
+    install -Dm644 /dev/stdin "%{install-root}%{sysconfdir}/profile.d/bluefin-shell-defaults.sh" <<'EOF'
+    : "${BLUEFIN_SHELL_ENABLE_MOTD:=1}"
+    export BLUEFIN_SHELL_ENABLE_MOTD
+    EOF
+  - "%{install-extra}"

--- a/files/just-overrides/default.just
+++ b/files/just-overrides/default.just
@@ -336,6 +336,18 @@ report:
     if ! gum confirm " Donate this report to your GitHub gist?"; then
         echo ""
         gum style --foreground 245 --margin "0 2" "Cancelled. Files kept at: $REPORT_DIR/"
+        # Opt-in: stash for AI troubleshooting tools (linux-mcp-server, Goose, etc.)
+        echo ""
+        gum style --foreground 245 --margin "0 2" \
+            "Your AI agent (Goose, OpenCode, etc.) can use a local copy for diagnostics."
+        STASH_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/bluefin/reports"
+        if gum confirm " Keep a local copy for AI troubleshooting tools? (e.g. Goose + linux-mcp-server)" --default=false; then
+            mkdir -p "$STASH_DIR"
+            cp "$REPORT_DIR/summary.md" "$STASH_DIR/last-report.md"
+            [[ -f "$REPORT_DIR/report.otlp.json" ]] && cp "$REPORT_DIR/report.otlp.json" "$STASH_DIR/last-report.otlp.json"
+            gum style --foreground 82 --margin "0 2" \
+                "✓ Stashed at $STASH_DIR/ — your MCP-connected agent can reference it."
+        fi
         trap - EXIT
         exit 0
     fi
@@ -361,6 +373,18 @@ report:
         gum style --foreground 245 --margin "0 4" "gh gist create --public --desc 'Bluefin diagnostic report' $REPORT_DIR/summary.md"
         echo ""
         gum style --foreground 245 --margin "0 2" "Your files are at: $REPORT_DIR/"
+        # Opt-in: stash for AI troubleshooting tools (linux-mcp-server, Goose, etc.)
+        echo ""
+        gum style --foreground 245 --margin "0 2" \
+            "Your AI agent (Goose, OpenCode, etc.) can use a local copy for diagnostics."
+        STASH_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/bluefin/reports"
+        if gum confirm " Keep a local copy for AI troubleshooting tools? (e.g. Goose + linux-mcp-server)" --default=false; then
+            mkdir -p "$STASH_DIR"
+            cp "$REPORT_DIR/summary.md" "$STASH_DIR/last-report.md"
+            [[ -f "$REPORT_DIR/report.otlp.json" ]] && cp "$REPORT_DIR/report.otlp.json" "$STASH_DIR/last-report.otlp.json"
+            gum style --foreground 82 --margin "0 2" \
+                "✓ Stashed at $STASH_DIR/ — your MCP-connected agent can reference it."
+        fi
         trap - EXIT
         exit 0
     fi
@@ -399,6 +423,20 @@ report:
         "✓ Donated — thank you for contributing to the kettle."
     echo ""
     gum style --margin "0 2" "$GIST_URL"
+    echo ""
+
+    # Opt-in: stash for AI troubleshooting tools (linux-mcp-server, Goose, etc.)
+    gum style --foreground 245 --margin "0 2" \
+        "Your AI agent (Goose, OpenCode, etc.) can use a local copy for diagnostics."
+    STASH_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/bluefin/reports"
+    if gum confirm " Keep a local copy for AI troubleshooting tools? (e.g. Goose + linux-mcp-server)" --default=false; then
+        mkdir -p "$STASH_DIR"
+        cp "$REPORT_DIR/summary.md" "$STASH_DIR/last-report.md"
+        [[ -f "$REPORT_DIR/report.otlp.json" ]] && cp "$REPORT_DIR/report.otlp.json" "$STASH_DIR/last-report.otlp.json"
+        printf '%s\n' "$GIST_URL" > "$STASH_DIR/last-report-gist-url"
+        gum style --foreground 82 --margin "0 2" \
+            "✓ Stashed at $STASH_DIR/ — your MCP-connected agent can reference it."
+    fi
     echo ""
 
     # Offer to open issue form with gist pre-filled

--- a/files/motd/template.md
+++ b/files/motd/template.md
@@ -1,0 +1,17 @@
+# 🦖 Welcome to Dakota
+
+󱋩 `${MOTD_IMAGE_NAME}:${MOTD_IMAGE_TAG}`
+
+|  Command | Description |
+| ------- | ----------- |
+| `ujust --choose`  | Show available commands  |
+| `ujust report` | File a diagnostic report |
+| `ujust bluefin-cli` | Enable terminal bling |
+| `ujust toggle-user-motd` | Toggle this banner on/off |
+| `brew help` | Manage command line packages |
+
+${MOTD_TIP}
+
+- **󰊤** [Issues](https://github.com/projectbluefin/dakota/issues)
+- **󰊤** [Ask Bluefin](https://ask.projectbluefin.io)
+- **󰈙** [Documentation](https://docs.projectbluefin.io)

--- a/files/motd/tips/10-tips.md
+++ b/files/motd/tips/10-tips.md
@@ -1,0 +1,16 @@
+Dakota is built entirely from source — no RPMs, no dnf. Pure BuildStream.
+`ujust report` collects structured diagnostics and uploads to your own gist — you review everything first.
+`ujust confirm <issue>` tells maintainers "me too" with your hardware fingerprint attached.
+`ujust verify <issue>` attests whether a shipped fix actually works on your machine.
+Hit a bug? Run `ujust report` — structured data helps maintainers fix things faster.
+Dakota uses atomic OCI updates via `bootc` — your system is always a known-good image.
+Update break something? Roll back instantly with `bootc rollback`.
+Use Goose + linux-mcp-server for AI-powered troubleshooting — it reads your system state live.
+`ujust --choose` shows every available shortcut and the script it runs.
+`ujust bluefin-cli` sets up your terminal with curated developer tools.
+`ujust check-idle-power-draw` measures your system's power consumption at idle.
+`ujust benchmark` runs a one-minute stress test to baseline your hardware.
+`brew search` and `brew install` manage command line packages — updates are automatic.
+Container development is first-class: devcontainers, Podman, and DistroShelf are all ready to go.
+Your feedback closes the loop: report → fix → verify → done. Every `ujust verify` is evidence.
+Dakota ships the same test suite contributors use — `ujust report` is your entry point.

--- a/files/motd/ublue-motd
+++ b/files/motd/ublue-motd
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+# Dakota-specific MOTD script with double-display guard.
+# freedesktop-sdk's /etc/bashrc re-sources profile.d on every shell (unlike
+# Fedora's bashrc which has a shopt -q login_shell guard). This causes profile.d
+# scripts to fire twice: once from /etc/profile, once from /etc/bashrc.
+# The UBLUE_MOTD_SHOWN guard prevents the MOTD from displaying twice.
+
+[ "${UBLUE_MOTD_SHOWN:-0}" = "1" ] && return 0 2>/dev/null || true
+export UBLUE_MOTD_SHOWN=1
+
+MOTD_TEMPLATE_FILE="${MOTD_TEMPLATE_FILE:-/usr/share/ublue-os/motd/template.md}"
+. "${MOTD_ENV_SCRIPT:-/usr/share/ublue-os/motd/env.sh}"
+
+if command -v tput >/dev/null 2>&1 && [ -t 1 ]; then
+  cols=$(tput cols 2>/dev/null)
+  envsubst < "${MOTD_TEMPLATE_FILE}" | glow -w $cols -
+else
+  envsubst < "${MOTD_TEMPLATE_FILE}" | glow -
+fi


### PR DESCRIPTION
## Summary

Three related improvements to the Dakota end-user experience:

### 1. Opt-in local report stash for AI troubleshooting tools

After `ujust report` generates diagnostics, users are offered (default=no) to keep a local copy at `~/.local/share/bluefin/reports/` for MCP-connected agents (Goose + linux-mcp-server).

Stashed files:
- `last-report.md` — structured summary
- `last-report.otlp.json` — deep metrics (if collected)
- `last-report-gist-url` — gist link (successful upload only)

Bridges the structured OTel output with AI diagnostic tooling already shipped in Bluefin. Users who do not want AI tooling simply decline the prompt.

### 2. Full gum widget polish for `ujust report`

Replaces all bare `echo` output with proper charm.sh widgets:
- `gum style` for headers, warnings, status messages
- `gum spin` for the OTel collection and gist upload
- `gum pager` / `glow` for review
- Consistent color palette (82=success, 245=dim, 214=warning, 196=error, 99=accent)

### 3. Dakota-specific MOTD (fixes issue #200 / #402)

- Dakota-branded template promoting `ujust report` and `ujust bluefin-cli`
- Dakota-specific tips replacing generic Bluefin tips
- **Fixes double-display bug** with `UBLUE_MOTD_SHOWN=1` guard in ublue-motd (freedesktop-sdk bashrc re-sources profile.d unlike Fedora)
- MOTD enabled by default (safe now that double-display is fixed)

## Verification

- [x] `just validate` passes (element graph sound)
- [x] No CI-breaking changes (local source elements only)
- [x] Branched from `upstream/main`

## Files changed

| File | Purpose |
|------|---------|
| `files/just-overrides/default.just` | gum polish + opt-in stash |
| `elements/bluefin/motd.bst` | New element for Dakota MOTD |
| `elements/bluefin/deps.bst` | Wire in motd.bst |
| `files/motd/template.md` | Dakota MOTD template |
| `files/motd/tips/10-tips.md` | Dakota-specific tips |
| `files/motd/ublue-motd` | Guarded MOTD script |

Closes #200
Closes #402