### PR TITLE
feat(bluefin): package and add fish

### DIFF
--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -78,7 +78,7 @@ Production Bluefin images are **Containerfile-based overlays** — they start wi
 | glow | Y | Y |
 | gum | Y | Y |
 | fzf | Y | Y |
-| fish | N | Y |
+| fish | Y | Y |
 | zsh | N | Y |
 | tmux | N | Y |
 | fastfetch | N | Y |
@@ -109,7 +109,6 @@ Nvidia drivers, ZFS, Xbox controller (xone), Framework laptop modules — not in
 |---|---|
 | fastfetch | System info tool, in both production Bluefins |
 | Starship prompt | Shell prompt, core Bluefin UX; pre-built binary |
-| fish shell | Alternative shell; requires build from source |
 | fwupd | Firmware updates; upstream element exists |
 | uupd (auto-updater) | Upstream OTA update daemon |
 | Bazaar (app store) | Flatpak-based app store |

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -17,6 +17,7 @@ depends:
   - bluefin/glow.bst
   - bluefin/gum.bst
   - bluefin/fzf.bst
+  - bluefin/fish.bst
   - bluefin/tealdeer.bst
 
   - bluefin/common.bst

--- a/elements/bluefin/fish.bst
+++ b/elements/bluefin/fish.bst
@@ -1,0 +1,25 @@
+kind: manual
+
+sources:
+- kind: tar
+  base-dir: ""
+  (?):
+  - arch == "x86_64":
+      url: github_files:fish-shell/fish-shell/releases/download/4.7.1/fish-4.7.1-linux-x86_64.tar.xz
+      ref: 345388add316b94a847b08cef01f1b46e85b98215328271ee22a21555a3204df
+  - arch == "aarch64":
+      url: github_files:fish-shell/fish-shell/releases/download/4.7.1/fish-4.7.1-linux-aarch64.tar.xz
+      ref: 72957265b8629fbb3cdb215260c302f6154403dbaf35d38103aac6af689fb7f6
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    install -Dm755 -t "%{install-root}%{bindir}" fish
+  - |
+    %{install-extra}


### PR DESCRIPTION
## What problem are you solving?
This PR packages the `fish` shell and adds it to the Dakota dependency stack.

- [x] I am using an agent and I take responsibility for this PR

---

## Changes

- Created new manual BuildStream element `elements/bluefin/fish.bst` that fetches the official `4.7.1` standalone pre-built release binaries for both `x86_64` and `aarch64` architectures.
- Added `bluefin/fish.bst` to the dependency stack in `elements/bluefin/deps.bst`.
- Updated `docs/skills/overview.md` to reflect that `fish` is now packaged in Dakota, and removed it from the "Notable Gaps" table.

## Testing

- [x] `just validate` passes
- [ ] `just boot-test` passes (automated boot smoke test)
- [ ] `just lint` passes on a built image
- [ ] `just boot-fast` or `just boot-vm` — desktop comes up, no regressions

## Checklist

- [x] New BST elements wired into `deps.bst`
- [x] Patches in `patches/` regenerated if junction refs changed (no junction refs changed)

## Community verification

```bash
fish --version
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fish shell version 4.7.1 is now available for both x86_64 and aarch64 architectures, expanding your available shell options in the environment.

* **Documentation**
  * Updated the Shell & Terminal Tools comparison table to reflect Fish shell inclusion and removed it from the list of notable feature gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->