### PR TITLE
fix(justfile): add chunkify group annotation and push-local recipe

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -169,6 +169,16 @@ export variant="default":
     echo "==> Export complete. Image loaded as ${FINAL_NAME}:${FINAL_TAG}"
     $SUDO_CMD podman images | grep -E "{{image_name}}|REPOSITORY" || true
 
+[group('build')]
+push-local tag=image_tag:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    SUDO_CMD=""
+    if [ "$(id -u)" -ne 0 ]; then
+        SUDO_CMD="sudo"
+    fi
+    LOCAL_REGISTRY="${LOCAL_REGISTRY:-localhost:5000}"
+    $SUDO_CMD podman push --tls-verify=false "{{image_name}}:{{tag}}" "${LOCAL_REGISTRY}/{{image_name}}:{{tag}}"
 
 # ── Clean ─────────────────────────────────────────────────────────────
 # Remove generated artifacts (disk image, OVMF vars, build output).
@@ -523,6 +533,7 @@ show-me-the-future:
 # the overlay + xattr-apply step can be removed. chunkah can then be run
 # with LD_PRELOAD=fakecap.so FAKECAP_MANIFEST=.../fakecap-manifest.tsv.
 # See also: projectbluefin/dakota#231.
+[group('build')]
 chunkify image_ref:
     #!/usr/bin/env bash
     set -euo pipefail


### PR DESCRIPTION
## Summary

- Add `[group('build')]` annotation to `chunkify` recipe (was ungrouped, inconsistent with all other recipes)\n- Add `push-local` recipe for pushing built image to local zot registry\n\n## Changes\n\n```\njust push-local [tag]   # push dakota:<tag> to LOCAL_REGISTRY/dakota:<tag>\n```\n\n`LOCAL_REGISTRY` defaults to `localhost:5000`. For ghost lab use: `LOCAL_REGISTRY=192.168.1.102:5000 just push-local pr-N`\n\nCloses #513\nCloses #514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New build automation recipe for pushing container images to a local registry. Includes automatic system privilege detection, customizable registry endpoint (defaults to localhost:5000), and TLS verification bypass for streamlined local development workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/580?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->