### PR TITLE
ci(hive): migrate to org board and hive/* labels in hive-status-sync

### DIFF
--- a/.github/workflows/hive-status-sync.yml
+++ b/.github/workflows/hive-status-sync.yml
@@ -23,7 +23,7 @@ jobs:
           from datetime import datetime, timezone
 
           SNAPSHOT_URL  = "https://raw.githubusercontent.com/kubestellar/docs/main/public/live/hive/bluefin/index.html"
-          PROJECT_ID    = "PVT_kwDOCCE0ds4BZAIm"
+          PROJECT_ID    = "PVT_kwDOCCE0ds4BLZBC"
           DASHBOARD_URL = "https://kubestellar.io/live/hive/bluefin/"
           REPO          = "projectbluefin/dakota"
           ISSUES_URL    = f"https://github.com/{REPO}/issues"
@@ -129,7 +129,8 @@ jobs:
                             "--label", label, "--state", "open", "--json", "number")
               return len(raw) if raw else 0
 
-          n_p0 = count_label("P0")
+          n_p0 = count_label("hive/p0")
+          n_p1 = count_label("hive/p1")
 
           # Fireteam — unique contributors from merged PRs (last 50), excluding bots
           # Ghost contributors (agent-assisted) detected via checked PR template checkbox
@@ -190,9 +191,10 @@ jobs:
           # Timestamp
           now_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
-          # Status bar — P0 count only surfaces when non-zero
+          # Status bar — Hive priority counts surface when non-zero
           p0_fragment = f" · ▲ {n_p0} P0" if n_p0 > 0 else ""
-          status_bar  = f"`[{health_bar}]` {formation_status} · {n_active}/{total} active · {ci_label}{p0_fragment}"
+          p1_fragment = f" · {n_p1} P1" if n_p1 > 0 else ""
+          status_bar  = f"`[{health_bar}]` {formation_status} · {n_active}/{total} active · {ci_label}{p0_fragment}{p1_fragment}"
 
           # Active agent names for header
           header = f"**{n_active}/{total} active**"
@@ -277,7 +279,7 @@ jobs:
           python3 << 'PYEOF'
           import json, subprocess, sys, os
 
-          PROJECT_ID = "PVT_kwDOCCE0ds4BZAIm"
+          PROJECT_ID = "PVT_kwDOCCE0ds4BLZBC"
           REPO = "projectbluefin/dakota"
 
           if not os.environ.get("GH_TOKEN"):
@@ -310,12 +312,15 @@ jobs:
 
           n_ready   = count_label("queue/agent-ready")
           n_claimed = count_label("queue/claimed")
-          n_p0      = count_label("P0")
+          n_p0      = count_label("hive/p0")
+          n_p1      = count_label("hive/p1")
 
           # Build title
           parts = [ci, f"{n_ready} ready", f"{n_claimed} claimed"]
           if n_p0 > 0:
               parts.append(f"{n_p0} P0 🔥")
+          if n_p1 > 0:
+              parts.append(f"{n_p1} P1")
           title = "Dakota Development — " + " · ".join(parts)
 
           print(f"Setting title: {title}")


### PR DESCRIPTION
## What

Fixes two bugs in the Hive status sync workflow:

1. **Wrong project board**: was posting to the dakota-local board (`PVT_kwDOCCE0ds4BZAIm`). The org contract is to post to the org board (`PVT_kwDOCCE0ds4BLZBC` — todo.projectbluefin.io). Fixed both occurrences.
2. **Dead label**: was counting `P0` (bare uppercase — label doesn't exist in this repo). Now counts `hive/p0` and `hive/p1` per the org Hive label taxonomy.

## Context
Part of org-wide Hive label taxonomy standardization. See [agentic-contributing.md](https://github.com/projectbluefin/documentation/blob/main/docs/agentic-contributing.md).

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot