### PR TITLE
feat(just): add debug-session recipe with serial capture and journal logging (#558)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Ignore Python local cache across repo
 **/__pycache__/
 
+# Debug session artifacts
+debug-session/
+
 # Ignore BuildStream local state
 .bst
 .bst2

--- a/Justfile
+++ b/Justfile
@@ -663,6 +663,125 @@ boot-fast: _ensure-bcvk
         --vcpus "{{vm_cpus}}" \
         "localhost/{{image_name}}:{{image_tag}}"
 
+# Interactive debug session — boots the image, captures serial console and systemd
+# journal on exit. Artifacts are saved to ./debug-session/ for bug reports.
+# Requires: bcvk, qemu-kvm, virtiofsd
+[group('test')]
+debug-session: _ensure-bcvk
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    VM_NAME="dakota-debug-$$"
+    SESSION_DIR="./debug-session"
+    START_TS=$(date +%s)
+
+    # Use sudo unless already root
+    SUDO_CMD=""
+    if [ "$(id -u)" -ne 0 ]; then
+        SUDO_CMD="sudo"
+    fi
+
+    if ! $SUDO_CMD podman image exists "{{image_name}}:{{image_tag}}"; then
+        echo "ERROR: Image '{{image_name}}:{{image_tag}}' not found in podman." >&2
+        echo "Run 'just build' first to build and export the OCI image." >&2
+        exit 1
+    fi
+
+    cleanup() {
+        set +e
+        END_TS=$(date +%s)
+        DURATION=$((END_TS - START_TS))
+
+        # Capture console log via podman logs (works even if guest hung/crashed)
+        $SUDO_CMD podman logs "$VM_NAME" > "${SESSION_DIR}/serial.log" 2>/dev/null || true
+
+        # Capture journal and summary via SSH if VM is still reachable
+        KERNEL="unknown"
+        FAILED_DISPLAY="none"
+        if $SUDO_CMD bcvk ephemeral ssh "$VM_NAME" -- true 2>/dev/null; then
+            echo "==> Capturing systemd journal..."
+            $SUDO_CMD bcvk ephemeral ssh "$VM_NAME" -- journalctl -b --no-pager > "${SESSION_DIR}/journal.log" 2>/dev/null || true
+
+            KERNEL=$($SUDO_CMD bcvk ephemeral ssh "$VM_NAME" -- uname -r 2>/dev/null || echo "unknown")
+            FAILED=$($SUDO_CMD bcvk ephemeral ssh "$VM_NAME" -- systemctl list-units --state=failed --no-legend --plain 2>/dev/null | awk '{print $1}' | head -10 | paste -sd ',' 2>/dev/null || true)
+            if [ -n "$FAILED" ]; then FAILED_DISPLAY="$FAILED"; fi
+        fi
+
+        {
+            echo "Debug session: {{image_name}}:{{image_tag}}"
+            echo "Duration: ${DURATION}s"
+            echo "Kernel: ${KERNEL}"
+            echo "Failed units: ${FAILED_DISPLAY}"
+            echo ""
+            echo "Artifacts:"
+            echo "  serial.log   — full serial console from boot"
+            echo "  journal.log  — systemd journal from this boot"
+            echo "  summary.txt  — this file"
+            echo ""
+            echo "Include these artifacts when filing an issue at:"
+            echo "  https://github.com/projectbluefin/dakota/issues/new?template=bug-report.yml"
+        } > "${SESSION_DIR}/summary.txt"
+
+        echo ""
+        echo "==> Debug session artifacts in ${SESSION_DIR}/"
+        if [[ -f "${SESSION_DIR}/serial.log" ]]; then
+            echo "    serial.log   ($(du -sh "${SESSION_DIR}/serial.log" | cut -f1)) — full serial console from boot"
+        fi
+        if [[ -f "${SESSION_DIR}/journal.log" ]]; then
+            echo "    journal.log  ($(du -sh "${SESSION_DIR}/journal.log" | cut -f1)) — systemd journal from this boot"
+        fi
+        if [[ -f "${SESSION_DIR}/summary.txt" ]]; then
+            echo "    summary.txt  — session summary"
+        fi
+        echo ""
+        echo "File an issue with the artifacts above:"
+        echo "  https://github.com/projectbluefin/dakota/issues/new?template=bug-report.yml"
+
+        echo "==> Tearing down VM ${VM_NAME}..."
+        $SUDO_CMD bcvk ephemeral rm -f "$VM_NAME" 2>/dev/null || true
+    }
+    trap cleanup EXIT
+
+    mkdir -p "${SESSION_DIR}"
+
+    echo "==> debug-session: booting {{image_name}}:{{image_tag}} with serial capture..."
+    echo "    RAM: {{vm_ram}}M, CPUs: {{vm_cpus}}"
+    echo "    Artifacts will be saved to ${SESSION_DIR}/"
+    echo ""
+
+    # Launch VM detached; -K enables bcvk ephemeral ssh, --console routes guest
+    # serial output to podman logs for reliable capture even when guest is hung
+    $SUDO_CMD bcvk ephemeral run -d --rm -K --console \
+        --memory "{{vm_ram}}M" \
+        --vcpus "{{vm_cpus}}" \
+        --name "$VM_NAME" \
+        "localhost/{{image_name}}:{{image_tag}}"
+
+    # Wait for SSH to become available
+    echo "==> Waiting for VM to boot..."
+    ELAPSED=0
+    TIMEOUT=120
+    while [ $ELAPSED -lt "$TIMEOUT" ]; do
+        if $SUDO_CMD bcvk ephemeral ssh "$VM_NAME" -- true 2>/dev/null; then
+            break
+        fi
+        sleep 5
+        ELAPSED=$((ELAPSED + 5))
+        printf '.' >&2
+    done
+    echo ""
+
+    if [ $ELAPSED -ge "$TIMEOUT" ]; then
+        echo "FAIL: SSH did not become available within ${TIMEOUT}s" >&2
+        exit 1
+    fi
+    echo "==> VM ready after ~${ELAPSED}s. Starting interactive session."
+    echo "    Reproduce your bug here. Exit the shell when done (Ctrl+D)."
+    echo ""
+
+    # Drop user into interactive SSH session
+    $SUDO_CMD bcvk ephemeral ssh "$VM_NAME"
+
 # Automated boot smoke test — boots the image, verifies GDM starts, exits 0/1.
 # Non-interactive. Intended for CI and agent verification loops.
 # Requires: bcvk, qemu-kvm, virtiofsd


### PR DESCRIPTION
## Summary

Closes #558

Adds a new `just debug-session` recipe that boots the Dakota image in an ephemeral VM, captures the serial console and systemd journal, and writes a session summary — all saved to `./debug-session/`.

### What it does

1. **Launches VM detached** (same as `boot-test`) and captures serial output to `debug-session/serial.log` in the background
2. **Waits for SSH**, then drops the user into an interactive SSH session to reproduce bugs
3. **On exit** (Ctrl+D or session end), the cleanup trap automatically:
   - Captures the full systemd journal via `journalctl -b --no-pager` → `debug-session/journal.log`
   - Writes `debug-session/summary.txt` with kernel version, failed units, and session duration
   - Prints artifact sizes and instructions for filing an issue

### Files changed

- **Justfile**: Add `debug-session` recipe (after `boot-fast`, before `boot-test`), in the `test` group
- **.gitignore**: Add `debug-session/` to prevent artifact commits

### Acceptance criteria

- [x] `just debug-session` exists and boots the image identically to `boot-fast`/`boot-test`
- [x] Serial console is captured to `./debug-session/serial.log`
- [x] On session exit, journal is pulled from the VM and written to `./debug-session/journal.log`
- [x] A `summary.txt` is written with kernel version, failed units, session duration
- [x] `debug-session/` is added to `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a debug-session command that launches an ephemeral VM, provides interactive access, captures serial console output, and automatically collects system diagnostics and logs.

* **Chores**
  * Updated ignore patterns to exclude debug-session artifacts and related outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->