### PR TITLE
docs(readme,motd): rewrite readme around feedback loop, overhaul motd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # Bluefin
 *Dakotaraptor steini*
 
-[Bluefin's](https://projectbluefin.io) final form. 
-
-`projectbluefin/dakota` is built on [GNOME OS](https://os.gnome.org/) using [BuildStream](https://buildstream.build/) and then published as a bootc container.
+[Bluefin](https://projectbluefin.io) built on [GNOME OS](https://os.gnome.org/), assembled entirely from source.
 
 <a href="https://docs.projectbluefin.io/changelogs">
   <picture>
@@ -12,198 +10,63 @@
   </picture>
 </a>
 
-## Status
+**Alpha** — [filing issues](https://github.com/projectbluefin/dakota/issues) is the whole point.
 
-- Alpha, public testing and [filing issues is appreciated](https://github.com/projectbluefin/dakota/issues)!
-- Built-in feedback loop: users report → contributors fix → community verifies → [read the design](docs/feedback-loop.md)
+## Built-in feedback loop
+
+Dakota doesn't eat tickets, it treats them as evidence.
+
+Every user running Dakota is part of a structured loop that flows directly back into upstream GNOME, freedesktop, and the kernel. When something breaks on your hardware, you have three commands:
+
+| Command | What it does |
+|---|---|
+| `ujust report` | Captures your system state and opens a pre-filled issue. One command instead of a wall of "please attach logs." |
+| `ujust confirm <issue>` | Tells the team your hardware hits the same bug. Adds a hardware fingerprint to the issue — no duplicate filing. |
+| `ujust verify <issue>` | After a fix ships in a nightly, confirms it works on your machine. Closes the loop with evidence. |
+
+No telemetry. No phone-home. Every report is reviewed by you before it leaves your machine, lives in a gist you own, and can be deleted anytime.
+
+When three users independently run `ujust verify` on a fix, that issue closes with real confidence — not just "we think this is fixed."
+
+### The hardware layer
+
+Each Dakota installation is designed to run as a hardware diagnostic lab for itself. When will you find your first?
+
+[Read the full feedback loop design](docs/feedback-loop.md)
+
+## The research behind it
+
+Dakota's feedback loop model is grounded in Andy Anderson's work on autonomous AI-assisted software development. The core finding: the intelligence of a system like this lives not in any single model, but in the infrastructure of instructions, tests, metrics, and feedback loops surrounding it.
+
+- [The AI Codebase Maturity Model](https://arxiv.org/abs/2604.09388) — the arxiv paper
+- [When AI agents become contributors](https://www.cncf.io/blog/2026/05/14/when-ai-agents-become-contributors-how-kubestellar-reached-81-pr-acceptance/) — CNCF blog
+- [Beyond prompting: How KubeStellar reached 81% PR acceptance](https://thenewstack.io/ai-codebase-maturity-model/) — The New Stack
+- [KubeStellar Hive](https://github.com/kubestellar/hive) — the reference implementation Dakota draws from
+
+## Help shape what gets built
+
+These issues need human judgment before any code is written — design review, domain knowledge, or hardware context the team doesn't have yet:
+
+### [Issues open for discussion &rarr;](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Astatus%2Fdiscussing)
+
+Leave a comment, push back on the design, or share how your hardware is affected. When a discussion reaches consensus, a maintainer marks it `status/approved` and it enters the contributor queue.
+
+Ready to build something? See the [agent-ready queue](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Aqueue%2Fagent-ready+no%3Aassignee) for issues with clear acceptance criteria and no open questions.
 
 ## ISO Download
 
 [dakota-live-latest.iso](https://projectbluefin.dev/dakota-live-latest.iso) · [Checksum](https://projectbluefin.dev/dakota-live-latest.iso-CHECKSUM)
 
-### ISO Archive
 
-Some ISOs are duds, so here's an archive:
+## Known gaps
 
-<!-- iso-table-start -->
-| Date | ISO | Checksum |
-|------|-----|----------|
-| 2026-05-09 | [dakota-nvidia-live-20260509-3059a71.iso](https://projectbluefin.dev/dakota-nvidia-live-20260509-3059a71.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260509-3059a71.iso-CHECKSUM) |
-| 2026-05-08 | [dakota-nvidia-live-20260508-3059a71.iso](https://projectbluefin.dev/dakota-nvidia-live-20260508-3059a71.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260508-3059a71.iso-CHECKSUM) |
-| 2026-05-07 | [dakota-live-20260507-3059a71.iso](https://projectbluefin.dev/dakota-live-20260507-3059a71.iso) | [checksum](https://projectbluefin.dev/dakota-live-20260507-3059a71.iso-CHECKSUM) |
-| 2026-05-07 | [dakota-nvidia-live-20260507-b00fb97.iso](https://projectbluefin.dev/dakota-nvidia-live-20260507-b00fb97.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260507-b00fb97.iso-CHECKSUM) |
-| 2026-05-06 | [dakota-live-20260506-b00fb97.iso](https://projectbluefin.dev/dakota-live-20260506-b00fb97.iso) | [checksum](https://projectbluefin.dev/dakota-live-20260506-b00fb97.iso-CHECKSUM) |
-| 2026-05-05 | [dakota-nvidia-live-20260505-b00fb97.iso](https://projectbluefin.dev/dakota-nvidia-live-20260505-b00fb97.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260505-b00fb97.iso-CHECKSUM) |
-| 2026-05-04 | [dakota-nvidia-live-20260504-b00fb97.iso](https://projectbluefin.dev/dakota-nvidia-live-20260504-b00fb97.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260504-b00fb97.iso-CHECKSUM) |
-| 2026-05-03 | [dakota-nvidia-live-20260503-6661b18.iso](https://projectbluefin.dev/dakota-nvidia-live-20260503-6661b18.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260503-6661b18.iso-CHECKSUM) |
-| 2026-05-02 | [dakota-nvidia-live-20260502-6661b18.iso](https://projectbluefin.dev/dakota-nvidia-live-20260502-6661b18.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260502-6661b18.iso-CHECKSUM) |
-| 2026-05-02 | [dakota-nvidia-live-20260502-029e632.iso](https://projectbluefin.dev/dakota-nvidia-live-20260502-029e632.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260502-029e632.iso-CHECKSUM) |
-| 2026-05-01 | [dakota-nvidia-live-20260501-029e632.iso](https://projectbluefin.dev/dakota-nvidia-live-20260501-029e632.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260501-029e632.iso-CHECKSUM) |
-| 2026-05-01 | [dakota-nvidia-live-20260501-c961e9c.iso](https://projectbluefin.dev/dakota-nvidia-live-20260501-c961e9c.iso) | [checksum](https://projectbluefin.dev/dakota-nvidia-live-20260501-c961e9c.iso-CHECKSUM) |
-| 2026-04-21 | [dakota-live-20260421-87f2aff.iso](https://projectbluefin.dev/dakota-live-20260421-87f2aff.iso) | [checksum](https://projectbluefin.dev/dakota-live-20260421-87f2aff.iso-CHECKSUM) |
-| 2026-04-20 | [dakota-live-20260420-87f2aff.iso](https://projectbluefin.dev/dakota-live-20260420-87f2aff.iso) | [checksum](https://projectbluefin.dev/dakota-live-20260420-87f2aff.iso-CHECKSUM) |
-<!-- iso-table-end -->
+- Installation path is still being worked on
+- Upgrades and rollbacks need more hardening
 
-## Goals
+See the [open issues](https://github.com/projectbluefin/dakota/issues) for where things stand.
 
-- No dx image, everything in homebrew or sysexts
+## Contributing or building from source
 
-## Missing things
-
-- Installation
-- Ensuring upgrades and rollbacks work
-
-## Get started
-    git clone https://github.com/projectbluefin/dakota.git
-    cd dakota
-    just show-me-the-future
-
-> How dare you.
->
-> -- John Bazzite
-
-## Trying it: 
-
-1. Clone this repo
-2. `just show-me-the-future`
-3. VM with Bluefin built on GNOME OS!
-4. WIP: Pushing to a locally run registry for super fast development!
-   - But also means a Dakotaraptor system can build and host itself. On a fast machine this can take about 2 minutes once the initial caching is complete!  
-
-## Make It Yours
-
-1. **Fork this repo** and clone your fork
-2. **Edit the package list** in `elements/bluefin/deps.bst` -- add or remove lines to customize what ships in your image
-3. **Build and boot:**
-   ```
-   just show-me-the-future
-   ```
-
-That's it. The first build takes about an hour (it pulls cached artifacts from GNOME's upstream servers). After that, rebuilds only touch what changed.
-
-## Prerequisites
-
-You need [podman](https://podman.io/docs/installation), [just](https://just.systems/man/en/packages.html)
-
-**(WIP)** `just preflight` -- a preflight check that validates your setup and auto-installs missing tools (like QEMU) via [Homebrew](https://brew.sh), reducing hard prerequisites to just `podman` and `just`.
-
-## Agent-driven Dakota
-
-Dakota is set up so **anyone can build it from a fresh clone** using the
-repository `Justfile` and the repo-local agent instructions.
-
-1. Run `just --list`
-2. Read `AGENTS.md`
-3. Load the skill that matches your task from `.github/skills/`
-
-| If you are doing... | Read this |
-|---|---|
-| Build / validate / boot loops | `.github/skills/dakota-build/SKILL.md` |
-| Issue triage, donated-agent reports, PR reviews | `.github/skills/dakota-agent-workflow/SKILL.md` |
-| CI, issue templates, or action routing | `.github/skills/dakota-ci/SKILL.md` |
-
-Humans can follow the same instructions directly; the skills just package the
-workflow in the standard `.github/skills/` layout.
-
-## How It Works
-
-[BuildStream](https://buildstream.build/) resolves a dependency graph rooted at `elements/oci/bluefin.bst`, pulls pre-built artifacts from GNOME's public cache, builds anything that's missing, and produces a bootable OCI container image. The image is installed to a virtual disk and booted in QEMU.
-
-All build artifacts are cached locally in `~/.cache/buildstream/`. There is no cloud dependency beyond the initial artifact fetch from GNOME's servers. Your laptop is the build farm.
-
-### Disk Space
-
-| What | Size |
-|---|---|
-| Build cache (after first build) | ~50 GB |
-| Bootable VM disk | 30 GB (sparse) |
-| Total recommended free | **100 GB** |
-
-### Step-by-Step Commands
-
-If you prefer more control over each step:
-
-```bash
-just build                     # Build the OCI image (~1 hour first time, minutes after)
-just generate-bootable-image   # Create a bootable disk from the image
-just boot-vm                   # Launch QEMU VM -- a GNOME desktop appears
-```
-
-### Verify it works
-
-```bash
-just boot-test                 # Automated: boots VM, checks GDM starts, exits 0/1
-```
-
-No human interaction needed — boots an ephemeral VM, verifies the desktop target is healthy, tears it down. Requires `bcvk`, `qemu-kvm`, and `virtiofsd`.
-
-### Iterative Development
-
-After the first build, the edit-rebuild-boot cycle is fast:
-
-```bash
-# 1. Edit elements/bluefin/deps.bst (or any element)
-# 2. Rebuild -- only changed elements are rebuilt
-just build
-# 3. Regenerate the disk and boot
-just generate-bootable-image
-just boot-vm
-```
-
-**(WIP)** Local OTA updates -- push rebuilt images to a local registry and update a running VM without rebooting the full pipeline:
-
-```bash
-just registry-start              # Start local OCI registry
-just build && just publish       # Build and push to local registry
-# In VM: sudo bootc upgrade      # Pull the update over the network
-```
-
-## Customizing Packages
-
-The file `elements/bluefin/deps.bst` controls what ships in the image. Each line is a BuildStream element:
-
-```yaml
-depends:
-  # GNOME Shell extensions
-  - bluefin/gnome-shell-extensions.bst
-
-  # CLI tools
-  - bluefin/glow.bst
-  - bluefin/gum.bst
-  - bluefin/fzf.bst
-
-  # Fonts
-  - bluefin/jetbrains-mono.bst
-
-  # ... add your own here
-```
-
-To **remove a package**: delete its line from `deps.bst`.
-
-To **add a package**: create a `.bst` element in `elements/bluefin/` and add it to `deps.bst`. Look at existing elements like `elements/bluefin/glow.bst` for a simple example -- it downloads a pre-built binary and installs it to the right path.
-
-Packages from the upstream [freedesktop-sdk](https://gitlab.com/freedesktop-sdk/freedesktop-sdk) and [gnome-build-meta](https://gitlab.gnome.org/GNOME/gnome-build-meta) projects can be included directly by referencing their junction path:
-
-```yaml
-  - freedesktop-sdk.bst:components/some-package.bst
-  - gnome-build-meta.bst:gnomeos-deps/some-other-package.bst
-```
-
-## Project Structure
-
-```
-.github/skills/      Repo-local agent skills and workflow docs
-elements/
-  bluefin/           Bluefin-specific packages (edit these)
-    deps.bst         Master package list (start here)
-  core/              Core system overrides (bootc, grub, ptyxis)
-  oci/               Image assembly pipeline
-    bluefin.bst      THE build target
-  freedesktop-sdk.bst   Junction to freedesktop-sdk
-  gnome-build-meta.bst  Junction to gnome-build-meta
-files/               Static files (plymouth theme, etc.)
-patches/             Patches applied to upstream projects
-Justfile             All build commands
-```
+See [AGENTS.md](AGENTS.md) for the full contributor workflow, build instructions, and PR checklist.
 
 ![Dakorator](https://github.com/user-attachments/assets/ee92291d-a617-496e-abb6-9045a4c665ce)

--- a/files/motd/template.md
+++ b/files/motd/template.md
@@ -1,17 +1,19 @@
-# 🦖 Welcome to Dakota
+# 🦖 Dakota · Field Dispatch
 
-󱋩 `${MOTD_IMAGE_NAME}:${MOTD_IMAGE_TAG}`
+```
+SPECIMEN : Dakotaraptor steini
+STATUS   : alpha · unstable · hunting
+BUILD    : ${MOTD_IMAGE_NAME}:${MOTD_IMAGE_TAG}
+MISSION  : report what you find
+```
 
-|  Command | Description |
-| ------- | ----------- |
-| `ujust --choose`  | Show available commands  |
-| `ujust report` | File a diagnostic report |
-| `ujust bluefin-cli` | Enable terminal bling |
-| `ujust toggle-user-motd` | Toggle this banner on/off |
-| `brew help` | Manage command line packages |
+| Signal | What happens |
+|---|---|
+| `ujust report` | Something broke. Grabs your system state, puts it in a gist you own, and files it as evidence. Maintainers get real data instead of guesswork. |
+| `ujust confirm <#>` | Someone else already filed this. Adds your hardware to the sighting — no duplicate, just weight behind the fix. |
+| `ujust verify <#>` | A fix shipped in a nightly. Run this to prove it worked on your machine. Three of these closes the case. |
+| `ujust --choose` | Every move available to you. Browse and run anything from here. |
 
-${MOTD_TIP}
+> Teamwork makes the dream work — every contribution matters.
 
-- **󰊤** [Issues](https://github.com/projectbluefin/dakota/issues)
-- **󰊤** [Ask Bluefin](https://ask.projectbluefin.io)
-- **󰈙** [Documentation](https://docs.projectbluefin.io)
+**HQ** · [Issues](https://github.com/projectbluefin/dakota/issues) · [Ask Bluefin](https://ask.projectbluefin.io) · [Docs](https://docs.projectbluefin.io)

--- a/files/motd/tips/10-tips.md
+++ b/files/motd/tips/10-tips.md
@@ -1,16 +1,1 @@
-Dakota is built entirely from source — no RPMs, no dnf. Pure BuildStream.
-`ujust report` collects structured diagnostics and uploads to your own gist — you review everything first.
-`ujust confirm <issue>` tells maintainers "me too" with your hardware fingerprint attached.
-`ujust verify <issue>` attests whether a shipped fix actually works on your machine.
-Hit a bug? Run `ujust report` — structured data helps maintainers fix things faster.
-Dakota uses atomic OCI updates via `bootc` — your system is always a known-good image.
-Update break something? Roll back instantly with `bootc rollback`.
-Use Goose + linux-mcp-server for AI-powered troubleshooting — it reads your system state live.
-`ujust --choose` shows every available shortcut and the script it runs.
-`ujust bluefin-cli` sets up your terminal with curated developer tools.
-`ujust check-idle-power-draw` measures your system's power consumption at idle.
-`ujust benchmark` runs a one-minute stress test to baseline your hardware.
-`brew search` and `brew install` manage command line packages — updates are automatic.
-Container development is first-class: devcontainers, Podman, and DistroShelf are all ready to go.
-Your feedback closes the loop: report → fix → verify → done. Every `ujust verify` is evidence.
-Dakota ships the same test suite contributors use — `ujust report` is your entry point.
+Teamwork makes the dream work — every contribution matters.

--- a/files/motd/ublue-motd
+++ b/files/motd/ublue-motd
@@ -11,9 +11,4 @@ export UBLUE_MOTD_SHOWN=1
 MOTD_TEMPLATE_FILE="${MOTD_TEMPLATE_FILE:-/usr/share/ublue-os/motd/template.md}"
 . "${MOTD_ENV_SCRIPT:-/usr/share/ublue-os/motd/env.sh}"
 
-if command -v tput >/dev/null 2>&1 && [ -t 1 ]; then
-  cols=$(tput cols 2>/dev/null)
-  envsubst < "${MOTD_TEMPLATE_FILE}" | glow -w $cols -
-else
-  envsubst < "${MOTD_TEMPLATE_FILE}" | glow -
-fi
+envsubst < "${MOTD_TEMPLATE_FILE}" | glow -


### PR DESCRIPTION
## What

- README rewritten to lead with the ujust report/confirm/verify model — what it is and why it matters. Technical build content lives in AGENTS.md now.
- MOTD redesigned as a field dispatch: raptor lore, plain-english command descriptions, hardcoded community quote, tips file trimmed to the one line that matters for alpha.
- Drops the `tput cols` race condition in `ublue-motd` — glow now auto-detects terminal width at render time instead of querying before the PTY is sized.

## Why

The README was leading with BuildStream and build commands. The actual differentiator is the feedback loop. Users should understand that running Dakota means helping fix it.

Closes nothing — housekeeping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced README with guidance for contributing to open discussions before implementation
  * Updated message of the day template with new format and command guidance
  * Refreshed daily tips

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->