### PR TITLE
ci: trigger testsuite smoke on post-merge publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -267,3 +267,27 @@ jobs:
           subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+      # Trigger the testsuite smoke run against the freshly published default image.
+      # Only fires for the default variant (not nvidia) and only when a token is
+      # configured. continue-on-error: true — testsuite unavailability must never
+      # block image publication.
+      - name: Notify testsuite
+        if: matrix.variant == 'default' && steps.push.outcome == 'success'
+        continue-on-error: true
+        env:
+          TESTSUITE_TOKEN: ${{ secrets.TESTSUITE_DISPATCH_TOKEN }}
+          BUILD_SHA: ${{ steps.context.outputs.sha }}
+        run: |
+          if [[ -z "${TESTSUITE_TOKEN}" ]]; then
+            echo "TESTSUITE_DISPATCH_TOKEN not configured — skipping testsuite notification"
+            exit 0
+          fi
+          gh api repos/projectbluefin/testsuite/dispatches \
+            --method POST \
+            -H "Authorization: Bearer ${TESTSUITE_TOKEN}" \
+            -f event_type=dakota-build \
+            -F "client_payload[image]=ghcr.io/projectbluefin/dakota:${BUILD_SHA}" \
+            -F "client_payload[image_tag]=${BUILD_SHA}" \
+            -F "client_payload[sha]=${BUILD_SHA}"
+          echo "Testsuite dispatch sent for dakota:${BUILD_SHA}"


### PR DESCRIPTION
## What

Adds a `Notify testsuite` step at the end of `publish.yml` that sends a `repository_dispatch` event to `projectbluefin/testsuite` after a successful push of `dakota:latest` to GHCR.

## Why

Closes the post-merge feedback loop: every image that ships gets an automated smoke test. Without this, there is no structured PASS/FAIL signal after merge — only the nightly testsuite run against `bluefin:latest` (which doesn't cover dakota).

See `docs/feedback-loop.md` for the architecture this completes.

## How it works

1. `publish.yml`'s default variant step `Push to GHCR` completes
2. New step `Notify testsuite` fires (only for `matrix.variant == 'default'`)
3. Sends `POST /repos/projectbluefin/testsuite/dispatches` with:
   - `event_type: dakota-build`
   - `client_payload.image: ghcr.io/projectbluefin/dakota:<sha>`
   - `client_payload.sha: <sha>`
4. `projectbluefin/testsuite` picks it up and runs Argo smoke suite on ghost

## Safety properties

- `continue-on-error: true` — testsuite unavailability **never** blocks image publication
- Skips gracefully if `TESTSUITE_DISPATCH_TOKEN` secret is not set (so this is mergeable before the secret is configured)
- Only fires for the default variant, not nvidia

## Companion PR

`projectbluefin/testsuite` needs the matching `dakota-smoke.yml` workflow: https://github.com/projectbluefin/testsuite/pull/new/feat/dakota-smoke

## Secret to configure

After merging, add `TESTSUITE_DISPATCH_TOKEN` to `projectbluefin/dakota` repo secrets:
- A GitHub PAT (classic or fine-grained) with `repo` scope on `projectbluefin/testsuite`
- Settings → Secrets and variables → Actions → New repository secret

## Checklist

- [x] I am using an agent and I take responsibility for this PR