### PR TITLE
feat(bluefin): package and add wireguard-tools

### DIFF
--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -89,7 +89,7 @@ Production Bluefin images are **Containerfile-based overlays** — they start wi
 | Package | Dakota | bluefin |
 |---|:---:|:---:|
 | Tailscale | Y | Y |
-| wireguard-tools | N | Y |
+| wireguard-tools | Y | Y |
 
 ### Containers
 

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -39,6 +39,7 @@ depends:
   - bluefin/xdg-terminal-exec.bst
   - bluefin/nautilus-python.bst
   - bluefin/network.bst
+  - bluefin/wireguard-tools.bst
 
   # Include things missing from the gnomeos base image
   - gnome-build-meta.bst:core-deps/fwupd.bst

--- a/elements/bluefin/wireguard-tools.bst
+++ b/elements/bluefin/wireguard-tools.bst
@@ -1,0 +1,23 @@
+kind: manual
+
+sources:
+- kind: tar
+  url: github_files:WireGuard/wireguard-tools/archive/refs/tags/v1.0.20260223.tar.gz
+  ref: 859f8af03702db5e5c43f8ece77f5ebef40a2f4627c3e03997a031d4940ea9bc
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-make.bst
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+- freedesktop-sdk.bst:components/libmnl.bst
+
+config:
+  build-commands:
+  - |
+    make -C src
+  install-commands:
+  - |
+    make -C src install DESTDIR="%{install-root}" PREFIX="%{prefix}"
+  - |
+    %{install-extra}


### PR DESCRIPTION
## What problem are you solving?
This PR packages `wireguard-tools` and adds it to the Dakota dependency stack.

- [x] I am using an agent and I take responsibility for this PR

---

## Changes

- Created new BuildStream element `elements/bluefin/wireguard-tools.bst` that builds `wg` and `wg-quick` from the official WireGuard source tarball (`v1.0.20260223`) against the `libmnl` already available in `freedesktop-sdk`.
- Added `bluefin/wireguard-tools.bst` to the dependency stack in `elements/bluefin/deps.bst`.
- Updated `docs/skills/overview.md` to reflect that `wireguard-tools` is now packaged in Dakota.

## Testing

- [x] `just validate` passes
- [ ] `just boot-test` passes (automated boot smoke test)
- [ ] `just lint` passes on a built image
- [ ] `just boot-fast` or `just boot-vm` — desktop comes up, no regressions

## Checklist

- [x] New BST elements wired into `deps.bst`
- [x] Patches in `patches/` regenerated if junction refs changed (no junction refs changed)

## Community verification

```bash
wg --version
```
