### PR TITLE
docs: trim AGENTS.md by 51%, tighten skills for token efficiency

### DIFF
--- a/.github/skills/ujust-recipes.md
+++ b/.github/skills/ujust-recipes.md
@@ -94,7 +94,7 @@ Fall back to `sed 's/ /%20/g; s/:/%3A/g; s|/|%2F|g'` for systems without Python.
 
 ---
 
-## Lore
+## Raptor spinner text
 
 Raptors travel in **kettles**, not packs. Use "kettle" in all raptor-related
 spinner messages and flavor text.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,90 +1,39 @@
 # AGENTS.md
 
-> This file tells AI coding agents (GitHub Copilot, Claude, Gemini, etc.) how to
-> contribute safely and test PRs in this repository. Human contributors can
-> follow the same steps.
+> Behavioral rules for AI agents contributing to Dakota. Human contributors follow the same steps.
 
 ## Find something to work on
 
 | Time available | Link |
-|----------------|------|
-| 30 minutes | [XS issues](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Aqueue%2Fagent-ready+label%3Asize%2Fxs+no%3Aassignee) |
-| Half a day | [S issues](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Aqueue%2Fagent-ready+label%3Asize%2Fs+no%3Aassignee) |
+|---|---|
+| 30 min | [XS issues](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Aqueue%2Fagent-ready+label%3Asize%2Fxs+no%3Aassignee) |
+| Half day | [S issues](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Aqueue%2Fagent-ready+label%3Asize%2Fs+no%3Aassignee) |
 | Full day | [M issues](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Aqueue%2Fagent-ready+label%3Asize%2Fm+no%3Aassignee) |
-| All sizes | [Everything ready](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Aqueue%2Fagent-ready+no%3Aassignee+sort%3Acreated-asc) |
+| All | [Everything ready](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Aqueue%2Fagent-ready+no%3Aassignee+sort%3Acreated-asc) |
 
-Comment `/claim` on any issue to take it. Actionadon assigns it to you and removes it from the pool. If there's no PR activity after 7 days it returns automatically — no hard feelings.
+Comment `/claim` on an issue to take it. Actionadon assigns it and removes it from the pool. No PR activity in 7 days returns it automatically.
 
-Dakota is a [BuildStream 2](https://buildstream.build/) project that produces
-**Bluefin** - a bootc OCI desktop image built entirely from source using
-freedesktop-sdk and gnome-build-meta as upstream foundations. No RPMs. No dnf.
-BST elements only.
+Dakota is a [BuildStream 2](https://buildstream.build/) project producing **Bluefin** — a bootc OCI desktop image built from source via freedesktop-sdk and gnome-build-meta. No RPMs. No dnf. BST elements only.
 
-Dakota's primary design goal is a **built-in quality feedback loop** where users,
-contributors, agents, and hardware all produce structured evidence that flows
-back into the next iteration. See [docs/feedback-loop.md](docs/feedback-loop.md)
-for the full architecture.
-
-This document establishes the **Mandatory Behavioral Gates** for all AI agents, automated contributors, and their human operators. Dakota is a human-managed repository; AI agents exist to accelerate human workflows, not to replace human oversight or bypass deterministic standards.
-
-**Non-compliance with these gates will result in an immediate, automated rejection of the contribution.**
+Dakota's primary design goal is a **built-in quality feedback loop** where users, contributors, agents, and hardware produce structured evidence that flows back into the next iteration. See [docs/feedback-loop.md](docs/feedback-loop.md).
 
 ---
 
-## 1. The Read-First Gate
+## Mandatory gates
 
-**Agents MUST read the top-level `README.md`, `AGENTS.md`, `.github/copilot-instructions.md`, and the relevant repo-local skill in `.github/skills/` before initiating any file modifications.**
+Non-compliance = automatic rejection.
 
-* You are prohibited from making assumptions about the project structure, dependency management, or architectural patterns.
-* Your first action in any session must be a systematic scan of the project's documentation to ensure context alignment.
-* Dakota keeps its agent instructions in-repo. Do not rely on operator-local `~/src/skills/*` paths for Dakota-specific guidance.
+**Read-First:** Read `README.md`, `AGENTS.md`, `.github/copilot-instructions.md`, and relevant `.github/skills/` files before modifying anything. Do not assume project structure or dependency patterns. Dakota keeps its instructions in-repo — do not rely on operator-local paths.
 
-## 2. The Rate Limiting Gate
+**Rate limit:** Max 4 open PRs at a time. If a PR is closed for quality, document the root cause on the closed PR before resubmitting.
 
-**Agents MUST NOT overwhelm human maintainers with high-volume or redundant submissions.**
+**Operator accountability:** The human deploying the agent is responsible for all decisions. PR template checkbox: `[ ] I am using an agent and I take responsibility for this PR`
 
-* **Concurrency Limit:** An agent (or its operator) MUST NOT have more than **four (4) active Pull Requests** pending review at any given time.
-* **Batching:** Small, incremental changes are preferred, but do not fragment a single logical feature into dozens of micro-PRs. Squash is your friend.
-* **Cooldown:** If a PR is closed due to poor quality, the agent (or its operator) must not submit a replacement PR until the root cause has been identified and documented as a comment on the closed PR. One PR at a time for the same issue.
+**Verification:** Every PR must confirm `just lint` passed and the image booted. Use `just boot-test` for automated pass/fail. No WIP PRs.
 
-## 3. The Operator Accountability Gate
+**Justfile integrity:** All maintenance tasks must be `just` recipes. No loose shell commands. If a task isn't covered by an existing recipe, add one before or alongside your change.
 
-**The human operator deploying the agent is strictly responsible for every line of code and every technical decision made by the agent.**
-
-This is in the pull request template: `[ ] I am using an agent and I take responsibility for this PR`
-
-## 4. The Verification Gate
-
-**No contribution shall be considered for merge without a deterministic verification report.**
-
-* **Justfile Execution:** Agents MUST run `just lint` and `just boot-test` (or `just boot-fast` / `just boot-vm`) on their local environment before submission. These are the canonical local verification targets. Prefer `just boot-test` for automated pass/fail verification; use `just boot-fast` for interactive debugging.
-* **Report Requirement:** The PR description MUST include confirmation that `just lint` passed and the image booted successfully.
-* **Zero-Failure Tolerance:** If lint fails or the image does not boot, the PR is considered non-compliant. Agents MUST NOT submit "Work In Progress" (WIP) code that breaks the build.
-* **Note:** `just verify` checks cosign/SBOM/SLSA signatures on published GHCR images — it requires a pushed image and is not part of the local contributor verification loop.
-
-## 5. The Justfile Integrity Gate
-
-**The `Justfile` is the single, canonical source of truth for all maintenance tasks.**
-
-* **No "Loose" Commands:** Agents are strictly forbidden from suggesting or using shell commands that are not encapsulated within the `Justfile`.
-* **Gap Closure:** If an agent identifies a maintenance task, setup step, or deployment requirement not currently covered by a `just` recipe, the agent **MUST** submit a PR to update the `Justfile` before or alongside the feature code.
-* **Determinism:** All recipes added by agents must be idempotent and deterministic.
-
-## 6. The Human Maintainability Gate
-
-**Agents are tools for acceleration; they do not dictate the evolution of the codebase.**
-
-* **Manual Parity:** Any process an agent performs must be fully replicable by a human using only the `Justfile`.
-* **No Black Boxes:** Contributions that introduce dependencies, obfuscated logic, or "AI-optimized" code that a standard human contributor cannot easily debug or maintain via the provided tooling will be rejected.
-* **Interface Stability:** Agents must not alter the CLI interface or existing `just` recipe names without explicit human approval, as this breaks human mental models of the system.
-
----
-
-### Failure to Comply
-
-Any Pull Request that bypasses these gates-specifically those lacking a `Justfile` verification report or the Operator Acknowledgment-will be **closed without review**.
-
-**Dakota prioritizes codebase integrity and human bandwidth over the speed of automated contributions.**
+**Human maintainability:** Every agent action must be replicable by a human via the Justfile. No AI-optimized black boxes. Do not rename existing recipes without explicit human approval.
 
 ---
 
@@ -92,13 +41,12 @@ Any Pull Request that bypasses these gates-specifically those lacking a `Justfil
 
 | Tool | Why | Install |
 |---|---|---|
-| `podman` (rootful + rootless) | BST runs inside a container; export + boot need rootful | Pre-installed on Bluefin ✓ |
-| `just` | All build and test commands | Pre-installed on Bluefin ✓ |
+| `podman` (rootful + rootless) | BST container + export/boot | Pre-installed on Bluefin ✓ |
+| `just` | All build/test commands | Pre-installed on Bluefin ✓ |
 | `qemu` | VM boot | `brew install qemu` |
-| `virtiofsd` | Required for `just boot-fast` only | `rpm-ostree install virtiofsd` then reboot |
-| `bcvk` | Fast ephemeral VM from container (no disk image) | Auto-installed by `just boot-fast` via cargo - or install manually: `cargo install --locked --git https://github.com/bootc-dev/bcvk bcvk` |
-| ~100 GB free disk | BST cache + image | - |
-| ~16 GB RAM | BST builds are parallel and hungry | - |
+| `virtiofsd` | `just boot-fast` only | `rpm-ostree install virtiofsd` then reboot |
+| `bcvk` | Ephemeral VM from container | Auto-installed by `just boot-fast` via cargo |
+| ~100 GB disk, ~16 GB RAM | BST cache + parallel builds | — |
 
 ---
 
@@ -106,320 +54,141 @@ Any Pull Request that bypasses these gates-specifically those lacking a `Justfil
 
 | Path | Purpose |
 |---|---|
-| `elements/freedesktop-sdk.bst` | fdsdk junction - pinned to a release tag |
-| `elements/gnome-build-meta.bst` | GBM junction - tracks `gnome-50` branch |
+| `elements/freedesktop-sdk.bst` | fdsdk junction — pinned to a release tag |
+| `elements/gnome-build-meta.bst` | GBM junction — tracks `gnome-50` branch |
 | `elements/bluefin/` | Bluefin-specific elements (~40 elements) |
-| `elements/oci/` | OCI image assembly - layers + final image |
+| `elements/oci/` | OCI image assembly — layers + final image |
 | `patches/freedesktop-sdk/` | Patches applied to fdsdk via `patch_queue` |
 | `patches/gnome-build-meta/` | Patches applied to GBM via `patch_queue` |
 | `patches/linux/` | Kernel patches (via fdsdk linux element) |
 | `files/` | Static files installed by elements |
-| `.github/skills/` | Repo-local agent skills for builds, reviews, and CI workflow work |
-| `.github/workflows/build.yml` | CI: `validate` on PRs, full `build` on merge queue |
-| `Justfile` | All local dev commands - run `just --list` first |
+| `.github/skills/` | Repo-local agent skills |
+| `Justfile` | All local dev commands — run `just --list` first |
 
 ---
 
-## Quick start - build and boot in one command
+## Dev loop
 
 ```bash
-just show-me-the-future
+just validate                  # graph check — always run first (~5 min, no build)
+
+export BUILD_SKIP_NVIDIA=1
+just build default             # build image — warm cache: 2–5 min; cold: 60–90 min
+
+just lint                      # bootc container lint — must pass before PR
+
+just boot-test                 # automated smoke test — exits 0 on success
+just boot-fast                 # interactive ephemeral VM via virtiofs (requires virtiofsd)
+
+just show-me-the-future        # full loop: build → export → disk image → QEMU VM
 ```
 
-This runs the full loop: BST build → export → bootable disk image → QEMU VM.
-Expect 45-90 minutes on first run (cold BST cache). Subsequent runs are fast
-because BST caches artifacts by content hash.
+First run is slow (cold BST cache). Subsequent runs are fast — BST caches by content hash.
 
 ---
 
-## Standard dev loop
+## PR checklist
 
-### 1. Validate - fast, no build
+### All PRs
 
-Always run this first. It checks the full element dependency graph without
-building anything. Same check CI runs on every PR.
-
-```bash
-just validate
-```
-
-`just validate` mirrors CI by checking both default and nvidia element graphs.
-The `just bst` wrapper defaults to `-o x86_64_v3 true --no-interactive`, so
-local graph checks match CI without extra environment variables.
-
-Exits non-zero if any element has a missing dep, bad ref, or patch that fails
-to apply. If this passes, the graph is structurally sound.
-
-### 2. Build
-
-```bash
-export BUILD_SKIP_NVIDIA=1    # skip nvidia variant - saves ~15 min
-
-just build default
-```
-
-BST pulls cached artifacts from upstream caches (`cache.freedesktop-sdk.io`,
-`gbm.gnome.org`) for anything it hasn't built locally. Most elements will be
-cache hits. A warm-cache build of a small element change takes 2–5 minutes.
-
-**First run:** cold cache means BST must build everything from source.
-Expect 60–90 minutes. Subsequent runs are fast — BST's content-addressed
-cache skips anything unchanged.
-
-### 3. Lint
-
-```bash
-just lint
-```
-
-Runs `bootc container lint` on the built image. Must pass before any PR is ready.
-
-### 4. Boot and verify
-
-**Automated smoke test (preferred for agents and CI):**
-
-```bash
-just boot-test
-```
-
-Boots the image in an ephemeral VM, waits for SSH, checks that `graphical.target`,
-`gdm`, and `bootc status` are healthy, then tears down the VM. Returns exit 0 on
-success, exit 1 on failure. Set `BOOT_TEST_TIMEOUT=180` to extend the default 120s
-timeout for slow machines.
-
-**Interactive path - ephemeral VM, no disk image:**
-
-```bash
-just boot-fast
-```
-
-Boots directly from the container via virtiofs. No install step. Requires
-`bcvk` (auto-installed by `just boot-fast` via cargo) and `virtiofsd`
-(`rpm-ostree install virtiofsd` then reboot, one-time setup).
-
-**Full path - installed disk image:**
-
-```bash
-just generate-bootable-image   # installs image to bootable.raw (~5 min)
-just boot-vm                   # boots in QEMU (native) or container fallback
-```
-
-### 5. Verify what's running inside the VM
-
-Once booted, open a terminal and check:
-
-```bash
-uname -r                       # kernel version
-bootc status                   # booted image + digest
-systemctl is-active gdm        # desktop session healthy
-```
-
----
-
-## PR review checklist
-
-### Any PR
-
-- [ ] Validate passes: `BST_FLAGS="-o x86_64_v3 true --no-interactive" just bst show --deps all oci/bluefin.bst`
+- [ ] `just validate` passes
 - [ ] `just lint` passes on a built image
-- [ ] `just boot-test` passes (automated) or `just boot-fast` / `just boot-vm` - desktop comes up, no regressions
-- [ ] Commit has exactly one `Assisted-by:` or `Signed-off-by:` trailer - no `Co-authored-by:`
-- [ ] PR body references the issue it closes (`Closes #NNN`)
+- [ ] `just boot-test` passes (or `just boot-fast` / `just boot-vm`)
+- [ ] Commit trailer: `Assisted-by:` or `Signed-off-by:` — **not** `Co-authored-by:`
+- [ ] `Closes #NNN` in the PR body
 
 ### Junction bumps (`gnome-build-meta.bst` or `freedesktop-sdk.bst`)
 
-- [ ] Only junction `.bst` files changed - no `patches/` modifications in the same commit
-- [ ] CI `validate` passes
-- [ ] Validate that existing patches in `patches/freedesktop-sdk/` and `patches/gnome-build-meta/` still apply cleanly after the bump (a patch that targeted an old `ref:` will now fail)
+- [ ] Only junction `.bst` files changed — no `patches/` modifications in the same commit
+- [ ] All existing patches in the relevant `patches/` directory still apply cleanly
 
-Junction-only bumps from `mergeraptor[bot]` that touch no patch files are
-pre-approved once `validate` passes. See issue #501 for the auto-merge roadmap.
-
-> **When bumping manually:** run `BST_FLAGS="-o x86_64_v3 true --no-interactive" just bst show --deps all oci/bluefin.bst` with the new junction ref before opening the PR to confirm all patches still apply.
+> Junction-only bumps from `mergeraptor[bot]` are pre-approved once `validate` passes.
 
 ### Patch additions or removals (`patches/`)
 
-- [ ] Patch has a clear `Upstream-Status:` line: `Submitted` / `Accepted` / `Pending` / `Not-applicable`
-- [ ] If backporting a fix: upstream commit or PR linked in the patch header
-- [ ] If the fix is already upstream in the new junction ref: **drop the patch** rather than keep it
-- [ ] Patch filename is numbered sequentially (patches apply alphabetically)
-- [ ] Patch adds an exit condition comment: "Drop when fdsdk ships X" or "Drop after GBM gnome-50 reaches Y"
+- [ ] `Upstream-Status:` header: `Submitted` / `Accepted` / `Pending` / `Not-applicable`
+- [ ] Upstream commit or PR linked if backporting
+- [ ] Drop the patch if the fix is already upstream in the new junction ref
+- [ ] Filenames numbered sequentially (alphabetical = apply order)
+- [ ] Exit condition documented: "Drop when fdsdk ships X" or "Drop after GBM gnome-50 reaches Y"
 
 ### OCI image assembly (`elements/oci/`)
 
-- [ ] `ldconfig -r /layer` is present after `dconf update` and before `build-oci` — see [docs/oci-assembly.md](docs/oci-assembly.md)
-- [ ] Any new post-install step is inserted **before** `ldconfig -r /layer`
+- [ ] `ldconfig -r /layer` present after `dconf update`, before `build-oci` — see [docs/oci-assembly.md](docs/oci-assembly.md)
 
 ### Element changes (`elements/bluefin/`)
 
-- [ ] `ln -sf` commands are preceded by `mkdir -p` for the target directory
-- [ ] `kind: manual` binary elements have a `ref:` pinned to a specific tag or commit - not a branch
-- [ ] No `date`, `hostname`, `whoami`, `curl`, or other non-reproducible / network calls in `install-commands`
-- [ ] New systemd units are enabled via the BST install commands, not via a post-install script
+- [ ] `mkdir -p` before any `ln -sf`
+- [ ] Binary elements: `ref:` pinned to tag/commit, not a branch
+- [ ] No `date`, `hostname`, `whoami`, `curl` in `install-commands`
+- [ ] New systemd units enabled via BST install commands, not post-install scripts
 
 ---
 
 ## Community workflow
 
-Dakota uses a structured issue lifecycle so that the community shapes what gets built and agents build exactly what was agreed on — no more, no less.
+Issues flow: `status/discussing` → `status/approved` (maintainer writes acceptance criteria) → `queue/agent-ready` → `/claim` → implement → PR with `Closes #NNN` → merge queue.
 
-This workflow is **opt-in** in the issue form. Issues only enter it automatically when the author selects **Raptor Current**. Otherwise they stay ordinary issues unless a maintainer or wrangler chooses to route them into the workflow later with `status/approved` plus `/ready`.
+**Actionadon bot:**
 
-There is also a fast lane for donated agent time: the **Help this project** issue form. That form takes a target URL and routes the issue straight into Hive with one of these flows:
-- `flow/project-report` — scanner writes a sourced project report
-- `flow/issue-review` — scanner reviews a linked issue and recommends next steps
-- `flow/pr-review` — reviewer audits a linked PR; Dakota PR reviews that depend on local proof use `just validate`, `just build default`, `just lint`, and `just boot-fast` or `just generate-bootable-image && just boot-vm`
-
-```
-New issue
-  │
-  ▼ actionadon labels status/discussing, posts welcome comment
-Discussion happens in the issue if people want it
-  │
-  ▼ Maintainer adds status/approved when the issue is ready for approval
-Maintainer writes acceptance criteria in the issue body
-  │
-  ▼ Maintainer adds queue/agent-ready
-Any human or agent can claim it — comment /claim on the issue
-  │
-  ▼ actionadon adds queue/claimed, assigns the claimer
-Implement the acceptance criteria, open a PR with Closes #NNN
-  │
-  ▼ CI validate passes, maintainer reviews, lab:pass applied
-Merge queue → issue closes automatically
-```
-
-### actionadon
-
-`actionadon` is the bot that drives this. It runs as a GitHub Actions workflow (`.github/workflows/actionadon.yml`) and posts one short comment each time an issue advances a stage.
-
-| Comment `/claim` | Takes the issue. actionadon assigns you and adds `queue/claimed`. |
+| Comment | Effect |
 |---|---|
-| Comment `/ready` | Wranglers and maintainers can move an approved, spec-complete issue into the queue. It requires a `### Acceptance criteria` section with real checklist items. |
-| Comment `/unclaim` | Returns it to the queue. The assignee, a wrangler, or a maintainer can unclaim. |
+| `/claim` | Assigns you, adds `queue/claimed` |
+| `/ready` | Moves approved+spec-complete issue into the queue (wranglers/maintainers only) |
+| `/unclaim` | Returns to the queue |
 
-If a claimed issue has no PR activity for 7 days, actionadon automatically returns it to the queue.
+**`kind:agent-donation` issues:** write the report as a comment, cite sources, close the issue. Do not open a PR.
 
-### Wrangler role
-
-Wranglers are the humans who keep the queue moving. This is intentionally a lower-barrier role than maintainer: they do not need to merge code or own every repo, they just need enough project context to shape issues into buildable specs and steer the bots.
-
-All projectbluefin maintainers are implicit wranglers. The list below is the extra named group for trusted contributors who should be able to drive the bots without becoming the merge gate.
-
-Wranglers can:
-- help turn discussion into acceptance criteria
-- comment `/ready` when an approved issue is spec-complete and should enter the queue
-- comment `/unclaim` when a claimed issue has gone stale and needs to go back in circulation
-- nudge Hive toward the right issues without becoming the merge gate
-
-Initial wranglers:
-- `castrojo`
-- `ahmedadan`
-- `alatiera`
-- `hanthor`
-- `coxde`
-- `renner0e`
-
-### Hive integration
-
-If you're running [Hive](https://github.com/kubestellar/hive) against this repo, copy `files/hive/hive-project.yaml.example` to `/etc/hive/hive-project.yaml` and load the agent policy files from `files/hive/agent-policies/` as your per-agent CLAUDE.md overrides. The repo-local skill folder at `.github/skills/` is the human-readable companion to those Hive policies: use `dakota-build` for local validation, `dakota-agent-workflow` for issue/PR/report flows, and `dakota-ci` for routing changes. Hive will route donated-agent issues by flow: scanner handles project reports and issue reviews, reviewer handles PR reviews, and architect handles larger Dakota structural work. All of them claim `queue/agent-ready` issues via the `/claim` protocol above.
-
----
-## Label protocol
-
-### Triage labels
-
-| Label | What it means |
-|---|---|
-| `status/discussing` | Structured issue flow in progress; not ready for the agent queue yet. |
-| `status/approved` | Approved for queue preparation — needs acceptance criteria before queue. |
-| `queue/claimed` | Actively being worked by a human or agent. |
-| `agent/blocked` | Blocked and needs human input before work can continue. |
-| `hold` | Do not touch; intentionally held by humans. |
-| `do-not-merge` | Do not merge or automate this item. |
-| `queue/agent-ready` | Issue is scoped with clear acceptance criteria. Ready for an agent or contributor to pick up and open a PR. |
-| `lgtm` | PR approved by a maintainer. |
-| `help wanted` | Good for any contributor, including agents. |
-| `kind:bug` | Something is broken and needs fixing. |
-| `kind:improvement` | Enhancement or cleanup — no spec required for small items. |
-| `kind:tech-debt` | Cleanup with no user-visible change. |
-| `kind:github-action` | CI or automation changes. |
-| `kind:agent-donation` | A donated-agent request to investigate a repo, issue, or PR and return a report instead of code. |
-| `flow/project-report` | Scanner flow for a linked repository, org, roadmap, or docs report. |
-| `flow/issue-review` | Scanner flow for a linked issue review. |
-| `flow/pr-review` | Reviewer flow for a linked PR review. |
-| `lab:pass` | Maintainer lab validation passed; enables label-gated auto-merge for maintainer-owned PR branches. After `lab:pass`, one maintainer ack/approval is sufficient for merge-queue entry. |
-| `needs-human/agent-oops` | An agent made a mistake here — wrong assumption, bad output, filed a spurious issue, broke something. This label builds a learning corpus. |
-
-### `queue/agent-ready` - how to use it
-
-When you see this label on an issue:
-1. Read the full issue - the acceptance criteria are there
-2. Run `just --list` to understand the build system
-3. Make the change, validate, build, boot, lint
-4. Open a PR with `Closes #NNN` in the body
-5. CI `validate` must pass
-
-If the issue also carries `kind:agent-donation`, follow the flow embedded in the issue body instead of opening a PR: write the report comment, cite sources, and close the issue when done.
-
-### Hive exempt labels
-
-Hive should not touch issues labeled:
-- `hold`
-- `do-not-merge`
-- `status/discussing`
-- `status/approved`
-- `queue/claimed`
-- `agent/blocked`
-- `needs-human/agent-oops`
-- `duplicate` / `kind/duplicate`
-- `wontfix` / `kind/wontfix`
-- `stale`
-
-### `needs-human/agent-oops` — how to use it
-
-When an agent makes an error:
-- A maintainer adds `needs-human/agent-oops` to the relevant issue or PR
-- Do **not** remove this label — it is intentional signal
-- If you are the agent that made the error, note what went wrong in your response to the maintainer (so the pattern can be captured in agent skill files)
-- Examples: filed a duplicate issue, proposed a fix for something already upstream, broke a patch apply, failed to check hardware after a build
+**Hive:** Copy `files/hive/hive-project.yaml.example` to `/etc/hive/hive-project.yaml` and load `files/hive/agent-policies/` as per-agent CLAUDE.md overrides.
 
 ---
 
-## Patch management rules
+## Labels
 
-Patches in `patches/freedesktop-sdk/` and `patches/gnome-build-meta/` are
-applied in **alphabetical filename order** via BuildStream's `patch_queue`
-source. The numbers in filenames control application order.
+| Label | Meaning |
+|---|---|
+| `status/discussing` | Not ready for the agent queue |
+| `status/approved` | Approved; needs acceptance criteria before queue |
+| `queue/agent-ready` | Scoped with acceptance criteria — claim it |
+| `queue/claimed` | In active work |
+| `agent/blocked` | Needs human input before work can continue |
+| `hold` | Do not touch |
+| `do-not-merge` | Do not merge or automate |
+| `lgtm` | Maintainer approved |
+| `lab:pass` | Lab validation passed; enables label-gated auto-merge |
+| `kind:bug` / `kind:improvement` / `kind:tech-debt` / `kind:github-action` | Change type |
+| `kind:agent-donation` | Investigation request — report comment, not code |
+| `flow/project-report` / `flow/issue-review` / `flow/pr-review` | Hive scanner flow routing |
+| `needs-human/agent-oops` | Agent error — do not remove; note what went wrong in your reply |
 
-**When bumping a junction ref:**
-1. Check every existing patch in the relevant `patches/` directory
-2. If a patch targets a `ref:` that no longer exists in the new junction - the patch will fail to apply. Either update the patch to match the new context or drop it if the fix is upstream.
-3. Kernel patches (`patches/linux/`) are applied to the kernel source by fdsdk's linux element - verify they still apply against the new kernel version
+**Hive exempt** (do not touch): `hold`, `do-not-merge`, `status/discussing`, `status/approved`, `queue/claimed`, `agent/blocked`, `needs-human/agent-oops`, `duplicate`, `wontfix`, `stale`
 
-**Patch lifecycle:**
+---
+
+## Patch management
+
+Patches apply in **alphabetical filename order**. Numbers in filenames control application order.
+
+When bumping a junction: verify every patch in the relevant `patches/` directory still applies; update or drop any that target a `ref:` no longer in the new junction. Kernel patches (`patches/linux/`) apply against kernel source — verify against the new kernel version too.
+
 ```
-Add patch → document Upstream-Status → track upstream PR →
+Add patch → Upstream-Status header → track upstream PR →
 upstream merges → junction bump includes fix → drop patch
 ```
 
-Never carry a patch longer than needed. Every patch is maintenance debt.
+Every patch is maintenance debt. Drop as soon as it's upstream.
 
 ---
 
-## CI overview
+## CI
 
-| Job | Fires on | What it does |
+| Job | Triggers | What |
 |---|---|---|
-| `validate` | `pull_request` | `bst show` - checks element graph, applies patches, validates deps. Fast (~5 min). |
-| `build` | `merge_group`, `schedule`, `workflow_dispatch` | Full OCI build + push artifact to remote CAS. Slow (~60-90 min). |
-| `build-aarch64` | disabled | ARM64 build — disabled pending investigation |
+| `validate` | `pull_request` | `bst show` — graph + patch check (~5 min) |
+| `build` | `merge_group`, `schedule`, `workflow_dispatch` | Full OCI build (~60–90 min) |
+| `build-aarch64` | disabled | ARM64 — pending investigation |
 
-The daily cron fires at **13:00 UTC** - after gnome-build-meta nightly (~08:00 UTC).
-
-**Never** bypass the merge queue with `--admin`. The queue's `build` job is the
-gate. If `validate` passes on a PR but `build` fails in the queue, that failure
-is real and must be fixed.
+Schedule: **13:00 UTC** daily (after GBM nightly at ~08:00 UTC). Never bypass the merge queue with `--admin`.
 
 ---
 
@@ -427,39 +196,31 @@ is real and must be fixed.
 
 | Don't | Why |
 |---|---|
-| `rpm-ostree`, `pip install`, `apt-get` in element commands | This is a BST-only build. All deps come from junctions. |
-| `$(date)`, `$(hostname)`, `$(curl ...)` in `install-commands` | Breaks BST's content-addressed caching and reproducibility |
-| Patch junction files directly | Use the `patch_queue` source in the junction `.bst` element |
+| `rpm-ostree`, `pip install`, `apt-get` in elements | BST-only build; all deps from junctions |
+| `$(date)`, `$(hostname)`, `$(curl ...)` in `install-commands` | Breaks reproducibility and BST caching |
+| Patch junction files directly | Use `patch_queue` source in the junction `.bst` |
 | Force-push to `main` | The merge queue owns merges |
-| Close issues via API or comment | Use `Closes #NNN` in the PR body - the issue closes automatically on merge |
-| Open a PR without running `validate` first | Saves everyone time |
+| Close issues via API or comment | Use `Closes #NNN` in the PR body |
+| Open a PR without running `just validate` | Wastes everyone's time |
 
 ---
 
 ## Useful BST commands
 
 ```bash
-# Check if your element changes are sound before building
-just validate
-
-# Build just one element (faster iteration)
-just bst build elements/bluefin/tailscale.bst
-
-# Open a shell inside the build sandbox for an element
-just bst shell --build elements/bluefin/tailscale.bst
-
-# Check what depends on an element (what will rebuild if this changes)
-just bst show --deps all --format '%{name}' oci/bluefin.bst \
-  | grep -F "$(just bst show --format '%{name}' elements/bluefin/tailscale.bst)"
+just validate                                           # check element graph
+just bst build elements/bluefin/tailscale.bst          # build one element
+just bst shell --build elements/bluefin/tailscale.bst  # sandbox shell
+just bst show --deps all oci/bluefin.bst               # full dependency graph
 ```
 
 ---
 
 ## Links
 
-- BuildStream docs: https://docs.buildstream.build/
-- freedesktop-sdk: https://gitlab.com/freedesktop-sdk/freedesktop-sdk
-- gnome-build-meta (GitHub mirror): https://github.com/GNOME/gnome-build-meta - branch `gnome-50`
-- Existing issues: https://github.com/projectbluefin/dakota/issues
-- Dakota Development board: https://github.com/orgs/projectbluefin/projects/3
-- todo.projectbluefin.io (all Bluefin projects): https://github.com/orgs/projectbluefin/projects/2
+- [BuildStream docs](https://docs.buildstream.build/)
+- [freedesktop-sdk](https://gitlab.com/freedesktop-sdk/freedesktop-sdk)
+- [gnome-build-meta](https://github.com/GNOME/gnome-build-meta) — branch `gnome-50`
+- [Dakota issues](https://github.com/projectbluefin/dakota/issues)
+- [Dakota board](https://github.com/orgs/projectbluefin/projects/3)
+- [All Bluefin projects](https://github.com/orgs/projectbluefin/projects/2)


### PR DESCRIPTION
## Summary

Trim AGENTS.md and audit in-repo skills for token efficiency.

### AGENTS.md: 465 → 226 lines (−51%)
- 6 verbose Gates → tight bullet block
- Dev loop: prose → command reference
- Removed wrangler role section (irrelevant to agents)
- Removed 'verify inside VM' sub-step (redundant with `boot-test`)
- Compressed community workflow prose into flow + bot table
- Labels: Hive-exempt collapsed to one line
- All policy content, PR checklist, CI table, patch rules preserved

### `.github/skills/ujust-recipes.md`
- Renamed `## Lore` → `## Raptor spinner text` so agents treat it as a constraint, not optional flavor

### `.github/skills/testlab.md`
- Already efficient, no changes

---
- [ ] I am using an agent and I take responsibility for this PR