### PR TITLE
feat(bluefin): package and add starship

### DIFF
--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -82,7 +82,7 @@ Production Bluefin images are **Containerfile-based overlays** — they start wi
 | zsh | N | Y |
 | tmux | N | Y |
 | fastfetch | N | Y |
-| Starship prompt | N | Y |
+| Starship prompt | Y | Y |
 
 ### Networking & VPN
 
@@ -108,7 +108,6 @@ Nvidia drivers, ZFS, Xbox controller (xone), Framework laptop modules — not in
 | Package | Notes |
 |---|---|
 | fastfetch | System info tool, in both production Bluefins |
-| Starship prompt | Shell prompt, core Bluefin UX; pre-built binary |
 | fish shell | Alternative shell; requires build from source |
 | fwupd | Firmware updates; upstream element exists |
 | uupd (auto-updater) | Upstream OTA update daemon |

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -17,6 +17,7 @@ depends:
   - bluefin/glow.bst
   - bluefin/gum.bst
   - bluefin/fzf.bst
+  - bluefin/starship.bst
   - bluefin/tealdeer.bst
 
   - bluefin/common.bst

--- a/elements/bluefin/starship.bst
+++ b/elements/bluefin/starship.bst
@@ -1,0 +1,25 @@
+kind: manual
+
+sources:
+- kind: tar
+  base-dir: ""
+  (?):
+  - arch == "x86_64":
+      url: github_files:starship/starship/releases/download/v1.25.1/starship-x86_64-unknown-linux-musl.tar.gz
+      ref: c6ddd3ecb9c0071a2ad38d98cee748160066b7c4f197421268058f4a5d6f8504
+  - arch == "aarch64":
+      url: github_files:starship/starship/releases/download/v1.25.1/starship-aarch64-unknown-linux-musl.tar.gz
+      ref: 01517aab398959ea9ea73bdb4f032ea4dbb51dff5c8e5eb05b4a1b9b7ab872b8
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    install -Dm755 -t "%{install-root}%{bindir}" starship
+  - |
+    %{install-extra}


### PR DESCRIPTION
## What problem are you solving?
This PR packages the `starship` shell prompt (core Bluefin UX) and adds it to the Dakota dependency stack.

- [x] I am using an agent and I take responsibility for this PR

---

## Changes

- Created new manual BuildStream element `elements/bluefin/starship.bst` that fetches and unpacks the official `v1.25.1` pre-built release binaries for both `x86_64` and `aarch64` architectures.
- Added `bluefin/starship.bst` to the dependency stack in `elements/bluefin/deps.bst`.
- Updated `docs/skills/overview.md` to reflect that `Starship prompt` is now packaged in Dakota, and removed it from the "Notable Gaps" table.

## Testing

- [x] `just validate` passes
- [ ] `just boot-test` passes (automated boot smoke test)
- [ ] `just lint` passes on a built image
- [ ] `just boot-fast` or `just boot-vm` — desktop comes up, no regressions

*Note: BuildStream graph validation successfully checked and parsed all element dependencies.*

## Checklist

- [x] New BST elements wired into `deps.bst`
- [x] Patches in `patches/` regenerated if junction refs changed (no junction refs changed)

## Community verification (bug-fix PRs)

This is a feature addition, but users can verify the tool exists on the system:
```bash
starship --version
```
