### PR TITLE
ci(hive-status-sync): update project title with live queue stats

### DIFF
--- a/.github/workflows/hive-status-sync.yml
+++ b/.github/workflows/hive-status-sync.yml
@@ -174,3 +174,81 @@ jobs:
           print(f"Posted status update: {update_id}")
           PYEOF
         shell: bash
+
+      - name: Update project title with live stats
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          python3 << 'PYEOF'
+          import json, subprocess, sys, os
+
+          PROJECT_ID = "PVT_kwDOCCE0ds4BZAIm"
+          REPO = "projectbluefin/dakota"
+
+          if not os.environ.get("GH_TOKEN"):
+              print("WARNING: PROJECT_TOKEN not set — skipping title update", file=sys.stderr)
+              sys.exit(0)
+
+          def gh(*args):
+              r = subprocess.run(["gh"] + list(args), capture_output=True, text=True)
+              if r.returncode != 0:
+                  print(f"ERROR: gh {' '.join(args)}\n{r.stderr}", file=sys.stderr)
+                  sys.exit(1)
+              return r.stdout.strip()
+
+          # CI status: latest completed build.yml run
+          ci_raw = gh("run", "list", "--repo", REPO, "--workflow", "build.yml",
+                      "--limit", "1", "--json", "conclusion")
+          ci_runs = json.loads(ci_raw)
+          if ci_runs and ci_runs[0].get("conclusion") == "success":
+              ci = "CI ✅"
+          elif ci_runs and ci_runs[0].get("conclusion") in ("failure", "startup_failure"):
+              ci = "CI ❌"
+          else:
+              ci = "CI ⏳"
+
+          # Issue queue counts
+          def count_label(label):
+              raw = gh("issue", "list", "--repo", REPO,
+                       "--label", label, "--state", "open", "--json", "number")
+              return len(json.loads(raw))
+
+          n_ready   = count_label("queue/agent-ready")
+          n_claimed = count_label("queue/claimed")
+          n_p0      = count_label("P0")
+
+          # Build title
+          parts = [ci, f"{n_ready} ready", f"{n_claimed} claimed"]
+          if n_p0 > 0:
+              parts.append(f"{n_p0} P0 🔥")
+          title = "Dakota Development — " + " · ".join(parts)
+
+          print(f"Setting title: {title}")
+
+          mutation = """
+          mutation($projectId: ID!, $title: String!) {
+            updateProjectV2(input: { projectId: $projectId, title: $title }) {
+              projectV2 { title }
+            }
+          }
+          """
+
+          result = subprocess.run(
+              ["gh", "api", "graphql",
+               "-f", f"query={mutation}",
+               "-f", f"projectId={PROJECT_ID}",
+               "-f", f"title={title}"],
+              capture_output=True, text=True
+          )
+
+          if result.returncode != 0 or '"errors"' in result.stdout:
+              print("ERROR updating title:", file=sys.stderr)
+              print(result.stdout, file=sys.stderr)
+              print(result.stderr, file=sys.stderr)
+              sys.exit(1)
+
+          resp = json.loads(result.stdout)
+          new_title = resp["data"]["updateProjectV2"]["projectV2"]["title"]
+          print(f"Title updated to: {new_title}")
+          PYEOF
+        shell: bash


### PR DESCRIPTION
Adds a step that updates the Dakota Development project title each hour with live stats.

**Before:** `Dakota Development`
**After:** `Dakota Development — CI ✅ · 11 ready · 0 claimed` (or `CI ❌` / `3 P0 🔥` when warranted)

## What it shows
- **CI ✅/❌/⏳** — conclusion of the latest `build.yml` run
- **N ready** — open issues labeled `queue/agent-ready`
- **N claimed** — open issues labeled `queue/claimed`
- **N P0 🔥** — only shown when P0 count > 0

## How
New step in `hive-status-sync.yml` (already runs hourly). Uses the existing `PROJECT_TOKEN` secret and the `updateProjectV2` GraphQL mutation. Gracefully skips if the token is absent.

Confirmed working: title already set live before this PR.

---
- [x] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Project status workflow improved to automatically update the project title with live statistics including CI status and priority issue counts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->