### PR TITLE
Label-driven issue templates with ghost diagnostic state

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,55 +1,61 @@
-name: "Bug report"
-description: "Something is broken — your ghost copy helps us fix it fast."
-title: "[Bug]: "
+name: Bug report
+description: Something is broken in the built image or build system.
 labels: ["kind/bug"]
-type: "Bug"
+type: Bug
 body:
   - type: markdown
     attributes:
       value: |
-        Found a bug? You're our eyes on the ground.
-
-        Run this first — it's your primary instrument:
+        Run this first if you can — it captures your system state and gives us everything we need:
 
         ```bash
         ujust report
         ```
 
-        It collects your system state, you review everything, and it uploads a gist. Paste that URL below and you're done — the structured data does the talking.
+        You review everything before it uploads. Paste the gist URL below.
 
   - type: checkboxes
     id: checks
     attributes:
-      label: "Before submitting"
+      label: Before submitting
       options:
-        - label: "I searched existing issues first"
+        - label: I searched existing issues first
           required: true
 
   - type: input
     id: report-link
     attributes:
-      label: "ujust report gist URL"
-      description: "This is all we need to see your exact image, kernel, extensions, and failed units. Paste and go."
+      label: ujust report gist URL
+      description: "Paste the gist URL from ujust report. This gives us your image digest, kernel, extensions, and failed units."
       placeholder: "https://gist.github.com/..."
     validations:
       required: false
 
   - type: dropdown
-    id: workflow-path
+    id: area
     attributes:
-      label: "Workflow path"
-      description: "Direct path by default. Pick Raptor Current only if you want the structured agent queue."
+      label: What area is affected?
+      description: Pick the closest match. This applies a label so maintainers can triage from the board.
       options:
-        - "Direct issue (skip workflow)"
-        - "Raptor Current (structured + wrangler + agent queue)"
+        - GNOME / desktop
+        - Audio / Bluetooth
+        - Networking
+        - Nvidia
+        - Hardware
+        - Build system
+        - Just recipes
+        - Flatpak
+        - Brew / CLI tools
+        - Services / systemd
+        - Other
     validations:
       required: true
 
   - type: textarea
     id: what-happened
     attributes:
-      label: "What happened?"
-      description: "What did you see? What did you expect? One paragraph is enough."
+      label: What happened?
+      description: What did you see? What did you expect? One paragraph is enough.
       placeholder: |
         Bluetooth disappears from the panel after suspend. The indicator is gone until I reboot. Expected it to reconnect automatically.
     validations:
@@ -58,8 +64,8 @@ body:
   - type: textarea
     id: repro
     attributes:
-      label: "Steps to reproduce"
-      description: "Minimal steps to hit the bug."
+      label: Steps to reproduce
+      description: Minimal steps to hit the bug.
       placeholder: |
         1. Suspend the machine
         2. Wake it
@@ -70,14 +76,8 @@ body:
   - type: textarea
     id: extra
     attributes:
-      label: "Extra context"
+      label: Extra context
       description: "Optional. Logs, upstream references, affected hardware. Leave blank if your gist covers it."
       placeholder: "Appears on Framework 13 AMD. Not affected on Intel NUC."
     validations:
       required: false
-
-  - type: markdown
-    attributes:
-      value: |
-        ---
-        *Once a fix ships, you can confirm it works on your machine with `ujust verify <issue-number>` — closing the loop.*

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: true
 contact_links:
-  - name: "Project board"
+  - name: Project board
     url: https://github.com/orgs/projectbluefin/projects/2
     about: "See what the fleet is working on."
-  - name: "Contribution guide"
+  - name: Contribution guide
     url: https://github.com/projectbluefin/dakota/blob/main/AGENTS.md
     about: "Build, validation, and workflow rules — read before opening a PR."
-  - name: "Feedback loop"
+  - name: Feedback loop
     url: https://github.com/projectbluefin/dakota/blob/main/docs/feedback-loop.md
     about: "How users, contributors, and the ghost lab close the loop together."

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,40 +1,48 @@
-name: "Feature request"
-description: "Propose something new — shape what Dakota becomes."
-title: "[Feature]: "
+name: Feature request
+description: Propose something new for the image or build system.
 labels: ["kind/enhancement"]
-type: "Feature"
+type: Feature
 body:
   - type: markdown
     attributes:
       value: |
-        You're not filing a ticket — you're shaping the future.
-
-        Keep it short and practical. If you opt into **Raptor Current**, it enters the structured queue where agents and contributors can pick it up.
+        Keep it short and practical. What's missing, and what would done look like?
 
   - type: checkboxes
     id: checks
     attributes:
-      label: "Before submitting"
+      label: Before submitting
       options:
-        - label: "I searched existing issues first"
+        - label: I searched existing issues first
           required: true
 
   - type: dropdown
-    id: workflow-path
+    id: area
     attributes:
-      label: "Workflow path"
-      description: "Use the direct path by default. Pick Raptor Current only if you want the structured queue."
+      label: What area does this affect?
+      description: Pick the closest match. This drives triage on the board.
       options:
-        - "Direct issue (skip workflow)"
-        - "Raptor Current (structured + wrangler + agent queue)"
+        - GNOME / desktop
+        - Audio / Bluetooth
+        - Networking
+        - Nvidia
+        - Hardware
+        - Build system
+        - Just recipes
+        - Flatpak
+        - Brew / CLI tools
+        - Services / systemd
+        - CI / automation
+        - Agent workflows
+        - Other
     validations:
       required: true
 
   - type: textarea
     id: problem
     attributes:
-      label: "What problem are you solving?"
-      description: "One paragraph. Plain language. What's broken, missing, or annoying today?"
+      label: What problem are you solving?
+      description: One paragraph. Plain language. What's broken, missing, or annoying today?
       placeholder: "I keep having to manually push my local build to the zot registry because there's no just recipe for it..."
     validations:
       required: true
@@ -42,42 +50,17 @@ body:
   - type: textarea
     id: solution
     attributes:
-      label: "What do you propose?"
-      description: "How should it work? What would done look like?"
+      label: What do you propose?
+      description: How should it work? What would done look like?
       placeholder: "Add a `just push-local` recipe that wraps `podman push` with the lab registry URL pre-filled."
     validations:
       required: true
 
-  - type: dropdown
-    id: area
-    attributes:
-      label: "Affected area"
-      description: "Pick the closest match."
-      options:
-        - "buildstream"
-        - "gnome / desktop"
-        - "brew / CLI"
-        - "just recipes"
-        - "services / systemd"
-        - "nvidia"
-        - "hardware"
-        - "testing / QA"
-        - "upstream / junctions"
-        - "other"
-    validations:
-      required: false
-
   - type: textarea
-    id: affected-elements
+    id: extra
     attributes:
-      label: "Extra context"
+      label: Extra context
       description: "Optional. Related issues, upstream references, or affected files."
-      placeholder: "Justfile only — no BST element changes"
+      placeholder: "Justfile only — no BST element changes needed."
     validations:
       required: false
-
-  - type: markdown
-    attributes:
-      value: |
-        ---
-        After this ships, the community verifies it works with `ujust verify <issue-number>` — your feature, confirmed by the fleet.

--- a/.github/ISSUE_TEMPLATE/help-this-project.yml
+++ b/.github/ISSUE_TEMPLATE/help-this-project.yml
@@ -1,28 +1,38 @@
-name: "Help this project"
-description: "Donate agent time — point at a repo, issue, or PR and get a high-signal report back."
-title: "[Help]: "
+name: Help this project
+description: Donate agent time — point at a repo, issue, or PR and get a report back.
+labels: ["kind:agent-donation"]
 body:
   - type: markdown
     attributes:
       value: |
-        Point your ghost at something and it comes back with a report.
-
-        Paste a URL below — Hive routes the right agent to investigate and report back here.
+        Paste a URL below. Hive routes the right agent to investigate and report back here.
 
   - type: input
     id: target-url
     attributes:
-      label: "Target URL"
+      label: Target URL
       description: "Paste the repo, issue, PR, roadmap, or docs URL that should get agent help."
       placeholder: "https://github.com/owner/repo"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: flow
+    attributes:
+      label: What kind of help?
+      description: This determines which agent picks it up.
+      options:
+        - "Project report (high-level analysis of a repo or roadmap)"
+        - "Issue review (assess a specific issue and recommend next steps)"
+        - "PR review (audit a pull request for correctness and completeness)"
     validations:
       required: true
 
   - type: textarea
     id: goal
     attributes:
-      label: "What help do you want?"
-      description: "Keep it short. One or two sentences is enough."
+      label: What specifically do you want to know?
+      description: One or two sentences is enough.
       placeholder: "Help this project. Give me a high-signal report on what needs attention first."
     validations:
       required: true
@@ -30,8 +40,8 @@ body:
   - type: textarea
     id: context
     attributes:
-      label: "Extra context"
-      description: "Optional. Add constraints, suspected problem areas, or specific questions for the agent."
+      label: Extra context
+      description: "Optional. Constraints, suspected problem areas, or specific questions."
       placeholder: "Focus on CI reliability and whether the PR review checklist is strong enough."
     validations:
       required: false

--- a/.github/workflows/actionadon.yml
+++ b/.github/workflows/actionadon.yml
@@ -124,6 +124,90 @@ jobs:
             --add-label "kind:agent-donation" \
             --add-label "$FLOW_LABEL"
 
+      - name: Auto-label bug diagnostics
+        if: contains(github.event.issue.labels.*.name, 'kind/bug')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          LABELS=""
+
+          # Detect gist URL — user submitted telemetry
+          if printf '%s\n' "$ISSUE_BODY" | grep -Eq 'https://gist\.github(usercontent)?\.com/'; then
+            LABELS="ghost/report-attached"
+          else
+            LABELS="ghost/needs-data"
+          fi
+
+          # Detect area from dropdown selection
+          AREA=""
+          if printf '%s\n' "$ISSUE_BODY" | grep -Fq "GNOME / desktop"; then
+            AREA="area/gnome"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Audio / Bluetooth"; then
+            AREA="area/hardware"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Networking"; then
+            AREA="area/services"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Nvidia"; then
+            AREA="area/nvidia"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Hardware"; then
+            AREA="area/hardware"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Build system"; then
+            AREA="area/buildstream"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Just recipes"; then
+            AREA="area/just"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Flatpak"; then
+            AREA="area/flatpak"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Brew / CLI tools"; then
+            AREA="area/brew"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Services / systemd"; then
+            AREA="area/services"
+          fi
+
+          if [ -n "$AREA" ]; then
+            LABELS="${LABELS},${AREA}"
+          fi
+
+          gh issue edit "$ISSUE_URL" --add-label "$LABELS"
+
+      - name: Auto-label feature area
+        if: contains(github.event.issue.labels.*.name, 'kind/enhancement')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          AREA=""
+          if printf '%s\n' "$ISSUE_BODY" | grep -Fq "GNOME / desktop"; then
+            AREA="area/gnome"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Audio / Bluetooth"; then
+            AREA="area/hardware"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Networking"; then
+            AREA="area/services"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Nvidia"; then
+            AREA="area/nvidia"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Hardware"; then
+            AREA="area/hardware"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Build system"; then
+            AREA="area/buildstream"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Just recipes"; then
+            AREA="area/just"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Flatpak"; then
+            AREA="area/flatpak"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Brew / CLI tools"; then
+            AREA="area/brew"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Services / systemd"; then
+            AREA="area/services"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "CI / automation"; then
+            AREA="area/ci"
+          elif printf '%s\n' "$ISSUE_BODY" | grep -Fq "Agent workflows"; then
+            AREA="area/agent"
+          fi
+
+          if [ -n "$AREA" ]; then
+            gh issue edit "$ISSUE_URL" --add-label "$AREA"
+          fi
+
       - name: Welcome comment
         if: steps.workflow.outputs.workflow == 'raptor_current'
         env:
@@ -132,14 +216,11 @@ jobs:
           WORKFLOW_NAME: ${{ env.WORKFLOW_NAME }}
         run: |
           cat << EOF > /tmp/comment.md
-          👋 A new chapter begins — thanks for bringing this to Dakota!
+          Thanks for bringing this to Dakota.
 
           You opted into **${WORKFLOW_NAME}**.
 
-          **Community:** discuss below. Does this fit Bluefin's direction? A 👍 goes a long way. If you hit the same bug, run:
-          \`\`\`bash
-          ujust confirm $(echo "$ISSUE_URL" | grep -oP '\d+$')
-          \`\`\`
+          **Community:** discuss below. Does this fit Bluefin's direction? A thumbs-up goes a long way.
 
           **Maintainers and wranglers:** when this issue is ready for the structured path, add \`status/approved\` and fill in the acceptance criteria. That spec is what a contributor or agent will build against.
           EOF
@@ -416,7 +497,6 @@ jobs:
             --json number,url,updatedAt,assignees \
             --jq ".[] | select(.updatedAt < \"$CUTOFF\") | .number" \
           | while read -r NUMBER; do
-              URL="https://github.com/${REPO}/issues/${NUMBER}"
               ASSIGNEE=$(gh issue view "$NUMBER" --repo "$REPO" \
                 --json assignees --jq '.assignees[0].login // ""')
 


### PR DESCRIPTION
## What

Rewrites issue templates to be label-driven. The board at todo.projectbluefin.io can now triage by filtering labels instead of parsing title prefixes.

## Changes

**Templates:**
- Removed `[Bug]:` `[Feature]:` `[Help]:` title prefixes — titles are now freeform
- Removed emojis from template names and config links
- Added area dropdown to bug reports (required)
- Added area dropdown to feature requests (required)
- Added flow-type dropdown to help-this-project
- Removed the Raptor Current workflow dropdown (internal routing handled by labels, not user-facing)

**Actionadon automation:**
- Auto-applies `ghost/report-attached` when a bug report contains a gist URL
- Auto-applies `ghost/needs-data` when a bug report has no gist
- Auto-applies `area/*` label based on dropdown selection (both bugs and features)

**New labels (already created on the repo):**

| Label | Meaning |
|-------|---------|
| `ghost/report-attached` | User submitted ujust report data — we have telemetry |
| `ghost/needs-data` | Flying blind — need ujust report or logs |
| `ghost/reproduced` | Someone else hit the same issue |
| `ghost/verified` | User confirmed the fix works on their hardware |
| `ghost/regression` | This was working before — something broke it |
| `area/ci` | CI/CD pipelines, linting, build automation |
| `area/agent` | Agent workflows, actionadon, Hive integration |
| `area/ujust` | ujust recipes, user-facing CLI workflows |

## Board triage model

The project board can now filter:
- **ghost/* labels** — diagnostic state at a glance (like an F1 garage wall: do we have data from the car?)
- **area/* labels** — subsystem routing
- **kind/* labels** — bugs vs improvements vs tech-debt

Done = merged PR auto-closes the issue, board status moves to Done.

## Verification

```
just validate
```
No element changes — graph unchanged. This is templates + workflow automation only.