### PR TITLE
feat(bluefin): package and add fastfetch

### DIFF
--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -81,7 +81,7 @@ Production Bluefin images are **Containerfile-based overlays** — they start wi
 | fish | N | Y |
 | zsh | N | Y |
 | tmux | N | Y |
-| fastfetch | N | Y |
+| fastfetch | Y | Y |
 | Starship prompt | N | Y |
 
 ### Networking & VPN
@@ -107,7 +107,6 @@ Nvidia drivers, ZFS, Xbox controller (xone), Framework laptop modules — not in
 
 | Package | Notes |
 |---|---|
-| fastfetch | System info tool, in both production Bluefins |
 | Starship prompt | Shell prompt, core Bluefin UX; pre-built binary |
 | fish shell | Alternative shell; requires build from source |
 | fwupd | Firmware updates; upstream element exists |

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -17,6 +17,7 @@ depends:
   - bluefin/glow.bst
   - bluefin/gum.bst
   - bluefin/fzf.bst
+  - bluefin/fastfetch.bst
   - bluefin/tealdeer.bst
 
   - bluefin/common.bst

--- a/elements/bluefin/fastfetch.bst
+++ b/elements/bluefin/fastfetch.bst
@@ -1,0 +1,24 @@
+kind: manual
+
+sources:
+- kind: tar
+  (?):
+  - arch == "x86_64":
+      url: github_files:fastfetch-cli/fastfetch/releases/download/2.63.1/fastfetch-linux-amd64.tar.gz
+      ref: 75dcbcf5dbe51a6c3785767085bda00f5253af46a1292a6444746b33215d4199
+  - arch == "aarch64":
+      url: github_files:fastfetch-cli/fastfetch/releases/download/2.63.1/fastfetch-linux-aarch64.tar.gz
+      ref: 2f4fc07751d2cdf3d8cb41ef6598699a1a4da5e7c50a0ea67ea601077a3d6ac1
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    cp -r usr/./ "%{install-root}%{prefix}/"
+  - |
+    %{install-extra}


### PR DESCRIPTION
## What problem are you solving?
This PR packages the `fastfetch` system information tool and adds it to the Dakota dependency stack. This resolves the issue where terminals or helper scripts (such as `/usr/bin/ublue-fastfetch` and terminal shell profiles) fail with `/usr/bin/ublue-fastfetch: line 25: exec: fastfetch: not found` due to the binary's absence in the Dakota base image.

- [x] I am using an agent and I take responsibility for this PR

---

## Changes

- Created new manual BuildStream element `elements/bluefin/fastfetch.bst` that fetches and unpacks the official `2.63.1` pre-built release binaries for both `x86_64` and `aarch64` architectures.
- Staged the `fastfetch` binary and all upstream configurations, man pages, shell completions, and licenses directly into `%{install-root}%{prefix}/`.
- Added `bluefin/fastfetch.bst` to the dependency stack in `elements/bluefin/deps.bst`.
- Updated `docs/skills/overview.md` to reflect that `fastfetch` is now packaged in Dakota, and removed it from the "Notable Gaps" table.

## Testing

- [x] `just validate` passes
- [ ] `just boot-test` passes (automated boot smoke test)
- [ ] `just lint` passes on a built image
- [ ] `just boot-fast` or `just boot-vm` — desktop comes up, no regressions

*Note: BuildStream graph validation successfully checked and parsed all element dependencies. Full image building and local bootc linting was skipped as it requires a massive compilation of upstream components due to a cold local cache, but this will be fully tested by the upstream CI pipeline.*

## Checklist

- [x] New BST elements wired into `deps.bst`
- [x] Patches in `patches/` regenerated if junction refs changed (no junction refs changed)

## Community verification (bug-fix PRs)

```verify
# Steps for users to verify this fix:
# 1. Run/boot the new nightly image or run:
ublue-fastfetch
# 2. Confirm it displays the system info layout cleanly without "fastfetch: not found" errors.
```

Closes projectbluefin/common#550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fastfetch CLI tool is now included in Dakota. This utility displays comprehensive system information and hardware specifications from the command line for quick system diagnostics and reporting.

* **Documentation**
  * Updated package documentation to reflect Fastfetch's inclusion in Dakota and removed it from the identified gaps list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->