### PR TITLE
fix(publish): remove invalid artifact-metadata permission causing startup_failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,6 @@ permissions:
   packages: write
   id-token: write
   attestations: write
-  artifact-metadata: write
   actions: read
 
 concurrency:
@@ -82,7 +81,6 @@ jobs:
       packages: write
       id-token: write
       attestations: write
-      artifact-metadata: write
       actions: read
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Problem

`artifact-metadata: write` is not a valid `GITHUB_TOKEN` permission scope. GitHub validates workflow metadata before creating any jobs, so this invalid key causes `startup_failure` with `jobs: []` on every dispatch — including all manual dispatches since the May 30 refactor.

## Fix

Remove `artifact-metadata: write` from both the top-level `permissions:` block and `jobs.publish.permissions`.

## Verification

- `actionlint` clean
- All other permissions remain unchanged

- [ ] I am using an agent and I take responsibility for this PR