### PR TITLE
fix(publish): replace read-all with explicit permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,13 @@ env:
   IMAGE_NAME: dakota
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
-permissions: read-all
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+  attestations: write
+  artifact-metadata: write
+  actions: read
 
 concurrency:
   group: publish-main


### PR DESCRIPTION
## Problem

`permissions: read-all` only grants read-level access to all scopes. GitHub validates at parse time that a reusable workflow call cannot request permissions exceeding the caller's top-level grant. The `e2e-gate` job calls `projectbluefin/testsuite` which requests `packages: write` — this exceeds the `packages: read` granted by `read-all`, producing `startup_failure` with `jobs: []` on every publish.yml run.

## Fix

Replace `permissions: read-all` with explicit permissions matching the pattern used in `projectbluefin/bluefin` build-images.yml.

## Testing

After merge, dispatch publish.yml — should no longer startup_failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security of the build and publish workflow by implementing more granular and restrictive permission settings, reducing unnecessary access levels to the minimum required for operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->