### PR TITLE
feat(bluefin): package and add tmux

### DIFF
--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -80,7 +80,7 @@ Production Bluefin images are **Containerfile-based overlays** — they start wi
 | fzf | Y | Y |
 | fish | N | Y |
 | zsh | N | Y |
-| tmux | N | Y |
+| tmux | Y | Y |
 | fastfetch | N | Y |
 | Starship prompt | N | Y |
 

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -17,6 +17,7 @@ depends:
   - bluefin/glow.bst
   - bluefin/gum.bst
   - bluefin/fzf.bst
+  - bluefin/tmux.bst
   - bluefin/tealdeer.bst
 
   - bluefin/common.bst

--- a/elements/bluefin/tmux.bst
+++ b/elements/bluefin/tmux.bst
@@ -1,0 +1,26 @@
+kind: manual
+
+sources:
+- kind: remote
+  filename: tmux.gz
+  (?):
+  - arch == "x86_64":
+      url: github_files:mjakob-gh/build-static-tmux/releases/download/v3.6b/tmux.linux-amd64.stripped.gz
+      ref: a23e56e9913d610c31f2893a1c9c669a73cb8bb2b8ded1180f6572bb55e52ca5
+  - arch == "aarch64":
+      url: github_files:mjakob-gh/build-static-tmux/releases/download/v3.6b/tmux.linux-arm64.stripped.gz
+      ref: c47968fab66e5d0eda6eaf547e1318412d35e180b95b1400bffa659960de8638
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    gunzip -c tmux.gz > tmux
+    install -Dm755 -t "%{install-root}%{bindir}" tmux
+  - |
+    %{install-extra}


### PR DESCRIPTION
## What problem are you solving?
This PR packages `tmux` and adds it to the Dakota dependency stack.

- [x] I am using an agent and I take responsibility for this PR

---

## Changes

- Created new manual BuildStream element `elements/bluefin/tmux.bst` using `mjakob-gh/build-static-tmux` pre-built stripped static binaries (`v3.6b`) for both `x86_64` and `aarch64` architectures.
- Added `bluefin/tmux.bst` to the dependency stack in `elements/bluefin/deps.bst`.
- Updated `docs/skills/overview.md` to reflect that `tmux` is now packaged in Dakota.

## Testing

- [x] `just validate` passes
- [ ] `just boot-test` passes (automated boot smoke test)
- [ ] `just lint` passes on a built image
- [ ] `just boot-fast` or `just boot-vm` — desktop comes up, no regressions

## Checklist

- [x] New BST elements wired into `deps.bst`
- [x] Patches in `patches/` regenerated if junction refs changed (no junction refs changed)

## Community verification

```bash
tmux -V
```
