### PR TITLE
chore(lockdown): add CODEOWNERS per-path entries and mandatory gates (Track C-2)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,8 @@
+# Default: any one maintainer approves
 * @castrojo @p5 @m2Giles @tulilirockz
+
+# Sensitive paths — require maintainer review
+.github/workflows/  @castrojo @p5 @m2Giles @tulilirockz
+Justfile            @castrojo @p5 @m2Giles @tulilirockz
+build_files/        @castrojo @p5 @m2Giles @tulilirockz
+elements/           @castrojo @p5 @m2Giles @tulilirockz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,12 @@ Non-compliance = automatic rejection.
 
 **Skill contribution:** If you discover a pattern, fix a recurring mistake, or learn something that would help future agents, you **must** update the relevant skill file in `docs/skills/` in the same PR as your change. If no relevant skill file exists, create one and add it to the routing table in `docs/skills/README.md`. Skills are living documents — every agent improves them.
 
+**Agents MUST NOT push directly to `main`.** All changes via PR from a feature branch. Branch protection enforces this.
+
+**Production promotion** (`weekly-testing-promotion.yml`) requires 2 distinct human approvals in the GitHub `production` Environment. No agent may trigger, approve, or bypass this gate. Admin bypasses are permanently logged in Environment deployment history.
+
+**`.github/workflows/`, `Justfile`, `build_files/`, and `elements/` are CODEOWNERS-protected** — PRs touching these paths require maintainer review.
+
 ## PR Comment Policy
 
 **One comment per PR event, max.** Combine all findings into a single comment. Never post a follow-up comment for a new observation — edit the existing one instead.


### PR DESCRIPTION
## Summary

- Adds per-path CODEOWNERS entries for `.github/workflows/`, `Justfile`, `build_files/`, and `elements/`
- Updates `AGENTS.md` mandatory gates: agents must not push to `main`, production promotion is 2-human gated via `environment: production`, CODEOWNERS-protected paths listed

## Track C-2 — branch protection + CODEOWNERS expansion

Part of the org-wide lockdown epic (`projectbluefin/actions` issue #18). CODEOWNERS per-path entries make GitHub surface the required-review signal in the PR UI for sensitive paths.

## Verification

- `cat .github/CODEOWNERS` shows per-path entries
- `cat AGENTS.md` shows updated mandatory gates section

[ ] I am using an agent and I take responsibility for this PR

Assisted-by: claude-sonnet-4-6 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated operational policies for code review and deployment processes.

* **Chores**
  * Enhanced code ownership and review requirements for critical paths to ensure maintainer oversight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->