### PR TITLE
fix(ci): grant packages:write so testsuite can push desktop screenshot

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,9 @@ on:
         required: false
         default: "smoke"
 
-permissions: read-all
+permissions:
+  contents: read
+  packages: write  # testsuite pushes desktop screenshot to GHCR
 
 concurrency:
   group: e2e-${{ github.ref }}


### PR DESCRIPTION
## Problem

Every e2e run since yesterday has been showing `startup_failure`. This is why the dep update PRs are all red.

Two separate bugs:

**1. `startup_failure` on all current runs** (this PR)

The `projectbluefin/testsuite` reusable workflow recently added a step that pushes a desktop screenshot as an OCI artifact to GHCR. That job declares `packages: write`. GitHub Actions raises `startup_failure` when a reusable workflow's job permissions exceed what the caller granted — and the caller here only had `permissions: read-all`, which grants read on everything but no write on packages.

**2. SSH wait race condition** (tracked in projectbluefin/testsuite#87)

Before the screenshot feature landed, runs were failing with `ERROR: SSH never became ready after 10 minutes`. The VM boots successfully but several unneeded services (`NetworkManager-wait-online`, `firewalld`, `wpa_supplicant`) collectively add ~2 min of latency, making the boot race the 10-minute SSH deadline. That fix is in the testsuite.

## Change

`permissions: read-all` → explicit permissions with `packages: write` added.

- [ ] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to follow the principle of least privilege, restricting access to only necessary resources for automated processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->