### PR TITLE
fix(ujust): show issue URL with template in not-signed-in path of ujust report

### DIFF
--- a/files/just-overrides/default.just
+++ b/files/just-overrides/default.just
@@ -352,6 +352,8 @@ report:
         exit 0
     fi
 
+    ISSUE_URL_BASE="https://github.com/projectbluefin/dakota/issues/new?template=bug-report.yml"
+
     if ! gh auth status --active &>/dev/null; then
         echo ""
         gum style --foreground 214 --bold --margin "0 2" \
@@ -367,6 +369,7 @@ report:
         else
             gum style --foreground 245 --margin "0 4" "(clipboard not available — open the file below)"
         fi
+        gum style --foreground 245 --margin "0 4" "Open: $ISSUE_URL_BASE"
         echo ""
         gum style --margin "0 2" "Option 2 — sign in to gh and upload:"
         gum style --foreground 245 --margin "0 4" "gh auth login"


### PR DESCRIPTION
## What

When `gh` is not authenticated, `ujust report` shows users two options for sharing their report but omitted the issue URL where they should file. Users had to discover the issue form themselves, sometimes landing on the bare `/issues/new` without the bug-report template pre-selected.

## Fix

- Define `ISSUE_URL_BASE` with `?template=bug-report.yml` before the auth check
- Show `Open: <url>` after the clipboard copy confirmation so users know where to go

## Testing

Code path exercised manually — the change is in the not-signed-in branch (`gh auth status --active` fails), immediately after clipboard copy.

Closes projectbluefin/dakota#576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a link to create GitHub issues in the report workflow. Users will now see an "Open" option to access the issue template when not signed in.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->