### PR TITLE
chore(ci): pin testsuite reusable workflow refs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,7 +39,7 @@ concurrency:
 
 jobs:
   e2e:
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@969d471323a5aed586ba19371a4d2c74c4fa6823 # main
     with:
       image: ${{ github.event.inputs.image || 'ghcr.io/projectbluefin/dakota:latest' }}
       suites: ${{ github.event.inputs.suites || 'smoke' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -281,7 +281,7 @@ jobs:
       needs.publish.result == 'success' &&
       (needs.setup.outputs.event == 'schedule' ||
        needs.setup.outputs.event == 'workflow_dispatch')
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@main
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@969d471323a5aed586ba19371a4d2c74c4fa6823 # main
     with:
       image: ghcr.io/projectbluefin/dakota:${{ needs.setup.outputs.sha }}
       suites: smoke


### PR DESCRIPTION
## What

Replaces unpinned `@main` testsuite refs with the current pinned SHA in both CI workflows.

## Changes

- `e2e.yml`: `@main` → `@969d471`
- `publish.yml`: `@main` → `@969d471`

## Why

Using `@main` is a supply-chain risk: a breaking change to the testsuite can silently bypass the PR e2e gate or fail the `:latest` publish pipeline with no clear root cause.

Pinning ensures:
1. **Reproducibility** — the same testsuite code runs until a deliberate bump
2. **Renovate tracking** — Renovate's github-actions manager will now open PRs when testsuite advances, keeping the pin current automatically

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Assisted-by: Claude Sonnet 4.6 via GitHub Copilot CLI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated E2E testing workflow to use a pinned version of the upstream test suite, ensuring more consistent and stable test execution across PR validation and publishing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->