### PR TITLE
fix(ci): group consecutive GITHUB_OUTPUT redirects (SC2129)

### DIFF
--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -40,8 +40,10 @@ jobs:
           sudo podman pull "$IMAGE"
           DIGEST=$(sudo podman inspect "$IMAGE" --format '{{.Digest}}')
           SHA=$(sudo podman inspect "$IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')
-          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
-          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          {
+            echo "digest=$DIGEST"
+            echo "sha=$SHA"
+          } >> "$GITHUB_OUTPUT"
           echo "Default :testing → digest=$DIGEST, source_sha=$SHA"
 
       - name: Resolve NVIDIA :testing digest


### PR DESCRIPTION
Actionlint is failing on all open PRs because `weekly-testing-promotion.yml` has consecutive `>> "$GITHUB_OUTPUT"` redirects that shellcheck flags as SC2129.

Since GitHub runs checks against the merge commit (PR branch + main), this causes the lint job to fail on every open PR, even ones that don't touch workflows.

**Fix:** group the two consecutive redirects in the `Resolve default :testing digest` step using `{ } >>` syntax.

This will unblock the lint check on: #656, #655, #654, #653, #652, #650, #649, #646, #644, #643, #626, #625, #624, #614, #613, #610, #600, #599, #591

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Actions workflow formatting for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->