### PR TITLE
Human-first issue templates — specificity drives velocity

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,57 +1,59 @@
 name: "Bug report"
-description: "Something is broken — your ghost copy helps us fix it fast."
-title: "[Bug]: "
-labels: ["kind/bug"]
+description: "Something is broken. You are the only person who can confirm it."
+labels: ["type/bug", "status/discussing"]
 type: "Bug"
 body:
   - type: markdown
     attributes:
       value: |
-        Found a bug? You're our eyes on the ground.
+        ## You are the most important person in this process
 
-        Run this first — it's your primary instrument:
+        No agent can reproduce what happened on your machine. No maintainer has your exact hardware. You are the ground truth.
+
+        **This process is human-driven by design.** A maintainer will read your report, decide what it means, and route it to the right epic. Agents can then implement the fix — but only after a human has confirmed the issue is real and specific enough to act on.
+
+        The faster you are specific, the faster this moves:
+
+        | Vague report | "Screen goes black sometimes" | Sits in **New** — can't triage without more info |
+        |---|---|---|
+        | Specific report | "Screen blanks on suspend on AMD ZBook, `journalctl` shows `amdgpu: failed to idle ring`" | Goes to **Ready** — an agent can pick this up today |
+
+        **Run this before filling out the form:**
 
         ```bash
         ujust report
         ```
 
-        It collects your system state, you review everything, and it uploads a gist. Paste that URL below and you're done — the structured data does the talking.
+        It captures your image, kernel, extensions, hardware, and failed units. You review everything before it uploads. Paste the gist URL below and we likely have everything we need — no follow-up questions.
 
   - type: checkboxes
     id: checks
     attributes:
       label: "Before submitting"
       options:
-        - label: "I searched existing issues first"
+        - label: "I searched existing issues and this is not a duplicate"
           required: true
+        - label: "I ran ujust report (or am about to — paste the URL below)"
+          required: false
 
   - type: input
     id: report-link
     attributes:
       label: "ujust report gist URL"
-      description: "This is all we need to see your exact image, kernel, extensions, and failed units. Paste and go."
+      description: "Paste the URL here. This single link gives us your exact image digest, kernel version, hardware, extensions, and any failed units — everything we need to triage without asking follow-up questions."
       placeholder: "https://gist.github.com/..."
     validations:
       required: false
-
-  - type: dropdown
-    id: workflow-path
-    attributes:
-      label: "Workflow path"
-      description: "Direct path by default. Pick Raptor Current only if you want the structured agent queue."
-      options:
-        - "Direct issue (skip workflow)"
-        - "Raptor Current (structured + wrangler + agent queue)"
-    validations:
-      required: true
 
   - type: textarea
     id: what-happened
     attributes:
       label: "What happened?"
-      description: "What did you see? What did you expect? One paragraph is enough."
+      description: "What did you see? What did you expect? Be specific — hardware model, exact error text, what you were doing when it happened."
       placeholder: |
-        Bluetooth disappears from the panel after suspend. The indicator is gone until I reboot. Expected it to reconnect automatically.
+        Bluetooth disappears from the panel after suspend on my Framework 13 AMD.
+        The indicator is gone until I reboot. journalctl shows "hci0: Bluetooth host wakeup failed".
+        Expected it to reconnect automatically, as it does on Fedora 42.
     validations:
       required: true
 
@@ -59,11 +61,32 @@ body:
     id: repro
     attributes:
       label: "Steps to reproduce"
-      description: "Minimal steps to hit the bug."
+      description: "Exact steps, every time. If it's intermittent, say so and describe the pattern."
       placeholder: |
-        1. Suspend the machine
-        2. Wake it
-        3. Bluetooth panel indicator is missing
+        1. Suspend with Bluetooth connected to headphones
+        2. Wake the machine
+        3. Bluetooth panel indicator is gone — no menu, no toggle
+        4. Only a reboot restores it (suspend/resume cycle does not)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: "Affected area"
+      description: "Where does this live? Helps route to the right epic."
+      options:
+        - "hardware / drivers"
+        - "GNOME / desktop"
+        - "bootc / image updates"
+        - "install / ISO"
+        - "nvidia"
+        - "just recipes / ujust"
+        - "flatpak / apps"
+        - "brew / CLI tools"
+        - "build system / BST"
+        - "CI / automation"
+        - "other"
     validations:
       required: true
 
@@ -71,8 +94,8 @@ body:
     id: extra
     attributes:
       label: "Extra context"
-      description: "Optional. Logs, upstream references, affected hardware. Leave blank if your gist covers it."
-      placeholder: "Appears on Framework 13 AMD. Not affected on Intel NUC."
+      description: "Optional — but please add it if you have it. Upstream bug links, kernel bisects, 'works on X but not Y', anything that narrows the cause."
+      placeholder: "Works fine on the Intel NUC in the same setup. Appears on both 6.14 and 6.15 kernels."
     validations:
       required: false
 
@@ -80,4 +103,4 @@ body:
     attributes:
       value: |
         ---
-        *Once a fix ships, you can confirm it works on your machine with `ujust verify <issue-number>` — closing the loop.*
+        A maintainer will triage this and assign it to the right epic. Once a fix ships, confirm it works on your hardware with `ujust verify <issue-number>` — your confirmation is what closes the loop and proves the fix works outside of CI.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,11 @@
 blank_issues_enabled: true
 contact_links:
-  - name: "Project board"
-    url: https://github.com/orgs/projectbluefin/projects/2
-    about: "See what the fleet is working on."
+  - name: "Dakota Flow — work queue"
+    url: https://github.com/orgs/projectbluefin/projects/4
+    about: "Left-to-right board showing every issue from New to Shipped. Find something to work on."
+  - name: "Dakota Development — full table"
+    url: https://github.com/orgs/projectbluefin/projects/3
+    about: "Detailed table with priority, size, area, and epic fields."
   - name: "Contribution guide"
     url: https://github.com/projectbluefin/dakota/blob/main/AGENTS.md
     about: "Build, validation, and workflow rules — read before opening a PR."

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,50 +1,55 @@
 name: "Feature request"
-description: "Propose something new — shape what Dakota becomes."
-title: "[Feature]: "
-labels: ["kind/enhancement"]
+description: "Propose something new. Specific proposals ship. Vague ones wait."
+labels: ["type/feature", "status/discussing"]
 type: "Feature"
 body:
   - type: markdown
     attributes:
       value: |
-        You're not filing a ticket — you're shaping the future.
+        ## Humans decide what gets built. Bots build it.
 
-        Keep it short and practical. If you opt into **Raptor Current**, it enters the structured queue where agents and contributors can pick it up.
+        This is not a ticket system — it is a conversation between you and the people building Dakota. A maintainer will read this, decide if it fits the project's direction, and write acceptance criteria. Once that is done, a contributor or agent can pick it up and ship it.
+
+        **The bottleneck is almost never implementation. It is clarity.**
+
+        Agents can implement well-scoped work fast — sometimes the same day. But they can only act on what is clearly defined. An unclear feature request goes to **Speccing** and waits for a human to define it. Your two paragraphs below determine whether this ships this week or sits in the backlog.
+
+        **Ask yourself before submitting:**
+        - Can someone read this and know exactly what file to change?
+        - Does "done" have a clear finish line — a command to run, a thing to see?
+        - Is this specific to Dakota, or would it be better filed upstream (GNOME, fdsdk, bootc)?
 
   - type: checkboxes
     id: checks
     attributes:
       label: "Before submitting"
       options:
-        - label: "I searched existing issues first"
+        - label: "I searched existing issues and this has not been proposed before"
           required: true
-
-  - type: dropdown
-    id: workflow-path
-    attributes:
-      label: "Workflow path"
-      description: "Use the direct path by default. Pick Raptor Current only if you want the structured queue."
-      options:
-        - "Direct issue (skip workflow)"
-        - "Raptor Current (structured + wrangler + agent queue)"
-    validations:
-      required: true
+        - label: "This is specific to Dakota (not a GNOME, Flatpak, or upstream issue)"
+          required: false
 
   - type: textarea
     id: problem
     attributes:
-      label: "What problem are you solving?"
-      description: "One paragraph. Plain language. What's broken, missing, or annoying today?"
-      placeholder: "I keep having to manually push my local build to the zot registry because there's no just recipe for it..."
+      label: "What is the problem today?"
+      description: "Plain language. What is missing, broken, or annoying? Be specific — name the command, the file, the workflow step."
+      placeholder: |
+        There is no `just push-local` recipe. Every time I build a local image and want to test it
+        on the lab machine, I have to hand-type `podman push localhost:5000/...` with the full tag.
+        This is error-prone and not documented anywhere.
     validations:
       required: true
 
   - type: textarea
     id: solution
     attributes:
-      label: "What do you propose?"
-      description: "How should it work? What would done look like?"
-      placeholder: "Add a `just push-local` recipe that wraps `podman push` with the lab registry URL pre-filled."
+      label: "What does done look like?"
+      description: "Describe the end state. What command do you run? What do you see? What file changes? A concrete finish line is what allows this to be implemented."
+      placeholder: |
+        `just push-local` pushes the most recently exported image to the local zot registry at
+        the address from Justfile variables. Running it should print the pushed digest and exit 0.
+        No new dependencies — just a recipe wrapping the existing `podman push` call.
     validations:
       required: true
 
@@ -52,27 +57,28 @@ body:
     id: area
     attributes:
       label: "Affected area"
-      description: "Pick the closest match."
+      description: "Where does this change live? Helps route it to the right epic and the right contributor."
       options:
-        - "buildstream"
-        - "gnome / desktop"
-        - "brew / CLI"
-        - "just recipes"
-        - "services / systemd"
+        - "just recipes / ujust"
+        - "GNOME / desktop"
+        - "bootc / image updates"
+        - "install / ISO"
         - "nvidia"
-        - "hardware"
-        - "testing / QA"
-        - "upstream / junctions"
+        - "flatpak / apps"
+        - "brew / CLI tools"
+        - "build system / BST"
+        - "CI / automation"
+        - "hardware / drivers"
         - "other"
     validations:
-      required: false
+      required: true
 
   - type: textarea
-    id: affected-elements
+    id: extra
     attributes:
       label: "Extra context"
-      description: "Optional. Related issues, upstream references, or affected files."
-      placeholder: "Justfile only — no BST element changes"
+      description: "Optional — related issues, upstream references, or files you think are affected. The more you add here, the less back-and-forth before this reaches Ready."
+      placeholder: "Justfile only — no BST element changes needed. Related: issue #513."
     validations:
       required: false
 
@@ -80,4 +86,6 @@ body:
     attributes:
       value: |
         ---
-        After this ships, the community verifies it works with `ujust verify <issue-number>` — your feature, confirmed by the fleet.
+        A maintainer will add acceptance criteria before this enters the work queue. The clearer your proposal, the less back-and-forth before that happens — and the faster someone can ship it.
+
+        Once it ships, the community verifies it with `ujust verify <issue-number>`. Your feature, confirmed on real hardware.

--- a/.github/ISSUE_TEMPLATE/help-this-project.yml
+++ b/.github/ISSUE_TEMPLATE/help-this-project.yml
@@ -1,29 +1,48 @@
 name: "Help this project"
 description: "Donate agent time — point at a repo, issue, or PR and get a high-signal report back."
-title: "[Help]: "
+labels: ["kind:agent-donation", "status/discussing"]
 body:
   - type: markdown
     attributes:
       value: |
-        Point your ghost at something and it comes back with a report.
+        ## Point an agent at something. Get a report back.
 
-        Paste a URL below — Hive routes the right agent to investigate and report back here.
+        This template is for donating agent compute to the project. You name a target — a repo, an issue, a PR, a roadmap — and a Hive agent investigates and files findings here.
+
+        **This is still human-driven.** You decide what to investigate. The agent does the reading, cross-referencing, and summarizing. A maintainer reviews the report and decides what to act on.
+
+        Be specific about what you want the agent to focus on. "Look at this repo" produces a shallow overview. "Check whether the PR review checklist catches the reproducibility class of bugs we've been seeing" produces something actionable.
 
   - type: input
     id: target-url
     attributes:
       label: "Target URL"
-      description: "Paste the repo, issue, PR, roadmap, or docs URL that should get agent help."
+      description: "Repo, issue, PR, roadmap, or docs page. Must be publicly accessible."
       placeholder: "https://github.com/owner/repo"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: flow
+    attributes:
+      label: "What kind of help?"
+      description: "This routes the right agent to the right task."
+      options:
+        - "Project report — survey a repo or org and summarize what needs attention"
+        - "Issue review — read a linked issue and recommend next steps"
+        - "PR review — audit a linked PR for correctness and completeness"
     validations:
       required: true
 
   - type: textarea
     id: goal
     attributes:
-      label: "What help do you want?"
-      description: "Keep it short. One or two sentences is enough."
-      placeholder: "Help this project. Give me a high-signal report on what needs attention first."
+      label: "What specifically should the agent focus on?"
+      description: "The more specific you are, the more useful the report. One to three sentences."
+      placeholder: |
+        Check whether the CI pipeline for this repo has any reliability issues that would
+        explain the flaky validate failures we have been seeing. Focus on the BST cache
+        interactions and the bst2 container pin check.
     validations:
       required: true
 
@@ -31,7 +50,13 @@ body:
     id: context
     attributes:
       label: "Extra context"
-      description: "Optional. Add constraints, suspected problem areas, or specific questions for the agent."
-      placeholder: "Focus on CI reliability and whether the PR review checklist is strong enough."
+      description: "Optional. Known problem areas, related Dakota issues, or constraints the agent should respect."
+      placeholder: "Related to #503. The agent should not suggest changes that require a new external dependency."
     validations:
       required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        Hive will route this to the right agent based on the flow type above. The agent files its report as a comment on this issue. A maintainer reviews the report and decides what to action.


### PR DESCRIPTION
## What

Rewrite all three issue templates around one principle: **humans decide what gets built, agents build it — but only when the issue is specific enough to act on.**

## Why

The old templates had two problems:
1. They led with process (Raptor Current, workflow path dropdowns) — internal detail that confused users
2. They didn't explain *why* specificity matters, so vague issues kept landing in Triage

The new templates make the implicit contract explicit: a maintainer reads every issue and decides what it means. Agents can move fast on a well-scoped issue. A vague one waits for a human. The reporter controls which world they're in.

## Changes

**Bug report**
- Remove `[Bug]: ` title prefix
- Lead with a clear table showing the speed difference between vague and specific reports
- Keep `ujust report` prominent — it's still the primary diagnostic instrument
- Add area dropdown (auto-routes to the correct epic via actionadon)
- Remove Raptor Current workflow dropdown

**Feature request**
- Remove `[Feature]: ` title prefix
- Explain the human-driven model: maintainer adds acceptance criteria, then agents or contributors ship
- Rename 'What do you propose?' → 'What does done look like?' — forces a concrete finish line
- Remove Raptor Current dropdown

**Help this project**
- Add flow-type dropdown (project report / issue review / PR review) — routes Hive automatically
- Remove `[Help]: ` title prefix

**config.yml**
- Add Dakota Flow kanban (project 4) as the primary board link

## Verification

- [ ] I am using an agent and I take responsibility for this PR

Closes #544 (supersedes the earlier template PR)