### PR TITLE
fix: ghost copy wording + streamlined issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,5 +1,5 @@
-name: "Bug report"
-description: "Something is broken. Let's fix it together."
+name: "🐛 Bug report"
+description: "Something is broken — your ghost copy helps us fix it fast."
 title: "[Bug]: "
 labels: ["kind/bug"]
 type: "Bug"
@@ -7,17 +7,15 @@ body:
   - type: markdown
     attributes:
       value: |
-        Found a bug? Let's squash it. 🐛
+        Found a bug? You're our eyes on the ground. 🦖
 
-        **Before you type anything** — if you're on a running Dakota system, run:
+        Run this first — it's your primary instrument:
 
         ```bash
         ujust report
         ```
 
-        It collects your system state (kernel, image, extensions, failed units) in a privacy-respecting gist and offers to open this form with it pre-attached. You review everything before it uploads. The gist is yours to keep, share, or delete.
-
-        Already have a gist? Paste the URL in the field below and keep the rest short.
+        It collects your system state, you review everything, and it uploads a gist. Paste that URL below and you're done — the structured data does the talking.
 
   - type: checkboxes
     id: checks
@@ -31,7 +29,7 @@ body:
     id: report-link
     attributes:
       label: "ujust report gist URL"
-      description: "Paste the URL from `ujust report`. Gives maintainers your image digest, kernel, extensions, and failed units automatically — no need to describe your environment manually."
+      description: "This is all we need to see your exact image, kernel, extensions, and failed units. Paste and go."
       placeholder: "https://gist.github.com/..."
     validations:
       required: false
@@ -82,4 +80,4 @@ body:
     attributes:
       value: |
         ---
-        *Once a fix ships in nightly, a maintainer will add verify steps so the community can confirm it with `ujust verify <issue-number>`.*
+        *Once a fix ships, you can confirm it works on your machine with `ujust verify <issue-number>` — closing the loop.*

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: true
 contact_links:
-  - name: "Project board"
+  - name: "🦖 Project board"
     url: https://github.com/orgs/projectbluefin/projects/2
-    about: "See what the team is actively working on."
-  - name: "Dakota contribution guide"
+    about: "See what the fleet is working on."
+  - name: "📖 Contribution guide"
     url: https://github.com/projectbluefin/dakota/blob/main/AGENTS.md
-    about: "Read the build, validation, and workflow rules before opening a PR."
-  - name: "Feedback loop design"
+    about: "Build, validation, and workflow rules — read before opening a PR."
+  - name: "🔄 Feedback loop"
     url: https://github.com/projectbluefin/dakota/blob/main/docs/feedback-loop.md
-    about: "How users, contributors, and the ghost lab produce evidence together."
+    about: "How users, contributors, and the ghost lab close the loop together."

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,5 +1,5 @@
-name: "Feature request"
-description: "Propose something new for Bluefin. Use the direct path or opt into the structured queue."
+name: "✨ Feature request"
+description: "Propose something new — shape what Dakota becomes."
 title: "[Feature]: "
 labels: ["kind/enhancement"]
 type: "Feature"
@@ -7,8 +7,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to propose something! 🐟
-        Keep it short and practical. If you opt into **Raptor Current**, `actionadon` will route it through the structured queue. Otherwise it stays a normal issue.
+        You're not filing a ticket — you're shaping the future. 🦖
+
+        Keep it short and practical. If you opt into **Raptor Current**, it enters the structured queue where agents and contributors can pick it up.
 
   - type: checkboxes
     id: checks
@@ -53,40 +54,16 @@ body:
       label: "Affected area"
       description: "Pick the closest match."
       options:
-        - "area/buildstream"
-        - "area/gnome"
-        - "area/brew"
-        - "area/just"
-        - "area/iso"
-        - "area/dx"
-        - "area/services"
-        - "area/flatpak"
-        - "area/nvidia"
-        - "area/hardware"
-        - "area/testing"
-        - "area/upstream"
-        - "area/policy"
+        - "buildstream"
+        - "gnome / desktop"
+        - "brew / CLI"
+        - "just recipes"
+        - "services / systemd"
+        - "nvidia"
+        - "hardware"
+        - "testing / QA"
+        - "upstream / junctions"
         - "other"
-    validations:
-      required: false
-
-  - type: markdown
-    attributes:
-      value: |
-        ---
-        ### Acceptance criteria
-        *Leave this blank unless you're preparing the issue for Raptor Current.*
-
-  - type: textarea
-    id: acceptance-criteria
-    attributes:
-      label: "Acceptance criteria"
-      description: "Optional. For Raptor Current only. Use markdown checklist items (`- [ ] ...`)."
-      placeholder: |
-        - [ ] `just push-local` recipe exists and is documented in `just --list`
-        - [ ] Recipe pushes to `localhost:5000` by default with `REGISTRY` override
-        - [ ] `just validate` passes after the change
-      render: markdown
     validations:
       required: false
 
@@ -94,7 +71,7 @@ body:
     id: affected-elements
     attributes:
       label: "Extra context"
-      description: "Optional. Link related issues, upstream references, or mention affected files/elements."
+      description: "Optional. Related issues, upstream references, or affected files."
       placeholder: "Justfile only — no BST element changes"
     validations:
       required: false
@@ -103,4 +80,4 @@ body:
     attributes:
       value: |
         ---
-        💡 After this feature ships, the community can verify it works with `ujust verify <issue-number>`.
+        💡 After this ships, the community verifies it works with `ujust verify <issue-number>` — your feature, confirmed by the fleet.

--- a/.github/ISSUE_TEMPLATE/help-this-project.yml
+++ b/.github/ISSUE_TEMPLATE/help-this-project.yml
@@ -1,21 +1,13 @@
-name: "Help this project"
-description: "Donate agent time with a repo, issue, or PR URL. Hive will coordinate the right flow."
-title: "[Help this project]: "
+name: "🐝 Help this project"
+description: "Donate agent time — point at a repo, issue, or PR and get a high-signal report back."
+title: "[Help]: "
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for donating agent time. 🐝
+        Point your ghost at something and it comes back with a report. 🐝
 
-        ### Workflow: Agent Donation
-
-        This form fast-tracks the issue into Hive's queue. The URL below tells agents which flow to follow:
-
-        - **Repository, org, roadmap, or docs URL** → produce a sourced project report
-        - **Issue URL** → review the issue quality, missing context, blockers, and recommended next steps
-        - **PR URL** → review the PR; if the target is Dakota and review claims depend on local proof, use `just validate`, `just build default`, `just lint`, and `just boot-fast` or `just generate-bootable-image && just boot-vm`
-
-        **Deliverable:** post a high-quality report comment with sources, then close this Dakota issue.
+        Paste a URL below — Hive routes the right agent to investigate and report back here.
 
   - type: input
     id: target-url

--- a/files/just-overrides/default.just
+++ b/files/just-overrides/default.just
@@ -336,17 +336,17 @@ report:
     if ! gum confirm " Donate this report to your GitHub gist?"; then
         echo ""
         gum style --foreground 245 --margin "0 2" "Cancelled. Files kept at: $REPORT_DIR/"
-        # Opt-in: stash for AI troubleshooting tools (linux-mcp-server, Goose, etc.)
+        # Opt-in: ghost copy for companion tools (Goose, OpenCode, etc.)
         echo ""
         gum style --foreground 245 --margin "0 2" \
-            "Your AI agent (Goose, OpenCode, etc.) can use a local copy for diagnostics."
+            "Keep a ghost copy so your companion tools can help you contribute."
         STASH_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/bluefin/reports"
-        if gum confirm " Keep a local copy for AI troubleshooting tools? (e.g. Goose + linux-mcp-server)" --default=false; then
+        if gum confirm " Save a ghost copy for companion tools? (Goose, OpenCode, etc.)" --default=false; then
             mkdir -p "$STASH_DIR"
             cp "$REPORT_DIR/summary.md" "$STASH_DIR/last-report.md"
             [[ -f "$REPORT_DIR/report.otlp.json" ]] && cp "$REPORT_DIR/report.otlp.json" "$STASH_DIR/last-report.otlp.json"
             gum style --foreground 82 --margin "0 2" \
-                "✓ Stashed at $STASH_DIR/ — your MCP-connected agent can reference it."
+                "✓ Ghost copy saved to $STASH_DIR/ — ready for your next contribution."
         fi
         trap - EXIT
         exit 0
@@ -373,17 +373,17 @@ report:
         gum style --foreground 245 --margin "0 4" "gh gist create --public --desc 'Bluefin diagnostic report' $REPORT_DIR/summary.md"
         echo ""
         gum style --foreground 245 --margin "0 2" "Your files are at: $REPORT_DIR/"
-        # Opt-in: stash for AI troubleshooting tools (linux-mcp-server, Goose, etc.)
+        # Opt-in: ghost copy for companion tools (Goose, OpenCode, etc.)
         echo ""
         gum style --foreground 245 --margin "0 2" \
-            "Your AI agent (Goose, OpenCode, etc.) can use a local copy for diagnostics."
+            "Keep a ghost copy so your companion tools can help you contribute."
         STASH_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/bluefin/reports"
-        if gum confirm " Keep a local copy for AI troubleshooting tools? (e.g. Goose + linux-mcp-server)" --default=false; then
+        if gum confirm " Save a ghost copy for companion tools? (Goose, OpenCode, etc.)" --default=false; then
             mkdir -p "$STASH_DIR"
             cp "$REPORT_DIR/summary.md" "$STASH_DIR/last-report.md"
             [[ -f "$REPORT_DIR/report.otlp.json" ]] && cp "$REPORT_DIR/report.otlp.json" "$STASH_DIR/last-report.otlp.json"
             gum style --foreground 82 --margin "0 2" \
-                "✓ Stashed at $STASH_DIR/ — your MCP-connected agent can reference it."
+                "✓ Ghost copy saved to $STASH_DIR/ — ready for your next contribution."
         fi
         trap - EXIT
         exit 0
@@ -425,17 +425,17 @@ report:
     gum style --margin "0 2" "$GIST_URL"
     echo ""
 
-    # Opt-in: stash for AI troubleshooting tools (linux-mcp-server, Goose, etc.)
+    # Opt-in: ghost copy for companion tools (Goose, OpenCode, etc.)
     gum style --foreground 245 --margin "0 2" \
-        "Your AI agent (Goose, OpenCode, etc.) can use a local copy for diagnostics."
+        "Keep a ghost copy so your companion tools can help you contribute."
     STASH_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/bluefin/reports"
-    if gum confirm " Keep a local copy for AI troubleshooting tools? (e.g. Goose + linux-mcp-server)" --default=false; then
+    if gum confirm " Save a ghost copy for companion tools? (Goose, OpenCode, etc.)" --default=false; then
         mkdir -p "$STASH_DIR"
         cp "$REPORT_DIR/summary.md" "$STASH_DIR/last-report.md"
         [[ -f "$REPORT_DIR/report.otlp.json" ]] && cp "$REPORT_DIR/report.otlp.json" "$STASH_DIR/last-report.otlp.json"
         printf '%s\n' "$GIST_URL" > "$STASH_DIR/last-report-gist-url"
         gum style --foreground 82 --margin "0 2" \
-            "✓ Stashed at $STASH_DIR/ — your MCP-connected agent can reference it."
+            "✓ Ghost copy saved to $STASH_DIR/ — ready for your next contribution."
     fi
     echo ""
 


### PR DESCRIPTION
Reframes the opt-in local report copy and overhauls issue templates.

**Ghost copy (was 'AI stash'):**
- "Save a ghost copy for companion tools?" — less ominous, contributor-first
- Your ghost is your companion, not surveillance

**Issue templates streamlined:**
- 🐛 Bug report: punchier intro, emphasizes `ujust report` as your primary instrument
- ✨ Feature request: trimmed acceptance criteria section (maintainers add that later), simplified area labels
- 🐝 Help this project: condensed from a wall of text to two lines
- config.yml: emoji, fleet language

**Vibe:** You're not filing tickets — you're shaping the future. This is your machine for helping Bluefin and Linux.

Follow-up to #540.