### PR TITLE
feat(nvidia): Upgrade drivers to 610.43.02 and ship nvidia-settings

### DIFF
--- a/elements/bluefin-nvidia/nvidia-drivers.bst
+++ b/elements/bluefin-nvidia/nvidia-drivers.bst
@@ -40,12 +40,12 @@ depends:
 
 sources:
 - kind: remote
-  url: nvidia:XFree86/Linux-x86_64/595.71.05/NVIDIA-Linux-x86_64-595.71.05.run
-  ref: 36203b8960b7e49c8a42f6ba1f5863cde34a05e93d2b24b798af06dd846f6b82
-  filename: NVIDIA-Linux-x86_64-595.71.05.run
+  url: nvidia:XFree86/Linux-x86_64/610.43.02/NVIDIA-Linux-x86_64-610.43.02.run
+  ref: 3034a054bb4cdf7752ff8dc272564cb105513804bff53538945901b16ca77463
+  filename: NVIDIA-Linux-x86_64-610.43.02.run
 
 variables:
-  nvidia-version: '595.71.05'
+  nvidia-version: '610.43.02'
   strip-binaries: ''
 
 config:
@@ -155,6 +155,7 @@ config:
         'libnvidia-vulkan-producer.so.*' \
         'libnvidia-pkcs11*.so.*' \
         'libnvidia-nvvm.so.*' \
+        'libnvidia-gtk*.so.*' \
     ; do
         for f in $pat; do
             [ -f "$f" ] && install -Dm755 "$f" "$LIBDIR/$f" || true
@@ -187,9 +188,20 @@ config:
         nvidia-cuda-mps-control \
         nvidia-cuda-mps-server \
         nvidia-powerd \
+        nvidia-settings \
     ; do
         [ -f "$bin" ] && install -Dm755 "$bin" "$BINDIR/$bin" || true
     done
+
+    # nvidia-settings desktop file and icon
+    if [ -f nvidia-settings.desktop ]; then
+        install -Dm644 nvidia-settings.desktop \
+            "%{install-root}/usr/share/applications/nvidia-settings.desktop"
+    fi
+    if [ -f nvidia-settings.png ]; then
+        install -Dm644 nvidia-settings.png \
+            "%{install-root}/usr/share/pixmaps/nvidia-settings.png"
+    fi
 
     if [ -f nvidia_icd.json ]; then
         install -Dm644 nvidia_icd.json \


### PR DESCRIPTION
Updates the NVIDIA proprietary drivers to the 610.43.02 release.

This also now includes the `nvidia-settings` utility, along with its
GTK libraries, desktop file, and icon, providing users with a graphical
interface for configuring NVIDIA GPU settings.

Closes: #632, #629


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NVIDIA proprietary drivers to version 610.43.02.
  * Extended driver package to include additional NVIDIA libraries.
  * Added NVIDIA Settings application to the driver installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->