### PR TITLE
fix(hive-status-sync): use correct GraphQL field for project status

### DIFF
--- a/.github/workflows/hive-status-sync.yml
+++ b/.github/workflows/hive-status-sync.yml
@@ -46,13 +46,13 @@ jobs:
           total = len(agents)
           n_active = len(active)
 
-          # Determine color
+          # Determine status
           if n_active >= 3:
-              color = "GREEN"
+              status = "ON_TRACK"
           elif n_active >= 1:
-              color = "YELLOW"
+              status = "AT_RISK"
           else:
-              color = "RED"
+              status = "OFF_TRACK"
 
           # Clean liveSummary (strip box-drawing, compress blank lines)
           def clean_summary(text):
@@ -127,7 +127,7 @@ jobs:
 
           body = "\n".join(body_parts)
 
-          print(f"Status color: {color}")
+          print(f"Status: {status}")
           print(f"Body preview ({len(body)} chars):")
           print(body[:500])
           print("...")
@@ -140,11 +140,11 @@ jobs:
 
           # Post to GitHub Project status update
           mutation = """
-          mutation($projectId: ID!, $body: String!, $color: ProjectV2StatusUpdateColor!) {
+          mutation($projectId: ID!, $body: String!, $status: ProjectV2StatusUpdateStatus!) {
             createProjectV2StatusUpdate(input: {
               projectId: $projectId
               body: $body
-              color: $color
+              status: $status
             }) {
               statusUpdate {
                 id
@@ -159,7 +159,7 @@ jobs:
                "-f", f"query={mutation}",
                "-f", f"projectId={PROJECT_ID}",
                "-f", f"body={body}",
-               "-f", f"color={color}"],
+               "-f", f"status={status}"],
               capture_output=True, text=True
           )
 


### PR DESCRIPTION
## What

Fixes the `createProjectV2StatusUpdate` mutation to use the correct GraphQL field.

## Why

The workflow was using `color: ProjectV2StatusUpdateColor` which doesn't exist in the GitHub GraphQL schema — the correct field is `status: ProjectV2StatusUpdateStatus`.

This caused the second failure after #564 set the `PROJECT_TOKEN` secret:
```
ProjectV2StatusUpdateColor isn't a defined input type
CreateProjectV2StatusUpdateInput doesn't accept argument 'color'
```

## Mapping

| Agents active | Old (invalid) | New |
|---|---|---|
| ≥ 3 | GREEN | ON_TRACK |
| ≥ 1 | YELLOW | AT_RISK |
| 0 | RED | OFF_TRACK |