### PR TITLE
fix(ujust): read actual booted image from bootc status for toggle-devmode

### DIFF
--- a/files/just-overrides/system.just
+++ b/files/just-overrides/system.just
@@ -18,24 +18,30 @@ devmode:
 toggle-devmode:
     #!/usr/bin/env bash
     set -e
-    IMAGE_INFO_FILE="${IMAGE_INFO_FILE:-/usr/share/ublue-os/image-info.json}"
-    IMAGE_NAME="$(jq -rc '."image-name"' "${IMAGE_INFO_FILE}")"
-    IMAGE_REF="$(jq -rc '."image-ref"' "${IMAGE_INFO_FILE}" | sed "s/.*ghcr/ghcr/")"
-    CURRENT_IMAGE="${IMAGE_REF}:$(jq -rc '."image-tag"' "${IMAGE_INFO_FILE}")"
-    IMAGE_BASE_NAME="$(cut -f1 -d\- <<< "${IMAGE_NAME}")"
+    BOOTED_JSON=$(sudo bootc status --json 2>/dev/null || echo '{}')
+    CURRENT_IMAGE=$(echo "$BOOTED_JSON" | jq -r '.status.booted.image.image.image // empty')
+    if [[ -z "${CURRENT_IMAGE}" ]]; then
+        echo "ERROR: could not determine the booted image from bootc status"
+        exit 1
+    fi
+    # Extract image tag (everything after the last colon)
+    IMAGE_TAG="${CURRENT_IMAGE##*:}"
+    # Extract base name without tag
+    IMAGE_REPO="${CURRENT_IMAGE%:*}"
+    IMAGE_BASE_NAME="$(basename "${IMAGE_REPO}")"
     set +e
 
-    if grep -q -E -e "dx$" <<< "${IMAGE_NAME}" ; then
+    if grep -q -E -e "dx$" <<< "${IMAGE_BASE_NAME}" ; then
         gum confirm "Would you like to disable developer mode?" || exit 0
         echo "Rebasing to a non developer image"
-        NEW_IMAGE="$(sed "s/\-dx//" <<< $CURRENT_IMAGE)"
+        NEW_IMAGE="$(sed "s/\-dx//" <<< ${IMAGE_REPO}):${IMAGE_TAG}"
         pkexec bootc switch --enforce-container-sigpolicy "${NEW_IMAGE}"
         exit 0
     fi
 
     gum confirm "Would you like to enable developer mode?" || exit 0
     echo "Rebasing to a developer image"
-    NEW_IMAGE="$(sed "s/${IMAGE_BASE_NAME}/${IMAGE_BASE_NAME}-dx/" <<< "${CURRENT_IMAGE}")"
+    NEW_IMAGE="${IMAGE_REPO}-dx:${IMAGE_TAG}"
     pkexec bootc switch --enforce-container-sigpolicy "${NEW_IMAGE}"
     if gum confirm "Do you want to also install the default development flatpaks?" ; then
         ADD_DEVMODE=1 ujust install-system-flatpaks 0 1


### PR DESCRIPTION
## What problem are you solving?

Fixes #180: `ujust devmode` no longer fails with 403 Forbidden when the build-time image tag doesn't match the actual running stream.

- [x] I am using an agent and I take responsibility for this PR

---

## Changes

`toggle-devmode` read the image tag from the static `/usr/share/ublue-os/image-info.json` baked at build time. For `stable-daily` images, the JSON contains `image-tag: "stable"`, causing devmode to try rebasing to `dakota-dx:latest` instead of `dakota-dx:stable-daily` — resulting in a 403 from ghcr.io.

Reads the actual booted container image from `bootc status --json` instead:
\`\`\`bash
bootc status --json | jq -r '.status.booted.image.image.image'
\`\`\`
- Uses the real running tag for rebasing
- Handles both enable (add -dx) and disable (remove -dx) directions correctly

Same root cause as projectbluefin/common#149 (fixed in common#346).

Closes #180

## Testing

- [ ] `just validate` passes
- [ ] `just boot-test` passes (automated boot smoke test)
- [ ] `just lint` passes on a built image
- [ ] `just boot-fast` or `just boot-vm` — desktop comes up, no regressions

## Checklist

- [ ] New BST elements wired into `deps.bst`
- [ ] Patches in `patches/` regenerated if junction refs changed

## Community verification (bug-fix PRs)

\`\`\`verify
# Steps for users to verify this fix:
ujust devmode
# On stable-daily: should offer to switch to dakota-dx:stable-daily (not :latest)
# On dx: should offer to switch back to dakota:stable-daily
\`\`\`

Assisted-by: Claude Sonnet 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the reliability of the developer mode toggle with improved error detection and better handling of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->