### PR TITLE
feat: add weekly GHCR cleanup workflow

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -1,0 +1,24 @@
+name: Cleanup Old Images
+on:
+  schedule:
+    - cron: "15 0 * * 0" # 0015 UTC on Sundays
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+
+jobs:
+  delete-older-than-90:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete Images Older Than 90 Days
+        uses: projectbluefin/actions/bootc-build/ghcr-cleanup@fb75840b642bc5ed21d93323894f62197372f3d8 # feat/ghcr-cleanup-orphaned-images
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          packages: dakota,dakota-nvidia
+          older-than: 90 days
+          delete-orphaned-images: true
+          keep-n-tagged: 7
+          keep-n-untagged: 7


### PR DESCRIPTION
## Summary

Adds a weekly scheduled workflow to prune `dakota` and `dakota-nvidia` image tags older than 90 days from GHCR.

Closes #664

## Design

Mirrors `projectbluefin/bluefin` [`clean.yml`](https://github.com/projectbluefin/bluefin/blob/main/.github/workflows/clean.yml) exactly, using the shared org action instead of calling `dataaxiom/ghcr-cleanup-action` directly.

| Setting | Value |
|---|---|
| Schedule | Sundays 00:15 UTC |
| Packages | `dakota,dakota-nvidia` |
| older-than | 90 days |
| keep-n-tagged | 7 |
| keep-n-untagged | 7 |
| delete-orphaned-images | true |

## Dependency

Requires [projectbluefin/actions#39](https://github.com/projectbluefin/actions/pull/39) to merge first (bumps ghcr-cleanup action to v1.2.1 + adds `delete-orphaned-images` input). This PR is pinned to the feature branch SHA `fb75840` for validation; will update to the `@v1` tag once that PR merges.