### PR TITLE
chore(agents): remove PR rate limit — gate is human now

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,8 +39,6 @@ Non-compliance = automatic rejection.
 
 **Read-First:** Read `README.md`, `AGENTS.md`, `.github/copilot-instructions.md`, and `docs/SKILL.md` before modifying anything. Do not assume project structure or patterns.
 
-**Rate limit:** Max 4 open PRs at a time. If a PR is closed for quality, document the root cause on the closed PR before resubmitting.
-
 **Operator accountability:** The human deploying the agent is responsible for all decisions. PR template checkbox: `[ ] I am using an agent and I take responsibility for this PR`
 
 **Verification:** Every PR must confirm `just lint` passed and the image booted. Use `just boot-test` for automated pass/fail. No WIP PRs.


### PR DESCRIPTION
Removes the hardcoded 4-PR open limit from AGENTS.md. PR volume is now gated by human maintainers, not an arbitrary agent-side cap.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>