### PR TITLE
feat(bluefin): package and add zsh

### DIFF
--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -79,7 +79,7 @@ Production Bluefin images are **Containerfile-based overlays** — they start wi
 | gum | Y | Y |
 | fzf | Y | Y |
 | fish | N | Y |
-| zsh | N | Y |
+| zsh | Y | Y |
 | tmux | N | Y |
 | fastfetch | N | Y |
 | Starship prompt | N | Y |

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -17,6 +17,7 @@ depends:
   - bluefin/glow.bst
   - bluefin/gum.bst
   - bluefin/fzf.bst
+  - bluefin/zsh.bst
   - bluefin/tealdeer.bst
 
   - bluefin/common.bst

--- a/elements/bluefin/zsh.bst
+++ b/elements/bluefin/zsh.bst
@@ -1,0 +1,25 @@
+kind: manual
+
+sources:
+- kind: tar
+  base-dir: ""
+  (?):
+  - arch == "x86_64":
+      url: github_files:romkatv/zsh-bin/releases/download/v6.1.1/zsh-5.8-linux-x86_64.tar.gz
+      ref: 6df668fb6e9a12874e0d80518d582f2e99e512d4a4532fa73d938360aaddc838
+  - arch == "aarch64":
+      url: github_files:romkatv/zsh-bin/releases/download/v6.1.1/zsh-5.8-linux-aarch64.tar.gz
+      ref: 5caca77bcdaa218ec12e79f2e65c53c39058e0ed4f4f299991d18a800ca7c06d
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    cp -r bin share "%{install-root}%{prefix}/"
+  - |
+    %{install-extra}


### PR DESCRIPTION
## What problem are you solving?
This PR packages `zsh` and adds it to the Dakota dependency stack.

- [x] I am using an agent and I take responsibility for this PR

---

## Changes

- Created new manual BuildStream element `elements/bluefin/zsh.bst` using `romkatv/zsh-bin` pre-built static binaries (`v6.1.1`, zsh `5.8`) for both `x86_64` and `aarch64` architectures.
- Added `bluefin/zsh.bst` to the dependency stack in `elements/bluefin/deps.bst`.
- Updated `docs/skills/overview.md` to reflect that `zsh` is now packaged in Dakota.

## Testing

- [x] `just validate` passes
- [ ] `just boot-test` passes (automated boot smoke test)
- [ ] `just lint` passes on a built image
- [ ] `just boot-fast` or `just boot-vm` — desktop comes up, no regressions

## Checklist

- [x] New BST elements wired into `deps.bst`
- [x] Patches in `patches/` regenerated if junction refs changed (no junction refs changed)

## Community verification

```bash
zsh --version
```
