### PR TITLE
docs: document publish pipeline, stream model, and factory restart

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -14,7 +14,8 @@
 `build` success on main triggers publish.yml via `workflow_run`:
 
 ```
-setup → publish (matrix) → e2e-gate → promote
+build.yml (main) → [workflow_run] → publish.yml
+                                    setup → publish (matrix) → e2e-gate → promote
 ```
 
 | Job | What |
@@ -25,6 +26,12 @@ setup → publish (matrix) → e2e-gate → promote
 | `promote` | Re-tags `:$sha` → `:testing` after e2e passes — schedule/dispatch only |
 
 `:testing` is never published without a passing e2e smoke test.
+
+**Critical ordering:** `publish.yml` pulls the OCI artifact from CAS. The artifact
+is only in CAS if `build.yml` ran on `main` first. If `build.yml` has only run on
+feature branches, CAS will not have the artifact for main's SHA and publish will
+fail with `"No artifacts to stage"`. Always dispatch `build.yml --ref main` before
+manually dispatching `publish.yml`.
 
 ## Weekly promotion (weekly-testing-promotion.yml)
 
@@ -61,6 +68,59 @@ Streams:
 Build triggers: `merge_group`, `schedule`, `workflow_dispatch` — **not** `pull_request`.
 
 Never bypass the merge queue with `--admin`.
+
+## Manual stable promotion
+
+To manually cut a `:stable` and `:latest` release:
+
+```bash
+# 1. Ensure :testing exists and is healthy
+gh run list --repo projectbluefin/dakota --workflow publish.yml --limit 5
+
+# 2. Dispatch the weekly promotion workflow
+gh workflow run weekly-testing-promotion.yml \
+  --repo projectbluefin/dakota
+
+# 3. Two human approvals required via production environment gate
+# Approval URL: https://github.com/projectbluefin/dakota/deployments
+```
+
+## Restarting the factory (publish pipeline has been idle)
+
+When the publish pipeline has been paused intentionally (e.g., post-refactor),
+the restart sequence is:
+
+```bash
+# 1. Verify publish.yml is healthy — no startup_failure
+gh run list --repo projectbluefin/dakota --workflow publish.yml --limit 5
+
+# 2. Dispatch a fresh build on main to populate the CAS
+gh workflow run build.yml --repo projectbluefin/dakota --ref main
+# Wait ~60–90 minutes for build to complete
+
+# 3. Dispatch publish.yml after build finishes (or let workflow_run auto-trigger)
+gh workflow run publish.yml --repo projectbluefin/dakota --ref main
+
+# 4. Monitor until :testing lands
+gh run watch --repo projectbluefin/dakota
+
+# 5. Cut stable release (see Manual stable promotion above)
+```
+
+**Common failure: `startup_failure` with `jobs: []`**
+
+This means GitHub rejected the workflow YAML before creating any jobs — no logs
+are available. Root causes found in this repo:
+
+| Cause | Fix |
+|---|---|
+| `artifact-metadata: write` in `permissions:` block | Not a valid GITHUB_TOKEN scope; remove it |
+| Job-level `permissions:` on a reusable workflow call job | Remove the job-level block; let it inherit from top-level |
+
+Valid `GITHUB_TOKEN` permission scopes: `actions`, `attestations`, `checks`,
+`contents`, `deployments`, `discussions`, `environments`, `id-token`, `issues`,
+`packages`, `pages`, `pull-requests`, `repository-projects`, `security-events`,
+`statuses`. Any unknown scope causes `startup_failure`.
 
 ## e2e path filter
 

--- a/docs/skills/quickstart.md
+++ b/docs/skills/quickstart.md
@@ -102,3 +102,20 @@ If working through a backlog of issues, do not stop after the first fix. Work fr
 
 > Add entries here when you discover a new pattern or fix a recurring mistake.
 > Format: `### <pattern name> (YYYY-MM-DD)`
+
+### Restarting the publish factory after a pause (2026-06-05)
+
+When publishing has been intentionally paused (e.g., post-repo-refactor), the
+factory restart sequence is:
+
+1. Fix any `startup_failure` in `publish.yml` — check for invalid `permissions:` scopes
+   (e.g., `artifact-metadata: write` is not a valid GITHUB_TOKEN scope) and
+   job-level `permissions:` on reusable workflow call jobs.
+2. Dispatch `build.yml --ref main` to populate the remote CAS.
+3. Wait ~60–90 minutes for the build to complete.
+4. `publish.yml` auto-triggers via `workflow_run`. If not, dispatch manually.
+5. After `:testing` lands, dispatch `weekly-testing-promotion.yml` and get
+   2 human approvals at https://github.com/projectbluefin/dakota/deployments
+   to promote `:testing` → `:latest` + `:stable`.
+
+Full details: `docs/ci.md` → "Restarting the factory".

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -158,9 +158,56 @@ Copy `files/hive/hive-project.yaml.example` to `/etc/hive/hive-project.yaml` and
 
 **Hive exempt** (do not touch): `hold`, `do-not-merge`, `status/discussing`, `status/approved`, `queue/claimed`, `agent/blocked`, `needs-human/agent-oops`, `duplicate`, `wontfix`, `stale`
 
-## Links
+## Image stream and branch model
 
-- [BuildStream docs](https://docs.buildstream.build/)
+Dakota publishes three streams from the `main` branch:
+
+```
+main (source of truth)
+  │
+  └─► build.yml (nightly + merge_group)
+          │
+          └─► publish.yml (workflow_run)
+                  │
+                  ├─► :sha     — immutable per-build tag
+                  └─► :testing — promoted after e2e smoke passes
+                                       │
+                              weekly-testing-promotion.yml
+                              (Tuesday 06:00 UTC, 2 human approvals)
+                                       │
+                                       ├─► :latest
+                                       └─► :stable
+```
+
+| Stream | Tag | Cadence | Gate |
+|---|---|---|---|
+| Development | `:sha` | Every merge to `main` | None |
+| Testing | `:testing` | Nightly | e2e smoke |
+| Latest | `:latest` | Weekly | e2e full suite + 2 human approvals |
+| Stable | `:stable` | Weekly | Same as `:latest` |
+
+**`main` IS the testing branch.** There is no separate `testing` branch for
+code. Content merges to `main`; CI builds from `main`; `:testing` is the
+published nightly result.
+
+**Branch protection is only on `main`.** Required status checks: `validate` + `e2e`.
+
+### Branch flow for contributors
+
+```bash
+# Branch from upstream/main (never fork's local main)
+git checkout upstream/main -b feat/my-change
+
+# Work, validate, commit
+just validate
+git commit -m "feat(bluefin): ..."
+
+# Push and open PR against main
+git push upstream feat/my-change
+gh pr create --repo projectbluefin/dakota --base main
+```
+
+
 - [freedesktop-sdk](https://gitlab.com/freedesktop-sdk/freedesktop-sdk)
 - [gnome-build-meta](https://github.com/GNOME/gnome-build-meta) — branch `gnome-50`
 - [Dakota issues](https://github.com/projectbluefin/dakota/issues)


### PR DESCRIPTION
## Summary

Post-factory-restart documentation pass (2026-06-05 session).

### Changes

- **`docs/ci.md`**: Added `workflow_run` ordering requirement (must build main before publish), manual stable promotion steps, and factory restart sequence with startup_failure root causes and CAS miss fix
- **`docs/workflow.md`**: Added image stream/branch model section — documents main→testing→latest/stable flow, tag cadences, and contributor branch flow
- **`docs/skills/quickstart.md`**: Added factory restart lesson for agents

### Why

The publish pipeline was paused May 30 for the repo refactor. During restart we discovered:
1. Two causes of `startup_failure` with `jobs: []` (invalid permission scope + job-level perms on reusable workflow call)
2. `publish.yml` requires a prior `build.yml` run on `main` to populate CAS
3. No documentation existed for factory restart sequence or stream/branch model

This ensures any future agent or contributor has the full playbook.

---
- [x] I am using an agent and I take responsibility for this PR