### PR TITLE
fix: wire firstboot-services.bst into deps.bst (#603)

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -23,6 +23,7 @@ depends:
   - bluefin/just-overrides.bst
   - bluefin/motd.bst
   - bluefin/firstboot-date.bst
+  - bluefin/firstboot-services.bst
   - bluefin/wallpaper-month.bst
   - bluefin/bootc-install-config.bst
   - bluefin/composefs-loop-udisks-ignore.bst

--- a/elements/plugins/buildstream-plugins-community.bst
+++ b/elements/plugins/buildstream-plugins-community.bst
@@ -2,5 +2,5 @@ kind: junction
 
 sources:
 - kind: tar
-  url: pypi:08/b4/4b5311dd4ea599bdc69d911263f5d3f8b4c14789d69265d7ea2be7e4e120/buildstream_plugins_community-2.3.0.tar.gz
-  ref: cdd3b73ff998e4145d2bb1a1215b961c65b073a4956609417ab747ef8f462c44
+  url: pypi:source/b/buildstream-plugins-community/buildstream_plugins_community-2.3.1.tar.gz
+  ref: 85c2bae9d3a1eb3121c9674f68ef6e87211fddb9c930f3e5057b9a1e66eb41d9

--- a/elements/plugins/buildstream-plugins.bst
+++ b/elements/plugins/buildstream-plugins.bst
@@ -2,5 +2,5 @@ kind: junction
 
 sources:
 - kind: tar
-  url: pypi:53/05/602efa27ee4cc04b489af78d401f7ce9ba96185677e8573b2eb71e2ec211/buildstream-plugins-2.5.0.tar.gz
+  url: pypi:source/b/buildstream-plugins/buildstream-plugins-2.5.0.tar.gz
   ref: 49c57dec88c0b4558f474520c2e29c69ecd42a1e5c07423baae5b29b153e54a6


### PR DESCRIPTION
Closes #603

firstboot-services.bst was created in commit 2c481c4 but the deps.bst wiring was silently dropped when the original fix batch was squashed.

This means the flatpak-preinstall.service fix from PR #588 never actually reaches the image, and ublue-boot-timeout.service is also missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new service component for system initialization and first-boot setup.
  * Updated build system plugin dependencies to their latest versions for improved compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->