### PR TITLE
Fix conditional check for BUILD_SKIP_CHUNKIFY

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -527,7 +527,7 @@ chunkify image_ref:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    if [ "${BUILD_SKIP_CHUNKIFY:-}" = "1" ]; then
+    if [ "$BUILD_SKIP_CHUNKIFY" = "1" ]; then
         echo "==> Skipping chunkify (BUILD_SKIP_CHUNKIFY=1)"
         exit 0
     fi


### PR DESCRIPTION
## What problem are you solving?
<!-- Write this in your own words. One paragraph. No AI. -->

- [ ] I am using an agent and I take responsibility for this PR

---

## Changes

<!-- Agent/tool-generated summary below this line is fine -->

## Testing

- [x] `just validate` passes
- [x] `just boot-test` passes (automated boot smoke test)
- [x] `just lint` passes on a built image
- [ ] `just boot-fast` or `just boot-vm` — desktop comes up, no regressions

## Checklist

- [ ] New BST elements wired into `deps.bst`
- [ ] Patches in `patches/` regenerated if junction refs changed

## Community verification (bug-fix PRs)

If this PR fixes a bug, add verify-steps to the issue so the community can confirm
the fix works on their hardware after the next nightly ships:

````markdown
```verify
# Steps for users to verify this fix:
systemctl status <affected-service>
# or whatever the user should check
```
````

Users will run `ujust verify <issue-number>` which fetches these steps automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration handling to enforce stricter validation of required build settings. The build process will now error if expected variables are not explicitly set, rather than treating them as empty values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->