### PR TITLE
feat: add bluefin-countme weekly user count ping

### DIFF
--- a/elements/bluefin/countme.bst
+++ b/elements/bluefin/countme.bst
@@ -1,0 +1,18 @@
+kind: manual
+
+sources:
+- kind: local
+  path: files/countme
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - install -Dm644 bluefin-countme.service "%{install-root}/usr/lib/systemd/system/bluefin-countme.service"
+  - install -Dm644 bluefin-countme.timer "%{install-root}/usr/lib/systemd/system/bluefin-countme.timer"
+  - mkdir -p "%{install-root}/usr/lib/systemd/system/timers.target.wants/"
+  - ln -sf ../bluefin-countme.timer "%{install-root}/usr/lib/systemd/system/timers.target.wants/bluefin-countme.timer"

--- a/elements/bluefin/countme.bst
+++ b/elements/bluefin/countme.bst
@@ -12,7 +12,6 @@ variables:
 
 config:
   install-commands:
-  - install -Dm644 bluefin-countme.service "%{install-root}/usr/lib/systemd/system/bluefin-countme.service"
-  - install -Dm644 bluefin-countme.timer "%{install-root}/usr/lib/systemd/system/bluefin-countme.timer"
+  - install -Dm644 bluefin-countme.{service,timer} -t "%{install-root}/usr/lib/systemd/system/"
   - mkdir -p "%{install-root}/usr/lib/systemd/system/timers.target.wants/"
   - ln -sf ../bluefin-countme.timer "%{install-root}/usr/lib/systemd/system/timers.target.wants/bluefin-countme.timer"

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -39,6 +39,7 @@ depends:
   - bluefin/xdg-terminal-exec.bst
   - bluefin/nautilus-python.bst
   - bluefin/network.bst
+  - bluefin/countme.bst
 
   # Include things missing from the gnomeos base image
   - gnome-build-meta.bst:core-deps/fwupd.bst

--- a/files/countme/bluefin-countme.service
+++ b/files/countme/bluefin-countme.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Report Bluefin active user count
+Documentation=https://countme.projectbluefin.io
+After=network-online.target
+Wants=network-online.target
+ConditionPathExists=!/etc/bluefin-countme-opt-out
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/os-release
+ExecStart=/usr/bin/bash -c '/usr/bin/curl -sf \
+  "https://countme.projectbluefin.io/count?os=${ID}&version=${VERSION_ID}&arch=$(uname -m)&countme=1" \
+  -o /dev/null'

--- a/files/countme/bluefin-countme.service
+++ b/files/countme/bluefin-countme.service
@@ -8,6 +8,6 @@ ConditionPathExists=!/etc/bluefin-countme-opt-out
 [Service]
 Type=oneshot
 EnvironmentFile=/etc/os-release
-ExecStart=/usr/bin/bash -c '/usr/bin/curl -sf \
+ExecStart=/usr/bin/bash -c '/usr/bin/curl -sf --max-time 10 \
   "https://countme.projectbluefin.io/count?os=${ID}&version=${VERSION_ID}&arch=$(uname -m)&countme=1" \
   -o /dev/null'

--- a/files/countme/bluefin-countme.timer
+++ b/files/countme/bluefin-countme.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Weekly Bluefin user count ping
+Documentation=https://countme.projectbluefin.io
+
+[Timer]
+OnCalendar=weekly
+RandomizedDelaySec=86400
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Add a systemd timer + oneshot service that sends a weekly privacy-preserving ping to `countme.projectbluefin.io`.

Dakota has no rpm-ostree so cannot reuse the `rpm-ostree-countme` mechanism. This is a standalone BST element using `/usr/bin/curl` (guaranteed present via the `systemd → curl` runtime dependency chain in freedesktop-sdk).

### Files added
- `elements/bluefin/countme.bst` — local element, installs two unit files
- `files/countme/bluefin-countme.service` — oneshot, reads `/etc/os-release`
- `files/countme/bluefin-countme.timer` — weekly, 24h random jitter, persistent

### What gets sent (once per week)
```
GET https://countme.projectbluefin.io/count?os=bluefin-dakota&version=0&arch=x86_64&countme=1
```

### Infrastructure
- Worker: https://countme.projectbluefin.io (Cloudflare Workers + D1, free tier at current scale)
- Source: https://github.com/castrojo/copilot-config/tree/main/countme-worker

### Opt-out
```bash
touch /etc/bluefin-countme-opt-out
```
The service has `ConditionPathExists=!/etc/bluefin-countme-opt-out`.

- [ ] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a weekly automated reporting service that sends basic system info (OS, version, architecture, and a count) to Bluefin.
  * Reporting runs on a scheduled timer with a randomized delay and persistent behavior to avoid duplicate misses.
  * Users can opt out by creating /etc/bluefin-countme-opt-out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Refs #dakota-616