### PR TITLE
chore(ci): run weekly testing promotion on Sundays

### DIFF
--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -2,7 +2,7 @@ name: Weekly Testing Promotion
 
 on:
   schedule:
-    - cron: '0 6 * * 2' # Tuesday 06:00 UTC (same as bluefin)
+    - cron: '0 6 * * 0' # Sunday 06:00 UTC
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -52,9 +52,11 @@ jobs:
           if sudo podman pull "$IMAGE" 2>/dev/null; then
             DIGEST=$(sudo podman inspect "$IMAGE" --format '{{.Digest}}')
             SHA=$(sudo podman inspect "$IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')
-            echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
-            echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-            echo "found=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "digest=$DIGEST"
+              echo "sha=$SHA"
+              echo "found=true"
+            } >> "$GITHUB_OUTPUT"
             echo "NVIDIA :testing → digest=$DIGEST, source_sha=$SHA"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Shift cadence from Tuesday to Sunday so risky code can land in `:testing` during the week and get a weekend soak before promoting to `:latest` and `:stable` on Sunday morning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted internal testing workflow schedule to run Sundays at 06:00 UTC (was Tuesday at 06:00 UTC).
  * Minor scripting tidy in the internal digest resolution step for clearer output grouping.

---

Note: This is an internal infrastructure change with no impact on end-user features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->