### PR TITLE
ci(hive-status-sync): also trigger on push to main

### DIFF
--- a/.github/workflows/hive-status-sync.yml
+++ b/.github/workflows/hive-status-sync.yml
@@ -1,6 +1,8 @@
 name: Hive Status Sync
 
 on:
+  push:
+    branches: [main]
   schedule:
     - cron: '0 * * * *'
   workflow_dispatch:


### PR DESCRIPTION
Fires after each merge so the status reflects current project activity rather than waiting for the next hourly tick. Builds take over an hour so this won't exceed the hourly publish interval in practice.