### PR TITLE
fix(publish): remove job-level permissions from e2e-gate reusable workflow call

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -285,8 +285,6 @@ jobs:
       needs.publish.result == 'success' &&
       (needs.setup.outputs.event == 'schedule' ||
        needs.setup.outputs.event == 'workflow_dispatch')
-    permissions:
-      packages: write  # testsuite pushes desktop screenshot to GHCR
     uses: projectbluefin/testsuite/.github/workflows/e2e.yml@9e18c86aceccb709d40c6d9a1f19af5262c1a6e0 # main
     with:
       image: ghcr.io/projectbluefin/dakota:${{ needs.setup.outputs.sha }}


### PR DESCRIPTION
## Problem

The `e2e-gate` job had a job-level `permissions:` block alongside `uses:` (external reusable workflow call). This combination may cause GitHub to fail the workflow at startup with `startup_failure, jobs: []`.

The working local `e2e.yml` calls the same testsuite reusable workflow without job-level permissions and runs successfully. Matching that pattern.

- [ ] I am using an agent and I take responsibility for this PR