### PR TITLE
feat(ci): add testing/latest/stable stream layout

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,7 +74,7 @@ https://github.com/bootc-dev/bootc/issues/7
 - **Schedule:** nightly at 13:00 UTC (after gnome-build-meta nightly ~08:00 UTC finish)
 - **Publish triggers:** `merge_group`, `schedule`, `workflow_dispatch` (not `pull_request`)
 - **Remote cache:** `cache.projectbluefin.io:11002` (mTLS — `CASD_CLIENT_CERT` + `CASD_CLIENT_KEY`)
-- **Image:** `ghcr.io/projectbluefin/dakota:latest` and `:<sha>`
+- **Image:** `ghcr.io/projectbluefin/dakota:{testing,latest,stable}` and `:<sha>`
 
 ## Key architecture
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,9 +21,9 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: "OCI image to test (default: dakota:latest)"
+        description: "OCI image to test (default: dakota:testing)"
         required: false
-        default: "ghcr.io/projectbluefin/dakota:latest"
+        default: "ghcr.io/projectbluefin/dakota:testing"
       suites:
         description: "Comma-separated GUI suites: smoke,developer,dx,software,vanilla-gnome"
         required: false
@@ -41,5 +41,5 @@ jobs:
   e2e:
     uses: projectbluefin/testsuite/.github/workflows/e2e.yml@main
     with:
-      image: ${{ github.event.inputs.image || 'ghcr.io/projectbluefin/dakota:latest' }}
+      image: ${{ github.event.inputs.image || 'ghcr.io/projectbluefin/dakota:testing' }}
       suites: ${{ github.event.inputs.suites || 'smoke' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -272,9 +272,9 @@ jobs:
           push-to-registry: true
 
   # ── E2E gate ─────────────────────────────────────────────────────────────
-  # Smoke-tests the freshly pushed :$sha before promoting to :latest.
+  # Smoke-tests the freshly pushed :$sha before promoting to :testing.
   # Only runs on schedule and workflow_dispatch — merge_group does not
-  # produce :latest so there is nothing to gate.
+  # produce :testing so there is nothing to gate.
   e2e-gate:
     needs: [setup, publish]
     if: >-
@@ -287,10 +287,12 @@ jobs:
       suites: smoke
     secrets: inherit
 
-  # ── Promote :latest ───────────────────────────────────────────────────────
-  # Re-tags :$sha as :latest once e2e passes.
+  # ── Promote :testing ──────────────────────────────────────────────────────
+  # Re-tags :$sha as :testing once e2e passes.
+  # Weekly promotion (weekly-testing-promotion.yml) later promotes :testing
+  # to :latest and :stable via digest-pinned re-tagging.
   # NVIDIA is continue-on-error so a failing NVIDIA promote does not
-  # prevent the default :latest from landing.
+  # prevent the default :testing from landing.
   promote:
     needs: [setup, publish, e2e-gate]
     if: needs.e2e-gate.result == 'success'
@@ -305,6 +307,7 @@ jobs:
             continue: true
     continue-on-error: ${{ matrix.continue }}
     permissions:
+      contents: write
       packages: write
     steps:
       - name: Login to GHCR
@@ -314,17 +317,34 @@ jobs:
         run: |
           echo "$GH_TOKEN" | sudo podman login ghcr.io --username "$GH_ACTOR" --password-stdin
 
-      - name: Promote :${{ needs.setup.outputs.sha }} to :latest
+      - name: Promote :${{ needs.setup.outputs.sha }} to :testing
         env:
           BUILD_SHA: ${{ needs.setup.outputs.sha }}
         run: |
           IMAGE="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}"
           sudo podman pull "${IMAGE}:${BUILD_SHA}"
-          sudo podman tag "${IMAGE}:${BUILD_SHA}" "${IMAGE}:latest"
+          sudo podman tag "${IMAGE}:${BUILD_SHA}" "${IMAGE}:testing"
           PUSH_OK=false
           for attempt in 1 2 3; do
-            sudo podman push --compression-format=zstd "${IMAGE}:latest" && { PUSH_OK=true; break; }
-            echo "Push attempt ${attempt} failed for :latest, retrying in 5s..."
+            sudo podman push --compression-format=zstd "${IMAGE}:testing" && { PUSH_OK=true; break; }
+            echo "Push attempt ${attempt} failed for :testing, retrying in 5s..."
             [ "$attempt" -lt 3 ] && sleep 5
           done
-          $PUSH_OK || { echo "ERROR: all push attempts failed for :latest"; exit 1; }
+          $PUSH_OK || { echo "ERROR: all push attempts failed for :testing"; exit 1; }
+
+      - name: Fast-forward testing branch
+        if: matrix.image_suffix == ''
+        env:
+          BUILD_SHA: ${{ needs.setup.outputs.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Fast-forward the testing branch to the promoted SHA.
+          # Creates the branch if it doesn't exist yet (first run after setup).
+          gh api repos/${{ github.repository }}/git/refs/heads/testing \
+            --method PATCH \
+            --field sha="$BUILD_SHA" \
+            --field force=false 2>/dev/null || \
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            --field ref="refs/heads/testing" \
+            --field sha="$BUILD_SHA"

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -1,0 +1,214 @@
+name: Weekly Testing Promotion
+
+on:
+  schedule:
+    - cron: '0 6 * * 2' # Tuesday 06:00 UTC (same as bluefin)
+  workflow_dispatch:
+
+concurrency:
+  group: weekly-testing-promotion
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  # ── Resolve current :testing digests ─────────────────────────────────────
+  # Pins the exact digests and verifies both variants share the same source SHA.
+  resolve:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    outputs:
+      source_sha: ${{ steps.verify.outputs.source_sha }}
+      default_digest: ${{ steps.resolve-default.outputs.digest }}
+      nvidia_digest: ${{ steps.resolve-nvidia.outputs.digest }}
+      has_nvidia: ${{ steps.resolve-nvidia.outputs.found }}
+    steps:
+      - name: Login to GHCR (read-only)
+        env:
+          GH_ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "$GH_TOKEN" | sudo podman login ghcr.io --username "$GH_ACTOR" --password-stdin
+
+      - name: Resolve default :testing digest
+        id: resolve-default
+        run: |
+          set -euo pipefail
+          IMAGE="ghcr.io/${{ github.repository_owner }}/dakota:testing"
+          sudo podman pull "$IMAGE"
+          DIGEST=$(sudo podman inspect "$IMAGE" --format '{{.Digest}}')
+          SHA=$(sudo podman inspect "$IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Default :testing → digest=$DIGEST, source_sha=$SHA"
+
+      - name: Resolve NVIDIA :testing digest
+        id: resolve-nvidia
+        run: |
+          set -euo pipefail
+          IMAGE="ghcr.io/${{ github.repository_owner }}/dakota-nvidia:testing"
+          if sudo podman pull "$IMAGE" 2>/dev/null; then
+            DIGEST=$(sudo podman inspect "$IMAGE" --format '{{.Digest}}')
+            SHA=$(sudo podman inspect "$IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')
+            echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+            echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "NVIDIA :testing → digest=$DIGEST, source_sha=$SHA"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "NVIDIA :testing not found — skipping NVIDIA promotion"
+          fi
+
+      - name: Verify variants share same source SHA
+        id: verify
+        env:
+          DEFAULT_SHA: ${{ steps.resolve-default.outputs.sha }}
+          NVIDIA_SHA: ${{ steps.resolve-nvidia.outputs.sha }}
+          HAS_NVIDIA: ${{ steps.resolve-nvidia.outputs.found }}
+        run: |
+          set -euo pipefail
+          if [ -z "$DEFAULT_SHA" ]; then
+            echo "ERROR: default :testing has no org.opencontainers.image.revision label"
+            exit 1
+          fi
+
+          if [ "$HAS_NVIDIA" = "true" ] && [ "$NVIDIA_SHA" != "$DEFAULT_SHA" ]; then
+            echo "ERROR: NVIDIA source SHA ($NVIDIA_SHA) != default source SHA ($DEFAULT_SHA)"
+            echo "Variants are out of sync — skipping promotion."
+            echo "Default was built from $DEFAULT_SHA, NVIDIA from $NVIDIA_SHA."
+            exit 1
+          fi
+
+          echo "source_sha=$DEFAULT_SHA" >> "$GITHUB_OUTPUT"
+          echo "Source SHA: $DEFAULT_SHA (both variants match)"
+
+  # ── Check diff — skip if already promoted ────────────────────────────────
+  check-diff:
+    needs: [resolve]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      has_diff: ${{ steps.compare.outputs.has_diff }}
+    steps:
+      - name: Login to GHCR
+        env:
+          GH_ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "$GH_TOKEN" | sudo podman login ghcr.io --username "$GH_ACTOR" --password-stdin
+
+      - name: Compare :testing vs :latest digests
+        id: compare
+        env:
+          TESTING_DIGEST: ${{ needs.resolve.outputs.default_digest }}
+        run: |
+          set -euo pipefail
+          IMAGE="ghcr.io/${{ github.repository_owner }}/dakota:latest"
+          if sudo podman pull "$IMAGE" 2>/dev/null; then
+            LATEST_DIGEST=$(sudo podman inspect "$IMAGE" --format '{{.Digest}}')
+            if [ "$LATEST_DIGEST" = "$TESTING_DIGEST" ]; then
+              echo "No diff between :testing and :latest — nothing to promote"
+              echo "has_diff=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          echo "has_diff=true" >> "$GITHUB_OUTPUT"
+          echo "Promotion needed: :testing differs from :latest"
+
+  # ── Promote :testing → :latest + :stable ────────────────────────────────
+  promote:
+    needs: [resolve, check-diff]
+    if: needs.check-diff.outputs.has_diff == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: default
+            image_suffix: ''
+            digest_key: default_digest
+            continue: false
+          - variant: nvidia
+            image_suffix: '-nvidia'
+            digest_key: nvidia_digest
+            continue: true
+    continue-on-error: ${{ matrix.continue }}
+    steps:
+      - name: Skip if variant unavailable
+        if: matrix.variant == 'nvidia' && needs.resolve.outputs.has_nvidia != 'true'
+        run: |
+          echo "NVIDIA variant not available — skipping"
+          exit 0
+
+      - name: Login to GHCR
+        env:
+          GH_ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "$GH_TOKEN" | sudo podman login ghcr.io --username "$GH_ACTOR" --password-stdin
+
+      - name: Promote to :latest and :stable
+        env:
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          IMAGE="ghcr.io/${{ github.repository_owner }}/dakota${{ matrix.image_suffix }}"
+
+          # Pull the :testing image (already digest-verified in resolve job)
+          sudo podman pull "${IMAGE}:testing"
+
+          # Tag and push as :latest
+          sudo podman tag "${IMAGE}:testing" "${IMAGE}:latest"
+          PUSH_OK=false
+          for attempt in 1 2 3; do
+            sudo podman push --compression-format=zstd "${IMAGE}:latest" && { PUSH_OK=true; break; }
+            echo "Push attempt ${attempt} failed for :latest, retrying in 5s..."
+            [ "$attempt" -lt 3 ] && sleep 5
+          done
+          $PUSH_OK || { echo "ERROR: all push attempts failed for :latest"; exit 1; }
+
+          # Tag and push as :stable
+          sudo podman tag "${IMAGE}:testing" "${IMAGE}:stable"
+          PUSH_OK=false
+          for attempt in 1 2 3; do
+            sudo podman push --compression-format=zstd "${IMAGE}:stable" && { PUSH_OK=true; break; }
+            echo "Push attempt ${attempt} failed for :stable, retrying in 5s..."
+            [ "$attempt" -lt 3 ] && sleep 5
+          done
+          $PUSH_OK || { echo "ERROR: all push attempts failed for :stable"; exit 1; }
+
+          echo "Promoted ${IMAGE}:testing → :latest + :stable (source SHA: $SOURCE_SHA)"
+
+  # ── Fast-forward branches ────────────────────────────────────────────────
+  update-branches:
+    needs: [resolve, promote]
+    if: needs.promote.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Fast-forward latest and stable branches
+        env:
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          REPO="${{ github.repository }}"
+
+          for BRANCH in latest stable; do
+            # Try fast-forward first; create if branch doesn't exist yet.
+            if ! gh api "repos/${REPO}/git/refs/heads/${BRANCH}" \
+                --method PATCH \
+                --field sha="$SOURCE_SHA" \
+                --field force=false 2>/dev/null; then
+              gh api "repos/${REPO}/git/refs" \
+                --method POST \
+                --field ref="refs/heads/${BRANCH}" \
+                --field sha="$SOURCE_SHA"
+              echo "Created ${BRANCH} branch at ${SOURCE_SHA}"
+            else
+              echo "Fast-forwarded ${BRANCH} to ${SOURCE_SHA}"
+            fi
+          done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,14 +14,14 @@ common ────────────────────────�
                                  ▼
 bluefin  (main→stable)       ←── images ──→ testsuite (e2e gate)
 bluefin-lts (main→lts)       ←── images ──→ testsuite (e2e gate)
-dakota  (main→:latest)       ←── images ──→ testsuite (e2e gate)
+dakota  (main→testing→latest/stable) ←── images ──→ testsuite (e2e gate)
                                  │
                                  ▼
                                 iso (installation media)
 ```
 
 Each image repo pulls `ghcr.io/projectbluefin/common:latest` as a base layer.
-testsuite gates `:latest` promotion in all three image repos.
+testsuite gates `:testing` promotion nightly and `:latest`/`:stable` promotion weekly.
 
 ---## Data donation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,7 +43,7 @@ Verify the image signature:
 cosign verify \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp '^https://github.com/projectbluefin/dakota/.github/workflows/publish.yml@refs/heads/main$' \
-  ghcr.io/projectbluefin/dakota:latest
+  ghcr.io/projectbluefin/dakota:stable
 ```
 
 Verify the SLSA provenance:
@@ -52,5 +52,5 @@ cosign verify-attestation \
   --type https://slsa.dev/provenance/v1 \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp '^https://github.com/projectbluefin/dakota/.github/workflows/publish.yml@refs/heads/main$' \
-  ghcr.io/projectbluefin/dakota:latest
+  ghcr.io/projectbluefin/dakota:stable
 ```

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -22,9 +22,24 @@ setup → publish (matrix) → e2e-gate → promote
 | `setup` | Resolves SHA and trigger event |
 | `publish` | Exports from CAS, pushes `:$sha`, signs, SBOM, attests |
 | `e2e-gate` | Smoke-tests `ghcr.io/projectbluefin/dakota:$sha` — schedule/dispatch only |
-| `promote` | Re-tags `:$sha` → `:latest` after e2e passes — schedule/dispatch only |
+| `promote` | Re-tags `:$sha` → `:testing` after e2e passes — schedule/dispatch only |
 
-`:latest` is never published without a passing e2e smoke test.
+`:testing` is never published without a passing e2e smoke test.
+
+## Weekly promotion (weekly-testing-promotion.yml)
+
+Runs Tuesday 06:00 UTC. Promotes `:testing` → `:latest` + `:stable` via digest-pinned re-tagging.
+
+```
+resolve → check-diff → promote → update-branches
+```
+
+| Job | What |
+|---|---|
+| `resolve` | Pins `:testing` digest, verifies default + NVIDIA share same source SHA |
+| `check-diff` | Skips if `:testing` == `:latest` (nothing new to promote) |
+| `promote` | Re-tags both variants as `:latest` + `:stable` |
+| `update-branches` | Fast-forwards `latest` and `stable` branches to promoted SHA |
 
 ## Schedule
 
@@ -36,7 +51,12 @@ setup → publish (matrix) → e2e-gate → promote
 
 ## Published images
 
-`ghcr.io/projectbluefin/dakota:latest` and `ghcr.io/projectbluefin/dakota:<sha>`
+`ghcr.io/projectbluefin/dakota:{testing,latest,stable}` and `ghcr.io/projectbluefin/dakota:<sha>`
+
+Streams:
+- `:testing` — nightly build, promoted after e2e passes
+- `:latest` — weekly promotion from testing (Tuesday 06:00 UTC)
+- `:stable` — weekly promotion from testing (same cadence as latest)
 
 Build triggers: `merge_group`, `schedule`, `workflow_dispatch` — **not** `pull_request`.
 

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -18,7 +18,7 @@ Load when debugging CI failures, understanding the build pipeline, or working wi
 | Build timeout | 330 min (job: 360 min) |
 | Remote cache server | `cache.projectbluefin.io:11002` |
 | Cache auth | mTLS — `CASD_CLIENT_CERT` (repo variable) + `CASD_CLIENT_KEY` (secret) |
-| Published image | `ghcr.io/projectbluefin/dakota:latest` and `:$SHA` |
+| Published image | `ghcr.io/projectbluefin/dakota:{testing,latest,stable}` and `:$SHA` |
 | Build logs artifact | `buildstream-logs-x86_64-<variant>` (7-day retention) |
 | Trigger (validate) | `pull_request` — `bst show --deps all`, no CAS |
 | Trigger (build) | `merge_group`, `schedule` (13:00 UTC), `workflow_dispatch` |
@@ -29,7 +29,8 @@ Load when debugging CI failures, understanding the build pipeline, or working wi
 | File | Role |
 |---|---|
 | `.github/workflows/build.yml` | BST build + push artifacts to remote CAS. Fires on merge_group/schedule/dispatch. Does NOT push to GHCR directly. |
-| `.github/workflows/publish.yml` | 4-stage pipeline: setup → publish → e2e-gate → promote. Pulls artifact from CAS, exports OCI, pushes `:$sha`, signs, attests, smoke-tests, then promotes to `:latest`. |
+| `.github/workflows/publish.yml` | 4-stage pipeline: setup → publish → e2e-gate → promote. Pulls artifact from CAS, exports OCI, pushes `:$sha`, signs, attests, smoke-tests, then promotes to `:testing`. |
+| `.github/workflows/weekly-testing-promotion.yml` | Weekly promotion (Tue 06:00 UTC): verifies `:testing` digests, re-tags as `:latest` + `:stable`, fast-forwards branches. |
 | `.github/workflows/e2e.yml` | Smoke test via projectbluefin/testsuite. Fires on PR when image-affecting paths change. |
 
 ## Trigger Behavior

--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -24,7 +24,8 @@ Load when you need context on what dakota is, how it differs from production Blu
 - The validation gate is: `bootc upgrade` on test hardware succeeds + reboot + GDM active.
 - CI green is not sufficient. Hardware confirmation is.
 
-**Production image = `ghcr.io/projectbluefin/dakota:latest`.**
+**Production image = `ghcr.io/projectbluefin/dakota:stable`.**
+- Streams: `:testing` (nightly, e2e-gated), `:latest` + `:stable` (weekly promotion)
 - When someone says "is X in the image", check the GHCR image via `skopeo inspect` or `podman run --rm` — not a local machine unless explicitly asked.
 
 **Verify hypothesis before stating root cause.**
@@ -38,7 +39,7 @@ freedesktop-sdk provides glibc/systemd/kernel, gnome-build-meta provides GNOME S
 
 **Key positioning:** Dakota is a **curated subset** of production Bluefin, not a 1:1 clone. It intentionally includes things production Bluefin doesn't have (sudo-rs, uutils-coreutils, GNOME nightly) and intentionally omits things that don't make sense for a from-source build (Nvidia drivers, ZFS, enterprise AD/Kerberos).
 
-Published image: `ghcr.io/projectbluefin/dakota:latest`
+Published image: `ghcr.io/projectbluefin/dakota:{testing,latest,stable}`
 
 ## Architecture Comparison
 


### PR DESCRIPTION
## Summary

Match the branch layout used by `bluefin` and `bluefin-lts` in the org.

### Stream model (re-tag, not rebuild)

Dakota's BST build takes 330 min. Instead of rebuilding per-branch like bluefin does with Containerfiles, we use a **re-tag model**: one build, promote via tag manipulation.

| Stream | Gate | Cadence |
|--------|------|---------|
| `:testing` | e2e passes on `:sha` | Nightly (after 13:00 UTC build) |
| `:latest` | Weekly promotion from `:testing` | Tuesday 06:00 UTC |
| `:stable` | Weekly promotion from `:testing` | Tuesday 06:00 UTC |

### Changes

- **publish.yml**: Promote to `:testing` (was `:latest`) after e2e; fast-forward `testing` branch
- **weekly-testing-promotion.yml** (new): Digest-pinned re-tagging of `:testing` to `:latest` + `:stable`, with NVIDIA variant SHA verification
- **e2e.yml**: Default dispatch image updated to `:testing`
- **Docs**: Updated all `:latest` references to reflect new stream model
- **Branches created**: `testing`, `latest`, `stable` from current `main` HEAD

### What this does NOT do

- No per-branch BST rebuilds (too expensive at 330 min)
- No cherry-pick-to-stable (would create branch/image divergence with retag model)
- No change to release.yml (still fires per nightly publish)

### Safety

- Weekly promotion resolves `:testing` to immutable digest before re-tagging
- Verifies default + NVIDIA variants share same source SHA
- Skips promotion if `:testing` == `:latest` (nothing new)
- Branches are fast-forwarded (not force-pushed)

---

- [x] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `testing` and `stable` image tags for Dakota, enabling multi-tier release channels alongside the existing `latest` tag.
  * Added weekly promotion workflow to advance tested images to `latest` and `stable` tags.

* **Documentation**
  * Updated CI documentation and security examples to reflect the new three-tier image tagging strategy with nightly and weekly promotion cadences.

* **Chores**
  * Updated E2E workflows and CI/CD pipelines to use the new testing image tag for validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->