### PR TITLE
docs: clarify push-to-upstream rule — dep-update PRs are same-repo

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,15 +24,21 @@ just bst build oci/bluefin.bst
 
 ## ⚠️ Hard rules (learned from real mistakes)
 
-### 1. Always branch from upstream/main
+### 1. Work directly in projectbluefin/dakota — always push to `upstream`
 
 ```bash
 git checkout upstream/main -b feature/my-change
+git push upstream feature/my-change
 ```
 
-**Never branch from local `main`.** The `castrojo/dakota` fork diverges from `projectbluefin/dakota` by 20+ commits. Branching from local `main` creates PRs with hundreds of unrelated files.
+**Never push via the `castrojo` fork** for any PR or retrigger intended for `projectbluefin/dakota`. The fork diverges and PRs/CI runs against the fork have no effect on upstream.
 
-Verify before pushing:
+**Dep-update PRs** (`auto/track-*`) are same-repo branches in `projectbluefin/dakota`. Retrigger by pushing directly to `upstream`:
+```bash
+git push upstream local-branch:auto/track-foo
+```
+
+Verify your diff is clean before pushing:
 ```bash
 git diff upstream/main...HEAD --stat
 ```


### PR DESCRIPTION
Dep-update PRs (`auto/track-*`) are same-repo branches in `projectbluefin/dakota`, not fork PRs. Retrigger commits must be pushed to `upstream` remote directly, not via the castrojo fork.

Updates hard rule #1 in `.github/copilot-instructions.md` to make this explicit.

Learned from a real mistake in session 2026-05-30 where retrigger commits were pushed to castrojo/dakota and had no effect on CI.

- [x] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development guidelines and contribution procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota/pull/619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Refs #dakota-619