### PR TITLE
fix(ujust): dx-group — guard PKEXEC_UID, offer reboot

### DIFF
--- a/files/just-overrides/system.just
+++ b/files/just-overrides/system.just
@@ -49,6 +49,13 @@ toggle-devmode:
 [group('System')]
 dx-group:
     #!/usr/bin/pkexec bash
+
+    # Guard: PKEXEC_UID must be set and non-root
+    if [[ -z "${PKEXEC_UID}" ]] || [[ "${PKEXEC_UID}" == "0" ]]; then
+        echo "ERROR: run this via ujust, not directly as root."
+        exit 1
+    fi
+
     append_group() {
         local group_name="$1"
         if ! grep -q "^$group_name:" /etc/group; then
@@ -64,7 +71,13 @@ dx-group:
         usermod -aG $GROUP_ADD {{ `id -un` }}
     done
 
-    echo "Reboot system and log back in to use docker, libvirt, incus, and serial connections."
+    echo ""
+    echo "Groups added: docker, incus-admin, libvirt, dialout."
+    echo "A reboot is required for group membership to take effect."
+    echo ""
+    if gum confirm "Reboot now?"; then
+        systemctl reboot
+    fi
 
 # Install system flatpaks for rebasers
 [group('System')]


### PR DESCRIPTION
## Summary

- Add `PKEXEC_UID` guard: exits with an error if empty or called directly as root, preventing accidental writes to `/.config/` on the root filesystem if pkexec is invoked outside a normal user session
- Replace the passive "Reboot system and log back in" echo with a `gum confirm "Reboot now?"` that calls `systemctl reboot` — users can reboot immediately without switching to another terminal

## Test plan
- Run `ujust dx-group` as a normal user — groups should be added, reboot prompt should appear
- Confirm running as root (outside pkexec) exits cleanly with the error message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a safety validation to prevent direct root execution with proper error messaging.
  * Enhanced reboot prompts with clearer messaging and user-friendly instructions after group additions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/597?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->