### PR TITLE
docs: reinforce dakota build boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Dakota is a [BuildStream 2](https://buildstream.build/) project producing **Bluefin** — a bootc OCI desktop image built from source. No RPMs. No dnf. BST elements only. Load [`docs/skills/not-bluefin.md`](docs/skills/not-bluefin.md) FIRST if you have any bluefin context.
+Dakota is a [BuildStream 2](https://buildstream.build/) project producing **Dakota** — Project Bluefin's bootc OCI desktop image built from source. No RPMs. No dnf. No Containerfile package overlays. BST elements only. Historical `bluefin/` paths in this repo are Dakota build paths, not permission to use bluefin's dnf/RPM workflow. Load [`docs/skills/not-bluefin.md`](docs/skills/not-bluefin.md) FIRST if you have any bluefin context.
 
 Load **[docs/SKILL.md](docs/SKILL.md)** for the full reference skill tree. Only load docs relevant to your task.
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,3 +1,6 @@
+# Lint helper only for an already-built Dakota image.
+# Do not add package installation or overlay logic here; Dakota image contents
+# come from BuildStream elements and OCI assembly `.bst` files.
 FROM ghcr.io/projectbluefin/dakota:latest
 
 RUN bootc container lint || true

--- a/Justfile
+++ b/Justfile
@@ -203,7 +203,9 @@ clean:
     rm -f bootable.raw .ovmf-vars.fd
     rm -rf .build-out
 
-# ── Containerfile build (alternative) ────────────────────────────────
+# ── Containerfile build (lint helper only) ───────────────────────────
+# This is not Dakota's package assembly path.
+# Real image content changes happen in BuildStream elements and `just build`.
 [group('build')]
 build-containerfile $image_name=image_name:
     sudo podman build --security-opt label=type:unconfined_t --squash-all -t "${image_name}:latest" .

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -2,13 +2,15 @@
 
 Agent entry point. Load only the skill for your current task — do not load everything.
 
+If your first draft says "use dnf/RPM/COPR" or "edit the Containerfile to add a package", stop and reload `docs/skills/not-bluefin.md`. Dakota image changes happen in `.bst` elements and `elements/bluefin/deps.bst`, even though those paths still say `bluefin`.
+
 ## Task → Skill
 
 | I need to... | Load |
 |---|---|
-| **Load the dakota build context first** | **⚠️ REQUIRED FIRST — `docs/skills/not-bluefin.md` before any other skill, especially if you have bluefin context** |
+| **Load the dakota build context first** | **⚠️ REQUIRED FIRST — `docs/skills/not-bluefin.md` before any other skill, especially if you have bluefin context. If your plan mentions dnf/RPM/Containerfile overlays, reload it and translate the task into BST terms first.** |
 | Review a pull request | `docs/workflow.md` + `docs/pr-checklist.md` |
-| Add a package to Bluefin | `docs/skills/add-package.md` |
+| Add a package to Dakota | `docs/skills/add-package.md` |
 | Remove a package | `docs/skills/remove-package.md` |
 | Update a package version | `docs/skills/update-refs.md` |
 | Understand BST element syntax | `docs/skills/buildstream.md` |

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -3,6 +3,8 @@
 Accumulated lessons from real work on this repo. Every agent working here
 should read the relevant file before starting in that area.
 
+If your first instinct is `dnf`, RPM/COPR, or a Containerfile package layer, you are in the wrong mental model. In this repo, historical `bluefin/` paths still contain Dakota's BuildStream elements; package changes happen there, not in Containerfile overlays.
+
 When you discover a new pattern or fix a recurring mistake, add it here in the
 same PR as your change. This is the feedback loop: lessons land here and help
 every future agent and contributor — not just you, and not just on one machine.
@@ -11,7 +13,7 @@ every future agent and contributor — not just you, and not just on one machine
 
 | Task | Load |
 |------|------|
-| **Load the dakota build context first** | **⚠️ REQUIRED FIRST — [`not-bluefin.md`](not-bluefin.md) before any other skill, especially if you have bluefin context** |
+| **Load the dakota build context first** | **⚠️ REQUIRED FIRST — [`not-bluefin.md`](not-bluefin.md) before any other skill, especially if you have bluefin context. If your plan mentions dnf/RPM/Containerfile overlays, reload it and translate the task into BST terms first.** |
 | Zero-context routine maintenance | [`quickstart.md`](quickstart.md) |
 | Adding a package | [`add-package.md`](add-package.md) |
 | Removing a package | [`remove-package.md`](remove-package.md) |
@@ -31,7 +33,7 @@ every future agent and contributor — not just you, and not just on one machine
 | Manual promotion (testing → stable) and release | [`ci.md`](ci.md) — *Manual stable promotion flow* |
 | Clearing stuck merge queue | [`merge-queue.md`](merge-queue.md) |
 | Actionadon lifecycle, issue queue, data donation | [`actionadon.md`](actionadon.md) |
-| Project overview and what Bluefin is | [`overview.md`](overview.md) |
+| Project overview and what Dakota is | [`overview.md`](overview.md) |
 | ujust recipes in `files/just-overrides/` | [`.github/skills/ujust-recipes.md`](../../.github/skills/ujust-recipes.md) |
 | Installer (bootc-installer) | [`installer.md`](installer.md) |
 | Merging dep-update PRs into testing | [`merge-queue.md`](merge-queue.md) |
@@ -58,4 +60,3 @@ relevant skill file in this directory — in the same PR as your change.
 
 - Role policies for Hive agents: [`../../files/hive/agent-policies/`](../../files/hive/agent-policies/)
 - Top-level agent rules: [`../../AGENTS.md`](../../AGENTS.md)
-

--- a/docs/skills/add-package.md
+++ b/docs/skills/add-package.md
@@ -1,6 +1,6 @@
 # Adding a Package
 
-Entry-point workflow for adding any software package to the Bluefin image.
+Entry-point workflow for adding any software package to the Dakota image.
 
 ## When NOT to Use
 
@@ -19,6 +19,11 @@ cp elements/bluefin/glow.bst elements/bluefin/<name>.bst
 ```
 
 There are no scaffold scripts. Copy an existing element of the appropriate kind as a starting point.
+
+**Historical path note:** new Dakota packages still live under
+`elements/bluefin/` and are added to `elements/bluefin/deps.bst`. That path
+name is historical only — do not translate package work into dnf, RPM, or
+Containerfile-overlay steps.
 
 ## Choose Element Kind
 
@@ -80,6 +85,7 @@ install-commands:
 | `EnvironmentFile=/etc/default/...` | GNOME OS doesn't use `/etc/default/`; remove from upstream service files |
 | Variables in source URLs | BuildStream doesn't support this; use literal URLs with aliases |
 | Missing `%{install-extra}` | Must be last install-command |
+| Trying to add the package in `Containerfile`/`Justfile` | Package and image-content changes belong in `.bst` elements plus `deps.bst` |
 | Forgot to add element to `deps.bst` | Element builds but won't be in the image |
 | Wrong dependency stack | Use `freedesktop-sdk.bst:public-stacks/runtime-minimal.bst` for runtime deps |
 

--- a/docs/skills/not-bluefin.md
+++ b/docs/skills/not-bluefin.md
@@ -23,6 +23,20 @@
 - **Upstream junctions**: `freedesktop-sdk.bst` and `gnome-build-meta.bst` provide most packages
 - **OCI assembly**: A `Containerfile` exists for final image assembly only — not for package installation
 
+## Historical name trap: `bluefin/` paths still mean Dakota
+
+- `elements/bluefin/*.bst`, `elements/bluefin/deps.bst`, `elements/oci/bluefin.bst`, and `elements/oci/layers/bluefin.bst` are Dakota's main build paths.
+- Those names are historical carry-over from the broader Bluefin project. They do **not** mean "use the bluefin repo workflow" or "install packages with dnf in a Containerfile."
+
+## Translate the request before acting
+
+| If someone asks for... | In Dakota, do this |
+|---|---|
+| "Add/remove a package" | Add/remove a `.bst` element and wire/unwire it in `elements/bluefin/deps.bst` |
+| "Enable a service by default" | Ship the unit/preset from a `.bst` element |
+| "Change what ends up in the image" | Edit BST elements or `elements/oci/*`, not the repo `Containerfile` |
+| "Enable a COPR / add an RPM repo" | Stop — Dakota has no COPR/RPM repo layer; package the software in BST terms |
+
 ## Adding a package to dakota
 
 See `docs/skills/add-package.md`. Never reach for `dnf5`.
@@ -31,6 +45,25 @@ See `docs/skills/add-package.md`. Never reach for `dnf5`.
 
 Dakota has a `Containerfile` for final OCI image assembly (copying BST artifacts into the image). It does NOT install packages. Do not add `RUN dnf5 install` to it.
 
+## Common file traps
+
+| File / path | What it actually is | What it is **not** |
+|---|---|---|
+| `Containerfile` | Local bootc lint helper for an already-built Dakota image | A package overlay or install stage |
+| `Justfile` `build-containerfile` recipe | Convenience wrapper around that lint helper | The primary image build path |
+| `elements/bluefin/deps.bst` | Dakota's package manifest | An RPM package list |
+| `elements/oci/bluefin.bst` | Final BuildStream OCI assembly step | A signal to switch to bluefin repo habits |
+
 ## The Justfile is NOT the same as bluefin's
 
 Dakota's `Justfile` has different semantics. `just lint` validates BST templates. There is no `just check` equivalent.
+
+## Lessons Learned
+
+### Historical bluefin path names are not workflow cues (2026-06-04)
+
+Dakota still uses `bluefin` in several path names (`elements/bluefin/*`,
+`oci/bluefin.bst`), which repeatedly causes agents to drift into dnf/RPM or
+Containerfile-overlay assumptions. Treat those names as repo history only.
+Actual Dakota image changes still happen in BuildStream elements, dependency
+stacks, and OCI assembly elements.

--- a/docs/skills/oci-layers.md
+++ b/docs/skills/oci-layers.md
@@ -23,6 +23,10 @@ elements/oci/bluefin.bst            ← kind: script (final OCI assembly)
   └── runs: build-oci script to assemble the image
 ```
 
+Historical path note: the `bluefin` filenames above are Dakota's OCI assembly
+paths. They are not a sign to switch to the separate bluefin repo's
+Containerfile-overlay workflow.
+
 ## Critical: `kind: compose` vs `kind: stack`
 
 **This is the most common layer bug:**
@@ -47,7 +51,7 @@ grep "^kind:" elements/oci/layers/bluefin.bst
 
 ```yaml
 kind: compose
-description: Bluefin image layer
+description: Dakota image layer (historical bluefin path name)
 depends:
 - deps.bst
 - filename: freedesktop-sdk.bst:elements/base/base.bst

--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -41,6 +41,10 @@ freedesktop-sdk provides glibc/systemd/kernel, gnome-build-meta provides GNOME S
 
 Published image: `ghcr.io/projectbluefin/dakota:{testing,latest,stable}`
 
+**Historical path note:** the repo still uses `bluefin` in key filenames such as
+`elements/bluefin/*` and `oci/bluefin.bst`. Those are Dakota paths, not proof
+that Dakota follows bluefin's dnf/Containerfile overlay model.
+
 ## Architecture Comparison
 
 | Dimension | **Dakota** | **bluefin** | **bluefin-lts** |

--- a/docs/skills/quickstart.md
+++ b/docs/skills/quickstart.md
@@ -2,6 +2,10 @@
 
 Zero-context entry point for routine dakota maintenance — add package, remove package, update refs.
 
+Historical path note: `elements/bluefin/*` is Dakota's package tree. The name
+is legacy. Do not use it as a cue to reach for dnf, RPM/COPR, or Containerfile
+overlay workflows.
+
 ## 5 Always Rules
 
 1. **Always run `just --list` first** — the Justfile is the ground truth for available recipes
@@ -10,13 +14,14 @@ Zero-context entry point for routine dakota maintenance — add package, remove 
 4. **Always grep for all references before removing** — `grep -r <name> elements/ .github/workflows/ files/`
 5. **Always use `just bst` not bare `bst`** — BST must run inside the pinned container
 
-## 5 Never Rules
+## 6 Never Rules
 
 1. **Never edit** `elements/freedesktop-sdk.bst` or `elements/gnome-build-meta.bst` without human review
 2. **Never open a PR** to `projectbluefin/dakota` without running `just validate` first
 3. **Never add Renovate entries** for elements already in the `track-tarballs` CI job — causes racing PRs
 4. **Never call `bst` directly** — always `just bst ...`
 5. **Never skip `just validate`** even if `just bst build` "looks right"
+6. **Never solve package/image-content changes in `Containerfile`** — those belong in `.bst` elements and `elements/bluefin/deps.bst`
 
 ## Task Routing
 

--- a/docs/skills/remove-package.md
+++ b/docs/skills/remove-package.md
@@ -1,6 +1,6 @@
 # Removing a Package
 
-Load when removing a software package from the Bluefin image in `projectbluefin/dakota`.
+Load when removing a software package from the Dakota image in `projectbluefin/dakota`.
 
 ## When NOT to Use
 
@@ -11,6 +11,11 @@ Load when removing a software package from the Bluefin image in `projectbluefin/
 ## Quick Start
 
 There is no `just remove-package` recipe. Remove packages manually using the checklist below.
+
+**Historical path note:** packages still live under `elements/bluefin/` because
+of repo history. Treat that as a path name only — removing software from Dakota
+means editing BST elements and dependency stacks, not Containerfile or RPM
+metadata.
 
 ## What to Remove
 

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -1,3 +1,6 @@
+# Historical path note: despite the directory name, this is Dakota's package
+# manifest. Add or remove image content via `.bst` elements here — never via
+# dnf/RPM/Containerfile overlay logic.
 kind: stack
 
 depends:


### PR DESCRIPTION
## What changed
- Reinforce Dakota != Bluefin boundaries at the main entrypoints and common confusion points
- Update matching docs/skills alongside the inline guardrails

## Validation
- Ran the repo-appropriate existing validation commands locally for this change set