### PR TITLE
feat(justfile): close Justfile parity gaps #3 and #5 (issue #510)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -169,6 +169,33 @@ export variant="default":
     echo "==> Export complete. Image loaded as ${FINAL_NAME}:${FINAL_TAG}"
     $SUDO_CMD podman images | grep -E "{{image_name}}|REPOSITORY" || true
 
+# Push exported image to a local zot registry for lab testing.
+[group('dev')]
+push-local registry="localhost:5000":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    SUDO_CMD=""
+    if [ "$(id -u)" -ne 0 ]; then
+        SUDO_CMD="sudo"
+    fi
+
+    SOURCE_REF="{{image_name}}:{{image_tag}}"
+    TARGET_REF="{{registry}}/{{image_name}}:{{image_tag}}"
+
+    if ! $SUDO_CMD podman image exists "$SOURCE_REF"; then
+        echo "ERROR: Image '$SOURCE_REF' not found in podman." >&2
+        echo "Run 'just build' first." >&2
+        exit 1
+    fi
+
+    trap '$SUDO_CMD podman rmi "$TARGET_REF" >/dev/null 2>&1 || true' EXIT
+
+    echo "==> Tagging $SOURCE_REF as $TARGET_REF"
+    $SUDO_CMD podman tag "$SOURCE_REF" "$TARGET_REF"
+    echo "==> Pushing $TARGET_REF"
+    $SUDO_CMD podman push "$TARGET_REF"
+
 
 # ── Clean ─────────────────────────────────────────────────────────────
 # Remove generated artifacts (disk image, OVMF vars, build output).
@@ -523,6 +550,7 @@ show-me-the-future:
 # the overlay + xattr-apply step can be removed. chunkah can then be run
 # with LD_PRELOAD=fakecap.so FAKECAP_MANIFEST=.../fakecap-manifest.tsv.
 # See also: projectbluefin/dakota#231.
+[group('build')]
 chunkify image_ref:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/docs/skills/local-ota.md
+++ b/docs/skills/local-ota.md
@@ -53,7 +53,7 @@ just build
 just export
 
 # 3. Push to local registry
-sudo podman push localhost:5000/dakota:latest
+just push-local localhost:5000
 
 # 4. Boot a VM (choose one):
 just boot-fast     # ephemeral VM via virtiofs (requires virtiofsd)
@@ -101,8 +101,8 @@ sudo systemctl reboot
 Do not use `podman push` with `--compression-format=zstd:chunked` for bootc images. The zstd:chunked format is broken with bootc's composefs backend. Use plain `podman push`:
 
 ```bash
-# ✅ Correct
-sudo podman push localhost:5000/dakota:latest
+# ✅ Correct (just push-local uses plain podman push internally)
+just push-local localhost:5000
 
 # ❌ Wrong — breaks composefs
 sudo podman push --compression-format=zstd:chunked localhost:5000/dakota:latest

--- a/docs/skills/testlab.md
+++ b/docs/skills/testlab.md
@@ -14,7 +14,7 @@ Load when running the live dakota validation loop: build → publish → bootc u
 Build host (your machine):
   1. just build               # build OCI image
   2. just export              # export OCI image to podman
-  3. sudo podman push <build-host-ip>:5000/dakota:latest  # push to local zot
+  3. just push-local <build-host-ip>:5000               # push to local zot
 
 Test machine (physical hardware running dakota):
   4. sudo bootc upgrade       # pull from build host's registry
@@ -34,7 +34,7 @@ Test machine (physical hardware running dakota):
 |---------|-------|------|
 | `just build` | Build host | Build OCI image |
 | `just export` | Build host | Export OCI image to podman |
-| `sudo podman push <build-host-ip>:5000/dakota:latest` | Build host | Push image to local zot registry |
+| `just push-local <build-host-ip>:5000` | Build host | Push image to local zot registry |
 | `sudo bootc upgrade` | Test machine | Pull latest from registry |
 | `bootc status` | Test machine | Verify booted image ref |
 | `systemctl --failed` | Test machine | Check for failed units |


### PR DESCRIPTION
- Add push-local recipe for lab registry workflow Closes gap 3: contributors no longer need to hand-roll podman push. Usage: just push-local [registry]  (default: localhost:5000)

- Add [group('build')] annotation to chunkify recipe Closes gap 5: chunkify now appears correctly in just --list.

Gaps 1, 2, and 4 were already closed in prior commits. Closes #510

## What problem are you solving?
<!-- Write this in your own words. One paragraph. No AI. -->

- [ ] I am using an agent and I take responsibility for this PR

---

## Changes

<!-- Agent/tool-generated summary below this line is fine -->

## Testing

- [ ] `just validate` passes
- [ ] `just boot-test` passes (automated boot smoke test)
- [ ] `just lint` passes on a built image
- [ ] `just boot-fast` or `just boot-vm` — desktop comes up, no regressions

## Checklist

- [ ] New BST elements wired into `deps.bst`
- [ ] Patches in `patches/` regenerated if junction refs changed

## Community verification (bug-fix PRs)

If this PR fixes a bug, add verify-steps to the issue so the community can confirm
the fix works on their hardware after the next nightly ships:

````markdown
```verify
# Steps for users to verify this fix:
systemctl status <affected-service>
# or whatever the user should check
```
````

Users will run `ujust verify <issue-number>` which fetches these steps automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a push-local command to streamline publishing built OCI images to a local registry, with automatic tagging and cleanup

* **Documentation**
  * Updated local OTA workflow to use push-local
  * Updated hardware testlab setup and commands to use push-local instead of manual push commands
<!-- end of auto-generated comment: release notes by coderabbit.ai -->