### PR TITLE
ci: align weekly promotion pipeline to spec (#520 #521 #522 #524)

### DIFF
--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -2,7 +2,7 @@ name: Weekly Testing Promotion
 
 on:
   schedule:
-    - cron: '0 6 * * 0' # Sunday 06:00 UTC
+    - cron: '0 6 * * 2' # Tuesday 06:00 UTC
   workflow_dispatch:
 
 concurrency:
@@ -21,6 +21,7 @@ jobs:
     timeout-minutes: 15
     outputs:
       source_sha: ${{ steps.verify.outputs.source_sha }}
+      locked_sha: ${{ steps.lock-sha.outputs.locked_sha }}
       default_digest: ${{ steps.resolve-default.outputs.digest }}
       nvidia_digest: ${{ steps.resolve-nvidia.outputs.digest }}
       has_nvidia: ${{ steps.resolve-nvidia.outputs.found }}
@@ -88,6 +89,16 @@ jobs:
           echo "source_sha=$DEFAULT_SHA" >> "$GITHUB_OUTPUT"
           echo "Source SHA: $DEFAULT_SHA (both variants match)"
 
+      - name: Lock source SHA for TOCTOU guard
+        id: lock-sha
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          SHA=$(gh api repos/${{ github.repository }}/git/ref/heads/main --jq '.object.sha')
+          echo "locked_sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Locked main SHA: $SHA"
+
   # ── Check diff — skip if already promoted ────────────────────────────────
   check-diff:
     needs: [resolve]
@@ -121,11 +132,78 @@ jobs:
           echo "has_diff=true" >> "$GITHUB_OUTPUT"
           echo "Promotion needed: :testing differs from :latest"
 
+  # ── Verify cosign signatures ─────────────────────────────────────────────
+  verify-signatures:
+    needs: [resolve, check-diff]
+    if: needs.check-diff.outputs.has_diff == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Install cosign
+        run: |
+          if ! command -v cosign &>/dev/null; then
+            COSIGN_VERSION="v2.5.0"
+            curl -fsSL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" \
+              -o /usr/local/bin/cosign
+            chmod +x /usr/local/bin/cosign
+          fi
+
+      - name: Verify signatures for all promoted variants
+        env:
+          DEFAULT_DIGEST: ${{ needs.resolve.outputs.default_digest }}
+          NVIDIA_DIGEST: ${{ needs.resolve.outputs.nvidia_digest }}
+          HAS_NVIDIA: ${{ needs.resolve.outputs.has_nvidia }}
+        run: |
+          set -euo pipefail
+          REGISTRY="ghcr.io/${{ github.repository_owner }}"
+          FAILED=0
+
+          verify_digest() {
+            local image_ref="$1"
+            echo "Verifying signature: ${image_ref}"
+            if ! cosign verify \
+              --certificate-identity-regexp "https://github.com/${{ github.repository }}/.github/workflows/" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              "${image_ref}" 2>/dev/null; then
+              echo "::error::Signature verification FAILED for ${image_ref}"
+              return 1
+            fi
+            echo "  ✅ Signature verified: ${image_ref}"
+          }
+
+          verify_digest "${REGISTRY}/dakota@${DEFAULT_DIGEST}" || FAILED=$((FAILED + 1))
+
+          if [ "${HAS_NVIDIA}" = "true" ] && [ -n "${NVIDIA_DIGEST}" ]; then
+            verify_digest "${REGISTRY}/dakota-nvidia@${NVIDIA_DIGEST}" || FAILED=$((FAILED + 1))
+          fi
+
+          if [ "${FAILED}" -gt 0 ]; then
+            echo "::error::${FAILED} image(s) failed signature verification — aborting promotion"
+            exit 1
+          fi
+          echo "✅ All signatures verified — proceeding with promotion"
+
+  # ── Full e2e gate at weekly promotion time ────────────────────────────────
+  e2e:
+    needs: [resolve, check-diff]
+    if: needs.check-diff.outputs.has_diff == 'true'
+    permissions:
+      packages: write
+      contents: read
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@e1c00af3b85513b51f9441a02ce239e231c26e8c # main
+    with:
+      image: ghcr.io/${{ github.repository_owner }}/dakota@${{ needs.resolve.outputs.default_digest }}
+      suites: smoke,common
+
+
   # ── Promote :testing → :latest + :stable ────────────────────────────────
   promote:
     environment: production
-    needs: [resolve, check-diff]
-    if: needs.check-diff.outputs.has_diff == 'true'
+    needs: [resolve, check-diff, verify-signatures, e2e]
+    if: >-
+      needs.check-diff.outputs.has_diff == 'true' &&
+      needs.verify-signatures.result == 'success' &&
+      needs.e2e.result == 'success'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
@@ -155,18 +233,40 @@ jobs:
         run: |
           echo "$GH_TOKEN" | sudo podman login ghcr.io --username "$GH_ACTOR" --password-stdin
 
+      - name: Verify source SHA has not advanced
+        env:
+          LOCKED_SHA: ${{ needs.resolve.outputs.locked_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          CURRENT_SHA=$(gh api repos/${{ github.repository }}/git/ref/heads/main --jq '.object.sha')
+          if [ "$CURRENT_SHA" != "$LOCKED_SHA" ]; then
+            echo "ERROR: main advanced during promotion ($LOCKED_SHA → $CURRENT_SHA). Aborting."
+            echo "Untested commits would reach latest/stable. Rerun next cycle."
+            exit 1
+          fi
+          echo "✅ SHA unchanged: $CURRENT_SHA"
+
       - name: Promote to :latest and :stable
         env:
           SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+          DEFAULT_DIGEST: ${{ needs.resolve.outputs.default_digest }}
+          NVIDIA_DIGEST: ${{ needs.resolve.outputs.nvidia_digest }}
         run: |
           set -euo pipefail
           IMAGE="ghcr.io/${{ github.repository_owner }}/dakota${{ matrix.image_suffix }}"
 
-          # Pull the :testing image (already digest-verified in resolve job)
-          sudo podman pull "${IMAGE}:testing"
+          # Use resolved digest directly — prevents TOCTOU tag re-pull race
+          if [ "${{ matrix.variant }}" = "nvidia" ]; then
+            DIGEST="$NVIDIA_DIGEST"
+          else
+            DIGEST="$DEFAULT_DIGEST"
+          fi
+
+          sudo podman pull "${IMAGE}@${DIGEST}"
 
           # Tag and push as :latest
-          sudo podman tag "${IMAGE}:testing" "${IMAGE}:latest"
+          sudo podman tag "${IMAGE}@${DIGEST}" "${IMAGE}:latest"
           PUSH_OK=false
           for attempt in 1 2 3; do
             sudo podman push --compression-format=zstd "${IMAGE}:latest" && { PUSH_OK=true; break; }
@@ -176,7 +276,7 @@ jobs:
           $PUSH_OK || { echo "ERROR: all push attempts failed for :latest"; exit 1; }
 
           # Tag and push as :stable
-          sudo podman tag "${IMAGE}:testing" "${IMAGE}:stable"
+          sudo podman tag "${IMAGE}@${DIGEST}" "${IMAGE}:stable"
           PUSH_OK=false
           for attempt in 1 2 3; do
             sudo podman push --compression-format=zstd "${IMAGE}:stable" && { PUSH_OK=true; break; }
@@ -185,7 +285,8 @@ jobs:
           done
           $PUSH_OK || { echo "ERROR: all push attempts failed for :stable"; exit 1; }
 
-          echo "Promoted ${IMAGE}:testing → :latest + :stable (source SHA: $SOURCE_SHA)"
+          echo "Promoted ${IMAGE}@${DIGEST} → :latest + :stable (source SHA: $SOURCE_SHA)"
+
 
   # ── Fast-forward branches ────────────────────────────────────────────────
   update-branches:

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -89,15 +89,23 @@ jobs:
           echo "source_sha=$DEFAULT_SHA" >> "$GITHUB_OUTPUT"
           echo "Source SHA: $DEFAULT_SHA (both variants match)"
 
-      - name: Lock source SHA for TOCTOU guard
+      - name: Lock tested source SHA for TOCTOU guard
         id: lock-sha
         env:
+          SOURCE_SHA: ${{ steps.verify.outputs.source_sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          SHA=$(gh api repos/${{ github.repository }}/git/ref/heads/main --jq '.object.sha')
-          echo "locked_sha=$SHA" >> "$GITHUB_OUTPUT"
-          echo "Locked main SHA: $SHA"
+          CURRENT_SHA=$(gh api repos/${{ github.repository }}/git/ref/heads/main --jq '.object.sha')
+          if [[ "${CURRENT_SHA}" != "${SOURCE_SHA}" ]]; then
+            echo "::error::main has advanced since :testing was built."
+            echo "  Built from: ${SOURCE_SHA}"
+            echo "  Current:    ${CURRENT_SHA}"
+            echo "Aborting promotion — re-run after the next testing build completes."
+            exit 1
+          fi
+          echo "locked_sha=${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Locked main SHA: ${SOURCE_SHA} (matches tested source)"
 
   # ── Check diff — skip if already promoted ────────────────────────────────
   check-diff:
@@ -144,8 +152,8 @@ jobs:
           if ! command -v cosign &>/dev/null; then
             COSIGN_VERSION="v2.5.0"
             curl -fsSL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" \
-              -o /usr/local/bin/cosign
-            chmod +x /usr/local/bin/cosign
+              -o "$RUNNER_TEMP/cosign"
+            sudo install -m 0755 "$RUNNER_TEMP/cosign" /usr/local/bin/cosign
           fi
 
       - name: Verify signatures for all promoted variants
@@ -162,7 +170,7 @@ jobs:
             local image_ref="$1"
             echo "Verifying signature: ${image_ref}"
             if ! cosign verify \
-              --certificate-identity-regexp "https://github.com/${{ github.repository }}/.github/workflows/" \
+              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/publish\\.yml@refs/heads/(main|gh-readonly-queue/main/.+)$" \
               --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
               "${image_ref}" 2>/dev/null; then
               echo "::error::Signature verification FAILED for ${image_ref}"


### PR DESCRIPTION
## Summary

Implements four sub-issues from the promotion pipeline consistency epic ([common#516](https://github.com/projectbluefin/common/issues/516)). All changes target `.github/workflows/weekly-testing-promotion.yml`.

### #520 — Align cron to Tuesday

Changes `0 6 * * 0` (Sunday) → `0 6 * * 2` (Tuesday 06:00 UTC) so all three image repos promote on the same day.

### #521 — Cosign verify before promotion

Adds a `verify-signatures` job that runs after `check-diff` (when there's a diff to promote). It cosign-verifies both the default and NVIDIA :testing digests using Sigstore OIDC. Promotion is blocked if any flavor fails verification.

### #522 — Full e2e suite at weekly promotion time

Adds an `e2e` job that runs `smoke,common` suites against the resolved `@digest` before the `promote` job can start. Promotion only proceeds if e2e passes.

### #524 — TOCTOU SHA guard

Locks the `main` HEAD SHA in the `resolve` job. The `promote` job re-verifies that SHA has not advanced before executing the final `skopeo copy`. Untested commits cannot reach `:latest`/`:stable` if a push lands during e2e.

Also: switches the promote step from `:testing` tag re-pull to digest-based pull (`@${DIGEST}`) to eliminate the TOCTOU tag substitution window.

## Refs

- Closes projectbluefin/common#520
- Closes projectbluefin/common#521
- Closes projectbluefin/common#522
- Closes projectbluefin/common#524 (dakota portion)
- Part of projectbluefin/common#516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Weekly release promotion now runs on Tuesdays.
  * Added signature verification and end-to-end testing gates before image promotion to enhance safety.
  * Pre-promotion validation prevents promotion if main has advanced since locking.
  * Promotions now pull and retag images by resolved digest and report promoted image digests in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->