### PR TITLE
docs(skills): document publish.yml startup_failure root causes

### DIFF
--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -202,6 +202,32 @@ Re-enable with:
 gh api repos/projectbluefin/dakota/actions/workflows/<id>/enable --method PUT
 ```
 
+**Two confirmed causes of `startup_failure` with `jobs: []` (2026-06-04):**
+
+1. **Invalid top-level `permissions:` key** — `artifact-metadata: write` is NOT a
+   valid `GITHUB_TOKEN` permission scope. GitHub rejects the workflow at parse time
+   before creating any jobs. `actionlint` does not catch this. Remove it.
+   Valid scopes: `actions`, `checks`, `contents`, `deployments`, `discussions`,
+   `environments`, `id-token`, `issues`, `packages`, `pages`, `pull-requests`,
+   `repository-projects`, `security-events`, `statuses`, `attestations`.
+
+2. **Job-level `permissions:` on a reusable workflow call job** — adding a
+   `permissions:` block to a job that uses `uses:` (external reusable workflow)
+   can cause GitHub to fail the entire workflow at startup. The working pattern
+   (used by local `e2e.yml`) is to call the reusable workflow WITHOUT job-level
+   permissions; it inherits from the top-level `permissions:` block instead.
+
+**After fixing startup_failure, publish may still fail if no BST artifact is in
+CAS for the current main SHA.** This happens when `build.yml` has only run on
+branches (not main). Fix: dispatch `build.yml` on main first, wait for it to
+complete (~5–6 hours), then dispatch `publish.yml`.
+
+```bash
+gh workflow run build.yml --repo projectbluefin/dakota --ref main
+# wait for completion, then:
+gh workflow run publish.yml --repo projectbluefin/dakota
+```
+
 ### Dep updates on testing not reaching main (2026-06-04)
 
 When dep-update PRs are merged directly to `testing`, `publish.yml` (which


### PR DESCRIPTION
Documents two confirmed causes of `startup_failure, jobs: []` found during the May 30 factory restart:

1. Invalid permission scope (`artifact-metadata: write`) — not caught by actionlint
2. Job-level `permissions:` on a reusable workflow call job

Also documents the CAS miss failure and the fix sequence (dispatch build first).

- [ ] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced CI troubleshooting guide with expanded guidance for workflow configuration issues, including common causes of startup failures and resolution steps for artifact-related problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->