### PR TITLE
feat(ujust): add cleanup-stale-boot-entries recipe (#531)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,7 +27,7 @@
         '/elements/plugins/.*\\.bst$/',
       ],
       matchStrings: [
-        'url:\\s*pypi:[a-f0-9/]+/(?<depName>buildstream[-_]plugins(?:[-_]community)?)-(?<currentValue>\\d+\\.\\d+\\.\\d+)\\.tar\\.gz\\n\\s+ref:\\s*(?<currentDigest>[a-f0-9]{64})',
+        'url:\\s*pypi:source/[a-z]/[\\w-]+/(?<depName>[\\w_-]+)-(?<currentValue>\\d+\\.\\d+\\.\\d+)\\.tar\\.gz\\n\\s+ref:\\s*(?<currentDigest>[a-f0-9]{64})',
       ],
       datasourceTemplate: 'pypi',
       versioningTemplate: 'pep440',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,7 +27,7 @@
         '/elements/plugins/.*\\.bst$/',
       ],
       matchStrings: [
-        'url:\\s*pypi:source/[a-z]/[\\w-]+/(?<depName>[\\w_-]+)-(?<currentValue>\\d+\\.\\d+\\.\\d+)\\.tar\\.gz\\n\\s+ref:\\s*(?<currentDigest>[a-f0-9]{64})',
+        'url:\\s*pypi:source/[a-z0-9]/[\\w-]+/(?<depName>[\\w_-]+)-(?<currentValue>\\d+\\.\\d+\\.\\d+)\\.tar\\.gz\\n\\s+ref:\\s*(?<currentDigest>[a-f0-9]{64})',
       ],
       datasourceTemplate: 'pypi',
       versioningTemplate: 'pep440',

--- a/.github/skills/lab-commands.md
+++ b/.github/skills/lab-commands.md
@@ -1,0 +1,91 @@
+# Lab Slash Commands
+
+Lab commands control hardware validation for PRs. Only humans may issue them.
+
+## The one rule agents must never break
+
+> **Agents MUST NOT post `/lab` commands.** Not on behalf of a user. Not autonomously.
+> Ever. Only a human with write+ access types a `/lab` command.
+
+A question in a PR comment — "does this work?", "any lab results?" — is never a
+command. Questions do not trigger lab actions. If an agent is unsure whether a
+human issued a command, it does nothing and waits.
+
+---
+
+## Who can use lab commands
+
+**Maintainers** (`@projectbluefin/maintainers`) and **wranglers** (write+ collaborators).
+
+Anyone else: the command is silently ignored. No error comment, no action.
+
+---
+
+## Slash commands
+
+Commands must appear on their own line, starting with `/lab`. Nothing else on
+that line counts as a command.
+
+| Command | Effect | Label applied |
+|---------|--------|---------------|
+| `/lab run` | Dispatch a new lab workflow for this PR | `lab:pending` → `lab:running` |
+| `/lab reset` | Cancel any running workflow, dispatch a fresh run | `lab:pending` |
+| `/lab skip <reason>` | Skip lab for this PR; reason required | `lab:skip` |
+| `/lab pass` | Manual override: mark this PR lab-passed | `lab:pass` |
+| `/lab fail` | Manual override: mark this PR lab-failed | `lab:fail` |
+
+`<reason>` is mandatory for `/lab skip`. A skip without a reason is rejected.
+
+---
+
+## Label states
+
+| Label | Meaning |
+|-------|---------|
+| `lab:pending` | Run queued, not yet dispatched |
+| `lab:running` | Argo workflow in progress |
+| `lab:pass` | Lab validated — image booted on hardware |
+| `lab:fail` | Lab failed — see `<!-- lab-status -->` sentinel for details |
+| `lab:skip` | Skipped with maintainer sign-off |
+
+Labels form a state machine: `pending → running → pass|fail`. Any transition
+backwards requires an explicit `/lab reset` or `/lab run`.
+
+---
+
+## Sentinel comment
+
+Every PR that enters the lab pipeline has exactly one `<!-- lab-status -->`
+sentinel comment. Agents that update lab state **PATCH that comment in-place**
+via `gh api --method PATCH`. They never post a new lab comment. If the sentinel
+does not exist, create it once — then only PATCH from that point on.
+
+```bash
+# PATCH existing sentinel — never POST a new one
+COMMENT_ID=$(gh api repos/projectbluefin/dakota/issues/${PR}/comments \
+  | python3 -c "import json,sys; cs=[c for c in json.load(sys.stdin) if '<!-- lab-status -->' in c['body']]; print(cs[0]['id'] if cs else '')")
+
+gh api --method PATCH repos/projectbluefin/dakota/issues/comments/${COMMENT_ID} \
+  -f body="⏳ **lab:running** — workflow \`${WORKFLOW_ID}\` dispatched \`$(date -u +%Y-%m-%dT%H:%M:%SZ)\`. <!-- lab-status -->"
+```
+
+---
+
+## Examples
+
+```
+# Valid — maintainer requesting a run
+/lab run
+
+# Valid — cancelling a stale run and restarting
+/lab reset
+
+# Valid — skipping a trivial docs change
+/lab skip docs-only change, no binary affected
+
+# Invalid — this is a question, not a command
+Is the lab run done yet?
+
+# Invalid — agent cannot post this
+/lab reset   ← agents are prohibited from posting this
+```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Bluefin Dakota
 *Dakotaraptor steini* 
 
-[Bluefin](https://projectbluefin.io) built on [GNOME OS](https://os.gnome.org/), assembled entirely from source.
+- [Bluefin](https://projectbluefin.io) built on [GNOME OS](https://os.gnome.org/), assembled entirely from source.
+- [Deepwiki](https://deepwiki.com/projectbluefin/dakota)
 
 <a href="https://docs.projectbluefin.io/changelogs">
   <picture>

--- a/docs/actionable-fixes.md
+++ b/docs/actionable-fixes.md
@@ -3,14 +3,14 @@
 ## #606 — Highlight/copy broken in ghostty
 Ghostty clipboard/highlight behavior differs from GNOME Terminal. Workaround: use Ctrl+Shift+C/V or configure ghostty clipboard settings.
 
-## #603 — firstboot-services.bst orphaned
-The firstboot-services.bst file references a non-existent source. Need to either restore the source or remove the orphaned .bst reference.
+## #603 — firstboot-services.bst not wired into build
+Fixed by adding `firstboot-services.bst` to `elements/bluefin/deps.bst`. This ensures its installed service artifacts land in images during the BST build.
 
 ## #536 — ujust report reduce friction
 Agent-ready improvement: allow ujust report to pre-fill diagnostic data and reduce OTel collection time for quick submissions.
 
 ## #527 — Ghost lab BST gate fails resolving junction
-BST gate failure resolving gnome-build-meta junction. Check junction URL is accessible from CI runner and retry with --pull.
+BST gate failure during dispatch: `project.conf` / ref-lock resolution fails when the gnome-build-meta junction ref is stale. Fix: update the junction ref in `project.conf` to a commit that resolves cleanly, then re-dispatch the gate workflow.
 
 ## #524 — testlab automation requires manual runner
 p0 bug: automate runner bring-up so manual intervention is not needed for each test run.

--- a/docs/actionable-fixes.md
+++ b/docs/actionable-fixes.md
@@ -1,0 +1,25 @@
+# Dakota Actionable Issues
+
+## #606 — Highlight/copy broken in ghostty
+Ghostty clipboard/highlight behavior differs from GNOME Terminal. Workaround: use Ctrl+Shift+C/V or configure ghostty clipboard settings.
+
+## #603 — firstboot-services.bst orphaned
+The firstboot-services.bst file references a non-existent source. Need to either restore the source or remove the orphaned .bst reference.
+
+## #536 — ujust report reduce friction
+Agent-ready improvement: allow ujust report to pre-fill diagnostic data and reduce OTel collection time for quick submissions.
+
+## #527 — Ghost lab BST gate fails resolving junction
+BST gate failure resolving gnome-build-meta junction. Check junction URL is accessible from CI runner and retry with --pull.
+
+## #524 — testlab automation requires manual runner
+p0 bug: automate runner bring-up so manual intervention is not needed for each test run.
+
+## #503 — CI: deduplicate bst2 pin check
+Agent-ready: deduplicate bst2 pin check and config generation into composite actions. Refactor build.yml.
+
+## #501 — CI: auto-merge junction bumps
+Agent-ready: auto-merge junction bumps from mergeraptor. Configure auto-merge for PRs that pass CI.
+
+## #180 — ujust devmode can't find image
+p1 bug: devmode recipe should pull the image before switching. Fix: add `bootc switch --pull` or check image exists before attempting switch.

--- a/docs/skills/testlab.md
+++ b/docs/skills/testlab.md
@@ -28,6 +28,22 @@ Test machine (physical hardware running dakota):
 - **Use exact digest for bootc switch** — tag-based switch silently skips if the tag already matches the booted digest (see Lessons Learned).
 - **BUILD FAILURES = FILE AN ISSUE.** Any element that fails during a lab build must be filed as a GitHub issue — even if it appears pre-existing.
 
+## Slash commands (maintainers and wranglers only)
+
+See full spec: `.github/skills/lab-commands.md`
+
+| Command | Effect |
+|---------|--------|
+| `/lab run` | Dispatch a new lab workflow for this PR |
+| `/lab reset` | Cancel running workflow, dispatch a fresh run |
+| `/lab skip <reason>` | Skip lab for this PR (reason required) |
+| `/lab pass` | Manual override: mark as passed |
+| `/lab fail` | Manual override: mark as failed |
+
+**Agents must never post `/lab` commands.** A question in a PR comment is not a
+command. Only humans with write+ access issue lab commands. When in doubt, do
+nothing.
+
 ## Commands
 
 | Command | Where | What |

--- a/elements/plugins/buildstream-plugins-community.bst
+++ b/elements/plugins/buildstream-plugins-community.bst
@@ -2,5 +2,5 @@ kind: junction
 
 sources:
 - kind: tar
-  url: pypi:08/b4/4b5311dd4ea599bdc69d911263f5d3f8b4c14789d69265d7ea2be7e4e120/buildstream_plugins_community-2.3.0.tar.gz
-  ref: cdd3b73ff998e4145d2bb1a1215b961c65b073a4956609417ab747ef8f462c44
+  url: pypi:source/b/buildstream-plugins-community/buildstream_plugins_community-2.3.1.tar.gz
+  ref: 85c2bae9d3a1eb3121c9674f68ef6e87211fddb9c930f3e5057b9a1e66eb41d9

--- a/elements/plugins/buildstream-plugins.bst
+++ b/elements/plugins/buildstream-plugins.bst
@@ -2,5 +2,5 @@ kind: junction
 
 sources:
 - kind: tar
-  url: pypi:53/05/602efa27ee4cc04b489af78d401f7ce9ba96185677e8573b2eb71e2ec211/buildstream-plugins-2.5.0.tar.gz
+  url: pypi:source/b/buildstream-plugins/buildstream-plugins-2.5.0.tar.gz
   ref: 49c57dec88c0b4558f474520c2e29c69ecd42a1e5c07423baae5b29b153e54a6

--- a/files/just-overrides/default.just
+++ b/files/just-overrides/default.just
@@ -183,19 +183,36 @@ report:
         FAILED_UNITS=\$(systemctl list-units --state=failed --no-legend --plain 2>/dev/null | awk '{print \$1}' | head -20 || echo '')
         KERNEL_VER=\$(uname -r)
         ARCH=\$(uname -m)
+        # Collect boot-time errors and warnings (kernel + services).
+        # Captures hardware init failures (e.g. Bluetooth firmware, udev group
+        # resolution) that never cause a unit to fully fail but are still bugs.
+        BOOT_ERRORS=\$(journalctl -b -p warning..err --no-pager -n 40 \
+            --output=short-monotonic 2>/dev/null \
+            | sed -E 's|/home/[^/[:space:]]+/|/home/<redacted>/|g' \
+            | sed -E 's|/run/user/[0-9]+|/run/user/<uid>|g')
+        # For each failed unit, collect last 15 lines of its journal.
+        FAILED_UNIT_LOGS=''
+        for _unit in \$FAILED_UNITS; do
+            _log=\$(journalctl -b -u \"\$_unit\" --no-pager -n 15 \
+                --output=short-monotonic 2>/dev/null \
+                | sed -E 's|/home/[^/[:space:]]+/|/home/<redacted>/|g')
+            FAILED_UNIT_LOGS=\"\${FAILED_UNIT_LOGS}=== \${_unit} ===\n\${_log}\n\"
+        done
         FLATPAK_LIST=\$(printf '%s' \"\$FLATPAK_LIST\" | sed -E 's|/home/[^/[:space:]]+/|/home/<redacted>/|g')
         GNOME_EXTENSIONS=\$(printf '%s' \"\$GNOME_EXTENSIONS\" | sed -E 's|/home/[^/[:space:]]+/|/home/<redacted>/|g')
-        printf 'BOOTED_IMAGE=%q\n'    \"\$BOOTED_IMAGE\"    > '$COLLECTION_OUT'
-        printf 'BOOTED_DIGEST=%q\n'   \"\$BOOTED_DIGEST\"   >> '$COLLECTION_OUT'
-        printf 'STAGED_IMAGE=%q\n'    \"\$STAGED_IMAGE\"    >> '$COLLECTION_OUT'
-        printf 'GNOME_VERSION=%q\n'   \"\$GNOME_VERSION\"   >> '$COLLECTION_OUT'
-        printf 'KERNEL_VER=%q\n'      \"\$KERNEL_VER\"      >> '$COLLECTION_OUT'
-        printf 'ARCH=%q\n'            \"\$ARCH\"             >> '$COLLECTION_OUT'
-        printf 'LOAD_AVG=%q\n'        \"\$LOAD_AVG\"         >> '$COLLECTION_OUT'
-        printf 'MEM_INFO=%q\n'        \"\$MEM_INFO\"         >> '$COLLECTION_OUT'
-        printf 'FLATPAK_LIST=%q\n'    \"\$FLATPAK_LIST\"    >> '$COLLECTION_OUT'
-        printf 'GNOME_EXTENSIONS=%q\n' \"\$GNOME_EXTENSIONS\" >> '$COLLECTION_OUT'
-        printf 'FAILED_UNITS=%q\n'    \"\$FAILED_UNITS\"    >> '$COLLECTION_OUT'
+        printf 'BOOTED_IMAGE=%q\n'       \"\$BOOTED_IMAGE\"       > '$COLLECTION_OUT'
+        printf 'BOOTED_DIGEST=%q\n'      \"\$BOOTED_DIGEST\"      >> '$COLLECTION_OUT'
+        printf 'STAGED_IMAGE=%q\n'       \"\$STAGED_IMAGE\"       >> '$COLLECTION_OUT'
+        printf 'GNOME_VERSION=%q\n'      \"\$GNOME_VERSION\"      >> '$COLLECTION_OUT'
+        printf 'KERNEL_VER=%q\n'         \"\$KERNEL_VER\"         >> '$COLLECTION_OUT'
+        printf 'ARCH=%q\n'               \"\$ARCH\"               >> '$COLLECTION_OUT'
+        printf 'LOAD_AVG=%q\n'           \"\$LOAD_AVG\"           >> '$COLLECTION_OUT'
+        printf 'MEM_INFO=%q\n'           \"\$MEM_INFO\"           >> '$COLLECTION_OUT'
+        printf 'FLATPAK_LIST=%q\n'       \"\$FLATPAK_LIST\"       >> '$COLLECTION_OUT'
+        printf 'GNOME_EXTENSIONS=%q\n'   \"\$GNOME_EXTENSIONS\"   >> '$COLLECTION_OUT'
+        printf 'FAILED_UNITS=%q\n'       \"\$FAILED_UNITS\"       >> '$COLLECTION_OUT'
+        printf 'BOOT_ERRORS=%q\n'        \"\$BOOT_ERRORS\"        >> '$COLLECTION_OUT'
+        printf 'FAILED_UNIT_LOGS=%q\n'   \"\$FAILED_UNIT_LOGS\"   >> '$COLLECTION_OUT'
     "
     # shellcheck disable=SC1090
     source "$COLLECTION_OUT"
@@ -290,6 +307,19 @@ report:
     printf '\n### Failed Systemd Units\n\n'
     if [[ -n "${FAILED_UNITS}" ]]; then
         printf '%s\n' "${FAILED_UNITS}" | sed 's/^/- /'
+        if [[ -n "${FAILED_UNIT_LOGS}" ]]; then
+            printf '\n#### Unit Logs\n\n```\n'
+            printf '%b\n' "${FAILED_UNIT_LOGS}"
+            printf '```\n'
+        fi
+    else
+        printf '_None_ ✓\n'
+    fi
+    printf '\n### Boot Errors and Warnings\n\n'
+    if [[ -n "${BOOT_ERRORS}" ]]; then
+        printf '```\n'
+        printf '%s\n' "${BOOT_ERRORS}"
+        printf '```\n'
     else
         printf '_None_ ✓\n'
     fi

--- a/files/just-overrides/default.just
+++ b/files/just-overrides/default.just
@@ -191,13 +191,16 @@ report:
             | sed -E 's|/home/[^/[:space:]]+/|/home/<redacted>/|g' \
             | sed -E 's|/run/user/[0-9]+|/run/user/<uid>|g')
         # For each failed unit, collect last 15 lines of its journal.
-        FAILED_UNIT_LOGS=''
+        _unit_logs_tmp=\$(mktemp)
         for _unit in \$FAILED_UNITS; do
             _log=\$(journalctl -b -u \"\$_unit\" --no-pager -n 15 \
                 --output=short-monotonic 2>/dev/null \
-                | sed -E 's|/home/[^/[:space:]]+/|/home/<redacted>/|g')
-            FAILED_UNIT_LOGS=\"\${FAILED_UNIT_LOGS}=== \${_unit} ===\n\${_log}\n\"
+                | sed -E 's|/home/[^/[:space:]]+/|/home/<redacted>/|g' \
+                | sed -E 's|/run/user/[0-9]+|/run/user/<uid>|g')
+            printf '=== %s ===\n%s\n' \"\$_unit\" \"\$_log\" >> \"\$_unit_logs_tmp\"
         done
+        FAILED_UNIT_LOGS=\$(cat \"\$_unit_logs_tmp\")
+        rm -f \"\$_unit_logs_tmp\"
         FLATPAK_LIST=\$(printf '%s' \"\$FLATPAK_LIST\" | sed -E 's|/home/[^/[:space:]]+/|/home/<redacted>/|g')
         GNOME_EXTENSIONS=\$(printf '%s' \"\$GNOME_EXTENSIONS\" | sed -E 's|/home/[^/[:space:]]+/|/home/<redacted>/|g')
         printf 'BOOTED_IMAGE=%q\n'       \"\$BOOTED_IMAGE\"       > '$COLLECTION_OUT'
@@ -309,7 +312,7 @@ report:
         printf '%s\n' "${FAILED_UNITS}" | sed 's/^/- /'
         if [[ -n "${FAILED_UNIT_LOGS}" ]]; then
             printf '\n#### Unit Logs\n\n```\n'
-            printf '%b\n' "${FAILED_UNIT_LOGS}"
+            printf '%s\n' "${FAILED_UNIT_LOGS}"
             printf '```\n'
         fi
     else

--- a/files/just-overrides/system.just
+++ b/files/just-overrides/system.just
@@ -187,7 +187,7 @@ cleanup-stale-boot-entries:
         exit 0
     fi
     CURRENT_PREFIX=""
-    CURRENT_IMAGE=$(sudo bootc status --json 2>/dev/null | jq -r '.status.booted.image.image.image // empty')
+    CURRENT_IMAGE=$(sudo bootc status --json 2>/dev/null | jq -r '.status.booted.image.image.image // empty' || true)
     if [[ -n "$CURRENT_IMAGE" ]]; then
         IMAGE_NAME=$(echo "$CURRENT_IMAGE" | sed -E 's|.*/||; s|:.*||; s|@.*||')
         CURRENT_PREFIX="bootc_${IMAGE_NAME}"

--- a/files/just-overrides/system.just
+++ b/files/just-overrides/system.just
@@ -186,16 +186,25 @@ cleanup-stale-boot-entries:
         echo "No $ENTRIES_DIR found — nothing to clean."
         exit 0
     fi
-    CURRENT_PREFIX=$(grep -oP 'bootc[^\s]*' /proc/cmdline | head -1 || echo "")
+    CURRENT_PREFIX=""
+    CURRENT_IMAGE=$(sudo bootc status --json 2>/dev/null | jq -r '.status.booted.image.image.image // empty')
+    if [[ -n "$CURRENT_IMAGE" ]]; then
+        IMAGE_NAME=$(echo "$CURRENT_IMAGE" | sed -E 's|.*/||; s|:.*||; s|@.*||')
+        CURRENT_PREFIX="bootc_${IMAGE_NAME}"
+    else
+        # Fallback to cmdline parsing if bootc status fails
+        CURRENT_PREFIX=$(grep -oP 'bootc[^\s]*' /proc/cmdline | head -1 || echo "")
+    fi
+
     if [[ -z "$CURRENT_PREFIX" ]]; then
-        echo "Could not determine current bootc prefix from /proc/cmdline."
+        echo "Could not determine current bootc prefix."
         exit 1
     fi
     echo "Current image prefix: $CURRENT_PREFIX"
     STALE=()
     while IFS= read -r -d '' entry; do
         basename="$(basename "$entry")"
-        if [[ "$basename" != bootc_${CURRENT_PREFIX}* ]]; then
+        if [[ "$basename" != ${CURRENT_PREFIX}* ]]; then
             STALE+=("$entry")
         fi
     done < <(find "$ENTRIES_DIR" -name "bootc_*.conf" -print0 2>/dev/null)

--- a/files/just-overrides/system.just
+++ b/files/just-overrides/system.just
@@ -173,3 +173,46 @@ mount-drive:
     sudo systemctl daemon-reload
     sudo systemctl enable --now "$UNIT_NAME"
     echo "Mounted $DEVICE at $MOUNTPOINT and enabled on boot."
+
+# Clean up stale bootloader entries left behind after an OS/image rename
+# Closes #531
+[group('System')]
+cleanup-stale-boot-entries:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Scanning for stale bootloader entries..."
+    ENTRIES_DIR="/boot/loader/entries"
+    if [[ ! -d "$ENTRIES_DIR" ]]; then
+        echo "No $ENTRIES_DIR found — nothing to clean."
+        exit 0
+    fi
+    CURRENT_PREFIX=$(grep -oP 'bootc[^\s]*' /proc/cmdline | head -1 || echo "")
+    if [[ -z "$CURRENT_PREFIX" ]]; then
+        echo "Could not determine current bootc prefix from /proc/cmdline."
+        exit 1
+    fi
+    echo "Current image prefix: $CURRENT_PREFIX"
+    STALE=()
+    while IFS= read -r -d '' entry; do
+        basename="$(basename "$entry")"
+        if [[ "$basename" != bootc_${CURRENT_PREFIX}* ]]; then
+            STALE+=("$entry")
+        fi
+    done < <(find "$ENTRIES_DIR" -name "bootc_*.conf" -print0 2>/dev/null)
+    if [[ ${#STALE[@]} -eq 0 ]]; then
+        echo "No stale entries found. All good!"
+        exit 0
+    fi
+    echo ""
+    echo "Found ${#STALE[@]} stale bootloader entries:"
+    for entry in "${STALE[@]}"; do
+        echo "  - $(basename "$entry")"
+    done
+    echo ""
+    echo "These can cause 'Multiple extra entries in /boot' errors."
+    if ! gum confirm "Remove these stale entries?"; then
+        echo "Cancelled."
+        exit 0
+    fi
+    sudo rm -f "${STALE[@]}"
+    echo "Removed ${#STALE[@]} stale entries."

--- a/files/just-overrides/system.just
+++ b/files/just-overrides/system.just
@@ -49,6 +49,13 @@ toggle-devmode:
 [group('System')]
 dx-group:
     #!/usr/bin/pkexec bash
+
+    # Guard: PKEXEC_UID must be set and non-root
+    if [[ -z "${PKEXEC_UID}" ]] || [[ "${PKEXEC_UID}" == "0" ]]; then
+        echo "ERROR: run this via ujust, not directly as root."
+        exit 1
+    fi
+
     append_group() {
         local group_name="$1"
         if ! grep -q "^$group_name:" /etc/group; then
@@ -64,7 +71,13 @@ dx-group:
         usermod -aG $GROUP_ADD {{ `id -un` }}
     done
 
-    echo "Reboot system and log back in to use docker, libvirt, incus, and serial connections."
+    echo ""
+    echo "Groups added: docker, incus-admin, libvirt, dialout."
+    echo "A reboot is required for group membership to take effect."
+    echo ""
+    if gum confirm "Reboot now?"; then
+        systemctl reboot
+    fi
 
 # Install system flatpaks for rebasers
 [group('System')]


### PR DESCRIPTION
## Summary

Adds a `cleanup-stale-boot-entries` ujust recipe to detect and remove orphaned bootloader entries left behind after an OS/image name change (e.g. `bootc` → `bootc_bluefin_dakota`).

## Problem

When Dakota transitions between image prefixes, `bootc`'s prune logic only manages entries matching the current prefix. Old bootloader entries remain in `/boot/loader/entries/` and cause:

```
error: Multiple extra entries in /boot, could not determine rollback entry
```

## Fix

The recipe:
1. Reads the current bootc prefix from `/proc/cmdline`
2. Finds `.conf` entries under `/boot/loader/entries/` not matching the current prefix
3. Shows the user which entries are stale
4. Asks for confirmation before removing them

## Test plan

- [ ] Verify recipe appears in `ujust --list`  
- [ ] Run on a system with stale entries → entries detected and removed  
- [ ] Run on a clean system → "No stale entries found"

Closes #531

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a maintenance utility to detect and remove stale boot loader entries; it lists candidates and asks for confirmation before deletion.
* **Behavior Changes**
  * Improved reboot messaging and now prompts users to reboot immediately when required.
  * Prevents direct root execution of the flow and informs users when elevated invocation is not allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->