### PR TITLE
fix(hive-status-sync): skip posting when PROJECT_TOKEN is not set

### DIFF
--- a/.github/workflows/hive-status-sync.yml
+++ b/.github/workflows/hive-status-sync.yml
@@ -132,6 +132,12 @@ jobs:
           print(body[:500])
           print("...")
 
+          # Guard: skip posting if PROJECT_TOKEN is not configured
+          import os
+          if not os.environ.get("GH_TOKEN"):
+              print("WARNING: PROJECT_TOKEN secret is not set — skipping project status post", file=sys.stderr)
+              sys.exit(0)
+
           # Post to GitHub Project status update
           mutation = """
           mutation($projectId: ID!, $body: String!, $color: ProjectV2StatusUpdateColor!) {


### PR DESCRIPTION
## What

Guards the hourly Hive status sync against a missing `PROJECT_TOKEN` secret.

## Why

The workflow fails hard when `secrets.PROJECT_TOKEN` is not configured — `GH_TOKEN` is empty, `gh` CLI exits non-zero with "set the GH_TOKEN environment variable", and the step fails.

This is a graceful-degradation fix: if the token isn't set, print a warning and exit 0 instead of failing the run.

Fixes: https://github.com/projectbluefin/dakota/actions/runs/26554901363/job/78224611716

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved status sync workflow robustness by adding validation for required credentials. The workflow now gracefully handles missing configuration with a warning message instead of failing silently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->