### PR TITLE
fix(systemd): guard flatpak-preinstall.service against missing subcommand

### DIFF
--- a/elements/bluefin/firstboot-services.bst
+++ b/elements/bluefin/firstboot-services.bst
@@ -3,6 +3,8 @@ kind: manual
 sources:
 - kind: local
   path: files/firstboot
+- kind: local
+  path: files/service-overrides
 
 build-depends:
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
@@ -15,4 +17,5 @@ config:
   - install -Dm644 ublue-boot-timeout.service "%{install-root}/usr/lib/systemd/system/ublue-boot-timeout.service"
   - install -d "%{install-root}/usr/lib/systemd/system/multi-user.target.wants"
   - ln -sf ../ublue-boot-timeout.service "%{install-root}/usr/lib/systemd/system/multi-user.target.wants/ublue-boot-timeout.service"
+  - install -Dm644 "flatpak-preinstall.service.d/condition-check.conf" "%{install-root}/usr/lib/systemd/system/flatpak-preinstall.service.d/condition-check.conf"
   - "%{install-extra}"

--- a/files/service-overrides/flatpak-preinstall.service.d/condition-check.conf
+++ b/files/service-overrides/flatpak-preinstall.service.d/condition-check.conf
@@ -1,0 +1,7 @@
+[Service]
+# The flatpak preinstall subcommand was added after 1.16.x.
+# Guard with ExecCondition so the service exits cleanly (not failed)
+# on images that ship an older flatpak, rather than logging errors on
+# every boot.  Drop this override once the minimum flatpak version
+# in fdsdk is >= the version that introduced 'flatpak preinstall'.
+ExecCondition=/bin/sh -c 'flatpak help 2>&1 | grep -q preinstall'


### PR DESCRIPTION
## Problem

`flatpak-preinstall.service` fails on every boot with exit code 1 because `flatpak preinstall` is not a valid subcommand in Flatpak 1.16.6 (shipped by fdsdk 25.08.12). The service retries 3× at 30s intervals before giving up, logging errors and degrading systemd status on every boot.

The service comes from `projectbluefin/common.git` — it's designed for a future flatpak version that has the `preinstall` subcommand.

## Fix

Add a systemd drop-in at `flatpak-preinstall.service.d/condition-check.conf` with:

```ini
ExecCondition=/bin/sh -c 'flatpak help 2>&1 | grep -q preinstall'
```

When the subcommand doesn't exist: `ExecCondition` returns non-zero → service exits 0 (skipped, not failed) → no errors. When it does exist: the condition passes and the service runs normally.

This is a localised override in Dakota's `firstboot-services.bst`. Drop it when fdsdk ships a flatpak version that has `preinstall`.

Closes projectbluefin/dakota#577