### PR TITLE
fix(publish): call just chunkify after export to restore 120-layer output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -156,6 +156,11 @@ jobs:
           OCI_IMAGE_VERSION: latest
         run: just export ${{ matrix.variant }}
 
+      - name: Chunkify image layers
+        env:
+          BUILD_IMAGE_NAME: ${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
+        run: just chunkify "${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}:latest"
+
       - name: Validate with bootc container lint
         env:
           BUILD_IMAGE_NAME: ${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}


### PR DESCRIPTION
## Problem

Images published to GHCR are a single squashed layer instead of ~120 chunkah-assigned layers. The `publish.yml` workflow calls `just export` (which squashes via `podman build --squash-all`) but never runs `just chunkify`, so chunkah never runs on published images.

Reported in issue 581.

## Fix

Add a **Chunkify image layers** step after `just export`, before `bootc container lint`. The existing `chunkify` recipe handles `BUILD_SKIP_CHUNKIFY=1` already for any bypass case.

## Test

- [ ] Lab: boot-test on exo-dakota after a local `just export && just chunkify`
- [ ] Verify `podman image inspect` shows multiple layers post-chunkify

Closes #581

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publish build pipeline to include additional image processing steps for each variant build.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->