### PR TITLE
docs(agents): document floating-tag pre-commit guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,8 @@ Non-compliance = automatic rejection.
 
 **Verification:** Every PR must confirm `just lint` passed and the image booted. Use `just boot-test` for automated pass/fail. No WIP PRs.
 
+**Pre-commit guard:** `no-floating-action-tags` blocks third-party `@main`/`@v*` floating action tags at commit time. `projectbluefin/` refs (`@v1`, `@main`) are intentional managed tags and are exempted.
+
 **Justfile integrity:** All maintenance tasks must be `just` recipes. No loose shell commands. If a task isn't covered by an existing recipe, add one alongside your change.
 
 **Human maintainability:** Every agent action must be replicable by a human via the Justfile. No AI-optimized black boxes. Do not rename existing recipes without explicit human approval.


### PR DESCRIPTION
## Summary
- document the new no-floating-action-tags pre-commit guard in AGENTS.md
- clarify the projectbluefin/actions managed-tag exemption

## Testing
- not run (docs-only change)