### PR TITLE
feat: add gnome-ponytail-daemon to image

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -39,6 +39,7 @@ depends:
   - bluefin/efibootmgr.bst
   - bluefin/xdg-terminal-exec.bst
   - bluefin/nautilus-python.bst
+  - bluefin/gnome-ponytail-daemon.bst
   - bluefin/network.bst
   - bluefin/countme.bst
 

--- a/elements/bluefin/gnome-ponytail-daemon.bst
+++ b/elements/bluefin/gnome-ponytail-daemon.bst
@@ -1,0 +1,22 @@
+kind: meson
+
+sources:
+- kind: git_repo
+  url: gnome_gitlab:ofourdan/gnome-ponytail-daemon.git
+  track: "master"
+  ref: 0.0.11-0-g72f222d912de8105208f6faa865b71480c189924
+
+variables:
+  conf-flags: >-
+    -Dsystemd_user_unit_dir=/usr/lib/systemd/user
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+- freedesktop-sdk.bst:components/python3.bst
+- freedesktop-sdk.bst:components/systemd-libs.bst
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+- freedesktop-sdk.bst:components/glib.bst
+- freedesktop-sdk.bst:components/libei.bst
+- freedesktop-sdk.bst:components/libxkbcommon.bst


### PR DESCRIPTION
## Summary

Adds `gnome-ponytail-daemon` (v0.0.11) to the Bluefin image.

### Why

`gnome-ponytail-daemon` is required by dogtail on GNOME 50 Wayland for window management and input event injection. Without it, the AT-SPI automation stack cannot obtain window IDs from the compositor, causing the e2e test `before_scenario` hook to fail immediately:

```
RuntimeError:
  1) Packages ['gnome-ponytail-daemon', 'python3-gnome-ponytail-daemon'] are not installed.
  2) If installed, the gnome-ponytail-daemon process might not be running.
```

This is the final blocker preventing the e2e smoke tests from running on dep-update PRs.

### What changed

- `elements/bluefin/gnome-ponytail-daemon.bst` — new meson element tracking v0.0.11
- `elements/bluefin/deps.bst` — wired into the image dep graph

### Details

- Source: https://gitlab.gnome.org/ofourdan/gnome-ponytail-daemon
- DBus activation via `org.gnome.Ponytail.service` (installed to `/usr/share/dbus-1/services/`)
- Systemd user service at `/usr/lib/systemd/user/gnome-ponytail-daemon.service`
- Python bindings (`ponytail` package) installed to site-packages
- Built with libei support for input emulation

### Checklist

- [ ] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new system daemon component with corresponding build and runtime dependencies configured for integration into the distribution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Refs #dakota-618