### PR TITLE
feat(report): add boot error log and per-unit journal to ujust report

### DIFF
--- a/files/just-overrides/default.just
+++ b/files/just-overrides/default.just
@@ -183,19 +183,36 @@ report:
         FAILED_UNITS=\$(systemctl list-units --state=failed --no-legend --plain 2>/dev/null | awk '{print \$1}' | head -20 || echo '')
         KERNEL_VER=\$(uname -r)
         ARCH=\$(uname -m)
+        # Collect boot-time errors and warnings (kernel + services).
+        # Captures hardware init failures (e.g. Bluetooth firmware, udev group
+        # resolution) that never cause a unit to fully fail but are still bugs.
+        BOOT_ERRORS=\$(journalctl -b -p warning..err --no-pager -n 40 \
+            --output=short-monotonic 2>/dev/null \
+            | sed -E 's|/home/[^/[:space:]]+/|/home/<redacted>/|g' \
+            | sed -E 's|/run/user/[0-9]+|/run/user/<uid>|g')
+        # For each failed unit, collect last 15 lines of its journal.
+        FAILED_UNIT_LOGS=''
+        for _unit in \$FAILED_UNITS; do
+            _log=\$(journalctl -b -u \"\$_unit\" --no-pager -n 15 \
+                --output=short-monotonic 2>/dev/null \
+                | sed -E 's|/home/[^/[:space:]]+/|/home/<redacted>/|g')
+            FAILED_UNIT_LOGS=\"\${FAILED_UNIT_LOGS}=== \${_unit} ===\n\${_log}\n\"
+        done
         FLATPAK_LIST=\$(printf '%s' \"\$FLATPAK_LIST\" | sed -E 's|/home/[^/[:space:]]+/|/home/<redacted>/|g')
         GNOME_EXTENSIONS=\$(printf '%s' \"\$GNOME_EXTENSIONS\" | sed -E 's|/home/[^/[:space:]]+/|/home/<redacted>/|g')
-        printf 'BOOTED_IMAGE=%q\n'    \"\$BOOTED_IMAGE\"    > '$COLLECTION_OUT'
-        printf 'BOOTED_DIGEST=%q\n'   \"\$BOOTED_DIGEST\"   >> '$COLLECTION_OUT'
-        printf 'STAGED_IMAGE=%q\n'    \"\$STAGED_IMAGE\"    >> '$COLLECTION_OUT'
-        printf 'GNOME_VERSION=%q\n'   \"\$GNOME_VERSION\"   >> '$COLLECTION_OUT'
-        printf 'KERNEL_VER=%q\n'      \"\$KERNEL_VER\"      >> '$COLLECTION_OUT'
-        printf 'ARCH=%q\n'            \"\$ARCH\"             >> '$COLLECTION_OUT'
-        printf 'LOAD_AVG=%q\n'        \"\$LOAD_AVG\"         >> '$COLLECTION_OUT'
-        printf 'MEM_INFO=%q\n'        \"\$MEM_INFO\"         >> '$COLLECTION_OUT'
-        printf 'FLATPAK_LIST=%q\n'    \"\$FLATPAK_LIST\"    >> '$COLLECTION_OUT'
-        printf 'GNOME_EXTENSIONS=%q\n' \"\$GNOME_EXTENSIONS\" >> '$COLLECTION_OUT'
-        printf 'FAILED_UNITS=%q\n'    \"\$FAILED_UNITS\"    >> '$COLLECTION_OUT'
+        printf 'BOOTED_IMAGE=%q\n'       \"\$BOOTED_IMAGE\"       > '$COLLECTION_OUT'
+        printf 'BOOTED_DIGEST=%q\n'      \"\$BOOTED_DIGEST\"      >> '$COLLECTION_OUT'
+        printf 'STAGED_IMAGE=%q\n'       \"\$STAGED_IMAGE\"       >> '$COLLECTION_OUT'
+        printf 'GNOME_VERSION=%q\n'      \"\$GNOME_VERSION\"      >> '$COLLECTION_OUT'
+        printf 'KERNEL_VER=%q\n'         \"\$KERNEL_VER\"         >> '$COLLECTION_OUT'
+        printf 'ARCH=%q\n'               \"\$ARCH\"               >> '$COLLECTION_OUT'
+        printf 'LOAD_AVG=%q\n'           \"\$LOAD_AVG\"           >> '$COLLECTION_OUT'
+        printf 'MEM_INFO=%q\n'           \"\$MEM_INFO\"           >> '$COLLECTION_OUT'
+        printf 'FLATPAK_LIST=%q\n'       \"\$FLATPAK_LIST\"       >> '$COLLECTION_OUT'
+        printf 'GNOME_EXTENSIONS=%q\n'   \"\$GNOME_EXTENSIONS\"   >> '$COLLECTION_OUT'
+        printf 'FAILED_UNITS=%q\n'       \"\$FAILED_UNITS\"       >> '$COLLECTION_OUT'
+        printf 'BOOT_ERRORS=%q\n'        \"\$BOOT_ERRORS\"        >> '$COLLECTION_OUT'
+        printf 'FAILED_UNIT_LOGS=%q\n'   \"\$FAILED_UNIT_LOGS\"   >> '$COLLECTION_OUT'
     "
     # shellcheck disable=SC1090
     source "$COLLECTION_OUT"
@@ -290,6 +307,19 @@ report:
     printf '\n### Failed Systemd Units\n\n'
     if [[ -n "${FAILED_UNITS}" ]]; then
         printf '%s\n' "${FAILED_UNITS}" | sed 's/^/- /'
+        if [[ -n "${FAILED_UNIT_LOGS}" ]]; then
+            printf '\n#### Unit Logs\n\n```\n'
+            printf '%b\n' "${FAILED_UNIT_LOGS}"
+            printf '```\n'
+        fi
+    else
+        printf '_None_ ✓\n'
+    fi
+    printf '\n### Boot Errors and Warnings\n\n'
+    if [[ -n "${BOOT_ERRORS}" ]]; then
+        printf '```\n'
+        printf '%s\n' "${BOOT_ERRORS}"
+        printf '```\n'
     else
         printf '_None_ ✓\n'
     fi

--- a/files/just-overrides/default.just
+++ b/files/just-overrides/default.just
@@ -191,13 +191,16 @@ report:
             | sed -E 's|/home/[^/[:space:]]+/|/home/<redacted>/|g' \
             | sed -E 's|/run/user/[0-9]+|/run/user/<uid>|g')
         # For each failed unit, collect last 15 lines of its journal.
-        FAILED_UNIT_LOGS=''
+        _unit_logs_tmp=\$(mktemp)
         for _unit in \$FAILED_UNITS; do
             _log=\$(journalctl -b -u \"\$_unit\" --no-pager -n 15 \
                 --output=short-monotonic 2>/dev/null \
-                | sed -E 's|/home/[^/[:space:]]+/|/home/<redacted>/|g')
-            FAILED_UNIT_LOGS=\"\${FAILED_UNIT_LOGS}=== \${_unit} ===\n\${_log}\n\"
+                | sed -E 's|/home/[^/[:space:]]+/|/home/<redacted>/|g' \
+                | sed -E 's|/run/user/[0-9]+|/run/user/<uid>|g')
+            printf '=== %s ===\n%s\n' \"\$_unit\" \"\$_log\" >> \"\$_unit_logs_tmp\"
         done
+        FAILED_UNIT_LOGS=\$(cat \"\$_unit_logs_tmp\")
+        rm -f \"\$_unit_logs_tmp\"
         FLATPAK_LIST=\$(printf '%s' \"\$FLATPAK_LIST\" | sed -E 's|/home/[^/[:space:]]+/|/home/<redacted>/|g')
         GNOME_EXTENSIONS=\$(printf '%s' \"\$GNOME_EXTENSIONS\" | sed -E 's|/home/[^/[:space:]]+/|/home/<redacted>/|g')
         printf 'BOOTED_IMAGE=%q\n'       \"\$BOOTED_IMAGE\"       > '$COLLECTION_OUT'
@@ -309,7 +312,7 @@ report:
         printf '%s\n' "${FAILED_UNITS}" | sed 's/^/- /'
         if [[ -n "${FAILED_UNIT_LOGS}" ]]; then
             printf '\n#### Unit Logs\n\n```\n'
-            printf '%b\n' "${FAILED_UNIT_LOGS}"
+            printf '%s\n' "${FAILED_UNIT_LOGS}"
             printf '```\n'
         fi
     else


### PR DESCRIPTION
[WHAT] Add two new sections to `ujust report` output: **Boot Errors and Warnings** and **Unit Logs**.

[WHY] Issues #575 and #578 were filed with incomplete data because current report only captures unit *names* for failures, and completely misses errors from services that stay running despite logging errors (udevd, Bluetooth firmware). Reporters and maintainers then have to ask follow-up questions to get the data that was already on the user's machine.

- `systemd-udevd` never enters "failed" state for "Unknown group" errors (issue #575) — invisible to current report
- Bluetooth firmware race errors (issue #578) are kernel+driver log messages, not in any "failed" unit — also invisible

[FIX]
1. **Boot Errors and Warnings** — `journalctl -b -p warning..err --no-pager -n 40 --output=short-monotonic` collected during the scan phase. Captures hardware init failures that never fail a unit. Redacts home paths and uid fragments.
2. **Unit Logs** — for each entry in `FAILED_UNITS`, collects last 15 lines of `journalctl -b -u <unit>`. Currently the report listed unit names with no context; this makes each failure self-explanatory.

Both sections follow the existing redaction pattern (`/home/<redacted>/`, `/run/user/<uid>`).

[NEXT] Do NOT remove the plain unit name list — it stays as a quick summary above the logs.

Fixes #575
Fixes #578

- [x] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagnostic reports now collect boot-time warning/error messages and per-failed-unit journal excerpts.
  * Reports redact local user/runtime paths for improved privacy.
  * The generated summary now conditionally includes "Boot Errors and Warnings" and per-unit "Unit Logs" sections alongside the failed units list.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->