### PR TITLE
Add contributor discovery table to AGENTS.md

### DIFF
--- a/.github/workflows/actionadon.yml
+++ b/.github/workflows/actionadon.yml
@@ -7,8 +7,8 @@ name: actionadon
 # Lifecycle:
 #   opened → status/discussing
 #   status/approved (maintainer) → needs spec comment
-#   needs-human/agent-ready (maintainer) → queue announcement
-#   /claim comment → agent/claimed + assigned
+#   queue/agent-ready (maintainer) → queue announcement
+#   /claim comment → queue/claimed + assigned
 #   /ready comment (wrangler) → queued for agents
 #   /unclaim comment → back in queue
 #   daily sweep → unclaim issues idle > 7 days
@@ -59,9 +59,9 @@ jobs:
           }
           label "status/discussing" "7c83fd" "Structured issue flow in progress; not ready for the agent queue yet."
           label "status/approved" "2ea44f" "Approved for queue preparation; add acceptance criteria before /ready."
-          label "agent/claimed" "e8b86d" "Actively being worked by a human or agent."
+          label "queue/claimed" "e8b86d" "Actively being worked by a human or agent."
           label "agent/blocked" "e74c3c" "Blocked and needs human input before work can continue."
-          label "needs-human/agent-ready" "a467dc" "Structured issue is ready for a human or agent to claim."
+          label "queue/agent-ready" "a467dc" "Structured issue is ready for a human or agent to claim."
           label "needs-human/agent-oops" "f795fe" "Agent mistake or bad automation outcome; Hive must not touch."
           label "kind:agent-donation" "1b7f83" "Donate agent time for a repo, issue, or PR review/report request."
           label "flow/project-report" "0e8a16" "Agent flow: produce a sourced project report."
@@ -120,7 +120,7 @@ jobs:
           FLOW_LABEL: ${{ steps.donation.outputs.flow_label }}
         run: |
           gh issue edit "$ISSUE_URL" \
-            --add-label "needs-human/agent-ready" \
+            --add-label "queue/agent-ready" \
             --add-label "kind:agent-donation" \
             --add-label "$FLOW_LABEL"
 
@@ -160,14 +160,14 @@ jobs:
           cat << 'EOF' > /tmp/comment.md
           ✅ Approved. The community has found its way here.
 
-          Before this goes to the build queue it needs **acceptance criteria** — the spec a contributor or agent will implement against. Add it to the issue body, then apply `needs-human/agent-ready` to open it up.
+          Before this goes to the build queue it needs **acceptance criteria** — the spec a contributor or agent will implement against. Add it to the issue body, then apply `queue/agent-ready` to open it up.
 
           **Wranglers:** write acceptance criteria, then comment `/ready`.
           EOF
           gh issue comment "$ISSUE_URL" --body-file /tmp/comment.md
 
-      - name: Comment on needs-human/agent-ready
-        if: github.event.label.name == 'needs-human/agent-ready'
+      - name: Comment on queue/agent-ready
+        if: github.event.label.name == 'queue/agent-ready'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
@@ -249,7 +249,7 @@ jobs:
           LABELS=$(gh issue view "$ISSUE_URL" --json labels --jq '[.labels[].name] | join(",")')
 
           # Already claimed
-          if echo "$LABELS" | grep -q "agent/claimed"; then
+          if echo "$LABELS" | grep -q "queue/claimed"; then
             ASSIGNEE=$(gh issue view "$ISSUE_URL" --json assignees --jq '.assignees[0].login // "someone"')
             cat << EOF > /tmp/comment.md
           Already claimed by @${ASSIGNEE}. If they've gone quiet, a maintainer can \`/unclaim\` to return it to the queue.
@@ -259,15 +259,15 @@ jobs:
           fi
 
           # Not in queue
-          if ! echo "$LABELS" | grep -q "needs-human/agent-ready"; then
+          if ! echo "$LABELS" | grep -q "queue/agent-ready"; then
             cat << 'EOF' > /tmp/comment.md
-          This issue isn't in the agent queue yet — it needs `needs-human/agent-ready` before it can be claimed.
+          This issue isn't in the agent queue yet — it needs `queue/agent-ready` before it can be claimed.
           EOF
             gh issue comment "$ISSUE_URL" --body-file /tmp/comment.md
             exit 0
           fi
 
-          gh issue edit "$ISSUE_URL" --add-label "agent/claimed" --add-assignee "$COMMENTER"
+          gh issue edit "$ISSUE_URL" --add-label "queue/claimed" --add-assignee "$COMMENTER"
           if echo "$LABELS" | grep -q "kind:agent-donation"; then
             cat << EOF > /tmp/comment.md
           🎣 @${COMMENTER} has this one! Follow the workflow embedded in the issue, post a sourced report comment when you're done, and close this issue so Hive can move on.
@@ -353,7 +353,7 @@ jobs:
             exit 0
           fi
 
-          if echo "$LABELS" | grep -q "needs-human/agent-ready"; then
+          if echo "$LABELS" | grep -q "queue/agent-ready"; then
             cat << 'EOF' > /tmp/comment.md
           This issue is already in the queue and ready for a human or agent to `/claim`.
           EOF
@@ -361,7 +361,7 @@ jobs:
             exit 0
           fi
 
-          gh issue edit "$ISSUE_URL" --add-label "needs-human/agent-ready"
+          gh issue edit "$ISSUE_URL" --add-label "queue/agent-ready"
 
       - name: Handle /unclaim
         if: startsWith(github.event.comment.body, '/unclaim')
@@ -388,7 +388,7 @@ jobs:
             exit 0
           fi
 
-          gh issue edit "$ISSUE_URL" --remove-label "agent/claimed"
+          gh issue edit "$ISSUE_URL" --remove-label "queue/claimed"
           if [ -n "$ASSIGNEE" ]; then
             gh issue edit "$ISSUE_URL" --remove-assignee "$ASSIGNEE"
           fi
@@ -412,15 +412,14 @@ jobs:
           CUTOFF=$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')
 
           gh issue list --repo "$REPO" \
-            --label "agent/claimed" \
+            --label "queue/claimed" \
             --json number,url,updatedAt,assignees \
             --jq ".[] | select(.updatedAt < \"$CUTOFF\") | .number" \
           | while read -r NUMBER; do
-              URL="https://github.com/${REPO}/issues/${NUMBER}"
               ASSIGNEE=$(gh issue view "$NUMBER" --repo "$REPO" \
                 --json assignees --jq '.assignees[0].login // ""')
 
-              gh issue edit "$NUMBER" --repo "$REPO" --remove-label "agent/claimed"
+              gh issue edit "$NUMBER" --repo "$REPO" --remove-label "queue/claimed"
               if [ -n "$ASSIGNEE" ]; then
                 gh issue edit "$NUMBER" --repo "$REPO" --remove-assignee "$ASSIGNEE"
                 cat << EOF > /tmp/comment.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -461,4 +461,7 @@ just bst show --deps all --format '%{name}' oci/bluefin.bst \
 - freedesktop-sdk: https://gitlab.com/freedesktop-sdk/freedesktop-sdk
 - gnome-build-meta (GitHub mirror): https://github.com/GNOME/gnome-build-meta - branch `gnome-50`
 - Existing issues: https://github.com/projectbluefin/dakota/issues
-- Project board: https://github.com/orgs/projectbluefin/projects/2
+- Dakota Flow (kanban): https://github.com/orgs/projectbluefin/projects/4
+- Dakota Epics (epic overview): https://github.com/orgs/projectbluefin/projects/5
+- Dakota Development (full table): https://github.com/orgs/projectbluefin/projects/3
+- todo.projectbluefin.io (all Bluefin projects): https://github.com/orgs/projectbluefin/projects/2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,17 @@
 > contribute safely and test PRs in this repository. Human contributors can
 > follow the same steps.
 
+## Find something to work on
+
+| Time available | Link |
+|----------------|------|
+| 30 minutes | [XS issues](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Aqueue%2Fagent-ready+label%3Asize%2Fxs+no%3Aassignee) |
+| Half a day | [S issues](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Aqueue%2Fagent-ready+label%3Asize%2Fs+no%3Aassignee) |
+| Full day | [M issues](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Aqueue%2Fagent-ready+label%3Asize%2Fm+no%3Aassignee) |
+| All sizes | [Everything ready](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Aqueue%2Fagent-ready+no%3Aassignee+sort%3Acreated-asc) |
+
+Comment `/claim` on any issue to take it. Actionadon assigns it to you and removes it from the pool. If there's no PR activity after 7 days it returns automatically — no hard feelings.
+
 Dakota is a [BuildStream 2](https://buildstream.build/) project that produces
 **Bluefin** - a bootc OCI desktop image built entirely from source using
 freedesktop-sdk and gnome-build-meta as upstream foundations. No RPMs. No dnf.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -461,7 +461,5 @@ just bst show --deps all --format '%{name}' oci/bluefin.bst \
 - freedesktop-sdk: https://gitlab.com/freedesktop-sdk/freedesktop-sdk
 - gnome-build-meta (GitHub mirror): https://github.com/GNOME/gnome-build-meta - branch `gnome-50`
 - Existing issues: https://github.com/projectbluefin/dakota/issues
-- Dakota Flow (kanban): https://github.com/orgs/projectbluefin/projects/4
-- Dakota Epics (epic overview): https://github.com/orgs/projectbluefin/projects/5
-- Dakota Development (full table): https://github.com/orgs/projectbluefin/projects/3
+- Dakota Development board: https://github.com/orgs/projectbluefin/projects/3
 - todo.projectbluefin.io (all Bluefin projects): https://github.com/orgs/projectbluefin/projects/2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,10 +279,10 @@ Discussion happens in the issue if people want it
   ▼ Maintainer adds status/approved when the issue is ready for approval
 Maintainer writes acceptance criteria in the issue body
   │
-  ▼ Maintainer adds needs-human/agent-ready
+  ▼ Maintainer adds queue/agent-ready
 Any human or agent can claim it — comment /claim on the issue
   │
-  ▼ actionadon adds agent/claimed, assigns the claimer
+  ▼ actionadon adds queue/claimed, assigns the claimer
 Implement the acceptance criteria, open a PR with Closes #NNN
   │
   ▼ CI validate passes, maintainer reviews, lab:pass applied
@@ -293,7 +293,7 @@ Merge queue → issue closes automatically
 
 `actionadon` is the bot that drives this. It runs as a GitHub Actions workflow (`.github/workflows/actionadon.yml`) and posts one short comment each time an issue advances a stage.
 
-| Comment `/claim` | Takes the issue. actionadon assigns you and adds `agent/claimed`. |
+| Comment `/claim` | Takes the issue. actionadon assigns you and adds `queue/claimed`. |
 |---|---|
 | Comment `/ready` | Wranglers and maintainers can move an approved, spec-complete issue into the queue. It requires a `### Acceptance criteria` section with real checklist items. |
 | Comment `/unclaim` | Returns it to the queue. The assignee, a wrangler, or a maintainer can unclaim. |
@@ -322,7 +322,7 @@ Initial wranglers:
 
 ### Hive integration
 
-If you're running [Hive](https://github.com/kubestellar/hive) against this repo, copy `files/hive/hive-project.yaml.example` to `/etc/hive/hive-project.yaml` and load the agent policy files from `files/hive/agent-policies/` as your per-agent CLAUDE.md overrides. The repo-local skill folder at `.github/skills/` is the human-readable companion to those Hive policies: use `dakota-build` for local validation, `dakota-agent-workflow` for issue/PR/report flows, and `dakota-ci` for routing changes. Hive will route donated-agent issues by flow: scanner handles project reports and issue reviews, reviewer handles PR reviews, and architect handles larger Dakota structural work. All of them claim `needs-human/agent-ready` issues via the `/claim` protocol above.
+If you're running [Hive](https://github.com/kubestellar/hive) against this repo, copy `files/hive/hive-project.yaml.example` to `/etc/hive/hive-project.yaml` and load the agent policy files from `files/hive/agent-policies/` as your per-agent CLAUDE.md overrides. The repo-local skill folder at `.github/skills/` is the human-readable companion to those Hive policies: use `dakota-build` for local validation, `dakota-agent-workflow` for issue/PR/report flows, and `dakota-ci` for routing changes. Hive will route donated-agent issues by flow: scanner handles project reports and issue reviews, reviewer handles PR reviews, and architect handles larger Dakota structural work. All of them claim `queue/agent-ready` issues via the `/claim` protocol above.
 
 ---
 ## Label protocol
@@ -333,11 +333,11 @@ If you're running [Hive](https://github.com/kubestellar/hive) against this repo,
 |---|---|
 | `status/discussing` | Structured issue flow in progress; not ready for the agent queue yet. |
 | `status/approved` | Approved for queue preparation — needs acceptance criteria before queue. |
-| `agent/claimed` | Actively being worked by a human or agent. |
+| `queue/claimed` | Actively being worked by a human or agent. |
 | `agent/blocked` | Blocked and needs human input before work can continue. |
 | `hold` | Do not touch; intentionally held by humans. |
 | `do-not-merge` | Do not merge or automate this item. |
-| `needs-human/agent-ready` | Issue is scoped with clear acceptance criteria. Ready for an agent or contributor to pick up and open a PR. |
+| `queue/agent-ready` | Issue is scoped with clear acceptance criteria. Ready for an agent or contributor to pick up and open a PR. |
 | `lgtm` | PR approved by a maintainer. |
 | `help wanted` | Good for any contributor, including agents. |
 | `kind:bug` | Something is broken and needs fixing. |
@@ -351,7 +351,7 @@ If you're running [Hive](https://github.com/kubestellar/hive) against this repo,
 | `lab:pass` | Maintainer lab validation passed; enables label-gated auto-merge for maintainer-owned PR branches. After `lab:pass`, one maintainer ack/approval is sufficient for merge-queue entry. |
 | `needs-human/agent-oops` | An agent made a mistake here — wrong assumption, bad output, filed a spurious issue, broke something. This label builds a learning corpus. |
 
-### `needs-human/agent-ready` - how to use it
+### `queue/agent-ready` - how to use it
 
 When you see this label on an issue:
 1. Read the full issue - the acceptance criteria are there
@@ -369,7 +369,7 @@ Hive should not touch issues labeled:
 - `do-not-merge`
 - `status/discussing`
 - `status/approved`
-- `agent/claimed`
+- `queue/claimed`
 - `agent/blocked`
 - `needs-human/agent-oops`
 - `duplicate` / `kind/duplicate`

--- a/docs/epics.md
+++ b/docs/epics.md
@@ -1,0 +1,146 @@
+# Dakota Epics
+
+Epics group related issues into single shippable goals. Each epic has a clear definition of done and fewer than ten child issues. When all children are closed, the epic closes.
+
+**Boards:**
+- [Dakota Epics](https://github.com/orgs/projectbluefin/projects/5) — one row per epic, status at a glance
+- [Dakota Flow](https://github.com/orgs/projectbluefin/projects/4) — every issue left-to-right from New to Shipped, filterable by epic
+
+---
+
+## How this works
+
+**Humans decide. Bots build.**
+
+A maintainer owns each epic: they write the acceptance criteria, decide which issues belong, and close the epic when the goal is met. Contributors and agents pick up individual child issues from the Ready column in Dakota Flow.
+
+The epics exist so that:
+1. Every issue has a clear parent goal — it is obvious why the work matters
+2. Progress is visible at a glance — you can see whether an area is moving or stuck
+3. Small contributors know exactly where to start — pick any Ready issue in an epic you care about
+
+**Epic lifecycle:**
+
+```
+Defining  →  Active  →  [Blocked]  →  Complete
+```
+
+- **Defining** — Acceptance criteria being written. Child issues exist but are not yet Ready.
+- **Active** — At least one child is in flight. New children can still be added.
+- **Blocked** — The whole epic is waiting on a dependency or decision. See the epic issue for context.
+- **Complete** — All children shipped. Epic closed.
+
+---
+
+## Current epics
+
+### P0 — Critical
+
+#### Alpha Stability (#493)
+**Goal:** Dakota boots reliably, installs cleanly, and does not surprise users with hardware-specific failures during the alpha period.
+
+**Children:**
+- #531 bootc status fails after image rename
+- #464 VM fails to boot after bootc upgrade
+- #415 Black screen after install on AMD HP ZBook
+- #450 First-use issues and install friction
+- #367 Increase boot time delay during alpha
+- #301 Login keyring not unlocked after reboot
+- #275 bootc switch fails on LUKS systems
+- #466 Duplicate graphics device in System Details (nvidia)
+
+**Definition of done:** No open P1 or P0 bugs in this list. Dakota can be installed on a fresh machine, booted, and used for a day without hitting any of these issues.
+
+---
+
+#### Testing Infrastructure (#548)
+**Goal:** The ghost lab runs fully automatically. `just boot-test` passes in CI without human intervention. `ujust devmode` reliably switches to the developer image.
+
+**Children:**
+- #524 Testlab automation should not require manual runner bring-up (P0)
+- #527 Ghost lab BST gate fails resolving gnome-build-meta junction
+- #180 ujust devmode can't find image (P1)
+
+**Definition of done:** `just boot-test` passes end-to-end in the ghost lab without a human starting the queue runner. `ujust devmode` switches image successfully on a clean system.
+
+**Note:** This epic unblocks Community Verification (#535) — a working lab is a prerequisite for meaningful verify data.
+
+---
+
+#### Community Verification (#535)
+**Goal:** Users who hit a bug can confirm a fix works on their hardware with `ujust verify`. Maintainers can publish verify-steps when a fix ships. The feedback loop closes without email threads.
+
+**Children:**
+- #536 ujust report: reduce friction for diagnostic donation (P1)
+- #537 Add maintainer verify-steps protocol for community testing (P1)
+- #538 ujust report: add area-specific diagnostic probes (P1)
+
+**Definition of done:** `ujust verify <issue>` runs the relevant probes, reports pass/fail, and offers to upload results. At least one shipped fix has verify-steps attached and confirmed by a community member.
+
+---
+
+### P1 — High
+
+#### Build System (#547)
+**Goal:** BST builds are reproducible across runs and months. Junction bumps merge without human review. CI is fast and not duplicated.
+
+**Children:**
+- #504 Build: date +%m breaks reproducibility (P0 — fix first)
+- #503 CI: deduplicate bst2 pin check into composite actions
+- #501 CI: auto-merge junction bumps from mergeraptor
+- #505 Patches: drop pipewire backports once fdsdk ships >= 1.6.1
+- #231 chunkah: upstream fakecap-xattr for BuildStream xattr support
+- #403 Contribute signing stack to GNOME OS
+- #404 Document Dakota as reference architecture for GNOMEOS and bootc
+- #55 Implement testing branch setup
+
+**Definition of done:** Monthly cache invalidation (#504) is fixed. Junction bumps from mergeraptor auto-merge when validate passes. CI validate job runs in under 5 minutes.
+
+---
+
+#### Justfile / Dev Workflow (#510)
+**Goal:** Every local developer workflow is covered by a `just` recipe. No undocumented workarounds. `just --list` shows a clean, grouped set of commands.
+
+**Children:**
+- #514 Justfile: add group annotation to chunkify recipe (XS)
+- #511 Justfile: document or default x86_64_v3 flag in bst wrapper (XS)
+- #513 Justfile: add push-local recipe for lab zot registry (XS)
+- #512 Justfile: export should skip chunkify for local builds (S)
+
+**Definition of done:** All four issues closed. `just --list` shows every recipe in a named group. A new contributor can run the full dev loop (build → export → push to lab → boot-test) using only `just` commands.
+
+---
+
+#### Feature Parity (#546)
+**Goal:** Dakota works as a daily driver. Users coming from Fedora or Bluefin do not encounter basic feature gaps.
+
+**Children:**
+- #430 Parity: Podman Desktop kubectl setup failure
+- #399 Parity: VMM flatpak missing kernel/library bits
+- #362 Parity: no way to persistently add kernel parameters
+- #353 Parity: user account dinosaur icons are missing
+- #237 Cannot automount second hard drive
+- #333 Feature: Zen Mode for focused work
+- #207 Docker on Dakota via brew
+
+**Definition of done:** All P1 parity items closed. Dakota can be used as a primary workstation for a week without needing a workaround for any item in this list.
+
+---
+
+## Adding an issue to an epic
+
+1. File or find the issue
+2. Add a checklist line to the epic's issue body: `- [ ] #NNN short description`
+3. Set the **Epic** field on the Dakota Flow board to match
+4. A maintainer will add acceptance criteria and move it to Approved when it is ready for a contributor to claim
+
+## Adding a new epic
+
+Epics are opened by maintainers when a cluster of related issues needs a shared goal. Before opening a new epic:
+
+1. Check that at least three related issues already exist
+2. Write a one-paragraph goal and a concrete definition of done
+3. Keep the child list to ten issues or fewer — split into two epics if it grows beyond that
+4. Set Priority and Status on the Epics board
+
+Ping a maintainer in the issue if you think a new epic is warranted.

--- a/docs/epics.md
+++ b/docs/epics.md
@@ -2,9 +2,13 @@
 
 Epics group related issues into single shippable goals. Each epic has a clear definition of done and fewer than ten child issues. When all children are closed, the epic closes.
 
-**Boards:**
+**Dakota boards:**
 - [Dakota Epics](https://github.com/orgs/projectbluefin/projects/5) — one row per epic, status at a glance
 - [Dakota Flow](https://github.com/orgs/projectbluefin/projects/4) — every issue left-to-right from New to Shipped, filterable by epic
+- [Dakota Development](https://github.com/orgs/projectbluefin/projects/3) — full table with priority, size, area, and epic fields
+
+**Org-wide board (all Bluefin projects):**
+- [todo.projectbluefin.io](https://github.com/orgs/projectbluefin/projects/2)
 
 ---
 

--- a/docs/epics.md
+++ b/docs/epics.md
@@ -2,13 +2,15 @@
 
 Epics group related issues into single shippable goals. Each epic has a clear definition of done and fewer than ten child issues. When all children are closed, the epic closes.
 
-**Dakota boards:**
-- [Dakota Epics](https://github.com/orgs/projectbluefin/projects/5) — one row per epic, status at a glance
-- [Dakota Flow](https://github.com/orgs/projectbluefin/projects/4) — every issue left-to-right from New to Shipped, filterable by epic
-- [Dakota Development](https://github.com/orgs/projectbluefin/projects/3) — full table with priority, size, area, and epic fields
+**Dakota board:** [Dakota Development](https://github.com/orgs/projectbluefin/projects/3)
 
-**Org-wide board (all Bluefin projects):**
-- [todo.projectbluefin.io](https://github.com/orgs/projectbluefin/projects/2)
+Views inside the board:
+- **All Issues** — full table, every field visible
+- **Flow** — kanban grouped by Status (New → Shipped), filterable by Epic
+- **Epics** — table filtered to epic issues only, grouped by Status
+- **By Priority** — table grouped by Priority
+
+**Org-wide board (all Bluefin projects):** [todo.projectbluefin.io](https://github.com/orgs/projectbluefin/projects/2)
 
 ---
 


### PR DESCRIPTION
## What

Adds a "Find something to work on" table at the very top of AGENTS.md — four filtered GitHub search links sorted by time investment. Any contributor with 30 minutes can land here and immediately find work without reading the full document.

## Why

The contribution model is distributed small work. The bottleneck isn't willingness — it's friction: *what do I do?* These links answer that question in 5 seconds.

## Links

| Time | Filter |
|------|--------|
| 30 min | queue/agent-ready + size/xs + no assignee |
| Half day | queue/agent-ready + size/s + no assignee |
| Full day | queue/agent-ready + size/m + no assignee |
| All | queue/agent-ready + no assignee + oldest first |

All queue/agent-ready issues have been sized (xs/s/m/l) and the xs ones have crisp "what to do" comments so contributors can act without needing context.

## Verification

```
just validate
```
Documentation only — graph unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Find something to work on" section with quick access to issues organized by time availability (XS/S/M/All sizes).
  * Included instructions for claiming issues with the `/claim` command.
  * Added information about automatic issue return after 7 days of inactivity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/545?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->