### PR TITLE
Remove command-order from 05-dakota-custom-command-menu

### DIFF
--- a/files/dconf/05-dakota-custom-command-menu
+++ b/files/dconf/05-dakota-custom-command-menu
@@ -14,7 +14,6 @@ menuoptions-setting=2
 menuicon-setting='ublue-logo-symbolic'
 menulocation-setting=1
 menuposition-setting=0
-command-order=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 command1=('---$(hostname)', '', '', true)
 command2=('About', 'gnome-control-center system about', '', true)
 command3=('System Monitor', '/usr/bin/flatpak run io.missioncenter.MissionCenter', '', true)


### PR DESCRIPTION
`command-order` should not be defined here because it reintroduces two separate bugs. It was previously removed here https://github.com/projectbluefin/dakota/pull/416 but was added back by this commit https://github.com/projectbluefin/dakota/commit/fa4bd1441bb7a36b6ddbce109f608a7516827f82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified custom command menu configuration by removing explicit ordering definition. Menu commands now rely on sequential command definitions instead.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->