### PR TITLE
feat(ci): add skill-drift wrapper workflow

### DIFF
--- a/.github/workflows/skill-drift.yml
+++ b/.github/workflows/skill-drift.yml
@@ -1,0 +1,16 @@
+name: Skill Drift
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  skill-drift:
+    uses: projectbluefin/actions/.github/workflows/skill-drift-check.yml@v1
+    with:
+      code-paths: '[".github/workflows/**", "build_files/**", "Justfile", "elements/**"]'
+      skill-paths: '["docs/skills/**", "docs/*.md", "AGENTS.md"]'


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/skill-drift.yml` — a 16-line wrapper that calls the reusable `projectbluefin/actions/.github/workflows/skill-drift-check.yml@v1`
- Warns (informational, exits 0) on PRs that change `.github/workflows/`, `build_files/`, `Justfile`, or `elements/` without also touching `docs/skills/`, `docs/*.md`, or `AGENTS.md`
- Closes issue: [projectbluefin/actions#26](https://github.com/projectbluefin/actions/issues/26) (dakota portion)

## What this does

When a PR changes CI or build files but no skill/doc files, CI emits a `::warning::` annotation asking the author to review whether docs need updating. The check always exits 0 — it is advisory, not blocking.

## Test plan

- [ ] Open a test PR that edits a workflow file without touching `docs/` — confirm warning annotation appears in CI
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to perform code quality checks on pull requests targeting the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->