### PR TITLE
feat(ujust): add probe recipe for AI-assisted diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@
 - Alpha, public testing and [filing issues is appreciated](https://github.com/projectbluefin/dakota/issues)!
 - Built-in feedback loop: users report → contributors fix → community verifies → [read the design](docs/feedback-loop.md)
 
+## Help shape what gets built
+
+These issues need human judgment before any code is written — design review, domain knowledge, or hardware context the team doesn't have yet:
+
+### [Issues open for discussion &rarr;](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Astatus%2Fdiscussing)
+
+Leave a comment, push back on the design, or share how your hardware is affected. When a discussion reaches consensus, a maintainer marks it `status/approved` and it enters the contributor queue.
+
+Ready to build something? See the [agent-ready queue](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Aqueue%2Fagent-ready+no%3Aassignee) for issues with clear acceptance criteria and no open questions.
+
 ## ISO Download
 
 [dakota-live-latest.iso](https://projectbluefin.dev/dakota-live-latest.iso) · [Checksum](https://projectbluefin.dev/dakota-live-latest.iso-CHECKSUM)

--- a/files/just-overrides/default.just
+++ b/files/just-overrides/default.just
@@ -658,6 +658,67 @@ verify issue_number:
         echo "Or authenticate gh first: gh auth login"
     fi
 
+# Start an AI-assisted debug session backed by your live system.
+# Installs linux-mcp-server and configures Goose automatically.
+# Usage: ujust probe
+probe:
+    #!/usr/bin/bash
+    set -euo pipefail
+
+    echo ""
+    gum style \
+        --border rounded --border-foreground 99 \
+        --padding "1 3" --margin "0 1" \
+        --bold --foreground 212 \
+        "Bluespeed — AI Debug Session"
+    echo ""
+    gum style --foreground 245 --margin "0 2" \
+        "Your system is the context. Ask about logs, services, network, anything."
+    echo ""
+
+    # 1. Check goose is installed
+    if ! command -v goose &>/dev/null; then
+        gum style --foreground 214 --margin "0 2" \
+            "Goose is not installed."
+        gum style --foreground 245 --margin "0 4" \
+            "Install it first:  ujust bbrew  →  select the 'ai' menu option"
+        exit 1
+    fi
+
+    # 2. Install linux-mcp-server if missing
+    if ! command -v linux-mcp-server &>/dev/null; then
+        gum style --foreground 245 --margin "0 2" \
+            "Installing linux-mcp-server..."
+        brew install ublue-os/tap/linux-mcp-server
+    fi
+
+    # 3. Wire linux-tools into Goose config if not already present
+    GOOSE_CFG="${HOME}/.config/goose/config.yaml"
+    if ! grep -q "linux-tools" "$GOOSE_CFG" 2>/dev/null; then
+        gum style --foreground 245 --margin "0 2" \
+            "Configuring linux-mcp-server in Goose..."
+        goose-mcp-setup
+    fi
+
+    # 4. If no provider is configured, tell the user how to set one up
+    if ! grep -qE "^GOOSE_PROVIDER:|^GOOSE_MODEL:" "$GOOSE_CFG" 2>/dev/null; then
+        echo ""
+        gum style --foreground 214 --margin "0 2" \
+            "No LLM provider configured."
+        gum style --foreground 245 --margin "0 2" \
+            "Run  goose configure  to set one up, then re-run ujust probe."
+        gum style --foreground 245 --margin "0 2" \
+            "See docs.projectbluefin.io/troubleshooting for options."
+        exit 1
+    fi
+
+    # 5. Launch the session
+    echo ""
+    gum style --foreground 82 --margin "0 2" \
+        "Starting session..."
+    echo ""
+    goose session
+
 # Measure Idle Power Draw
 check-idle-power-draw:
     #!/usr/bin/bash


### PR DESCRIPTION
## Summary

Adds `ujust probe` — the one-command entry point for Bluespeed's AI troubleshooting flow.

Instead of static diagnostic scripts, this installs `linux-mcp-server` and wires it into Goose so the AI has live read-only access to the user's system: logs, services, processes, network state, disk — whatever the bug requires.

## What it does

1. Checks if `goose` is installed; if not, directs user to `ujust bbrew`
2. Installs `linux-mcp-server` via `ublue-os/tap` if not present
3. Runs `goose-mcp-setup` to wire the `linux-tools` extension into Goose config (skips if already configured)
4. If no LLM provider is configured, tells the user to run `goose configure` and points them to the docs
5. Launches `goose session`

## Testing

`just validate` passes. Recipe parses cleanly under just 1.47.1.

Closes #538

- [x] I am using an agent and I take responsibility for this PR