### PR TITLE
docs: complete skill audit — frontmatter, correctness fixes, real lessons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,14 @@ Agent works on task
 - Obvious things any developer would know
 - Ephemeral state ("currently broken, fix pending")
 
+### Where learnings live
+
+| You are working in... | Write to |
+|---|---|
+| `projectbluefin/dakota` | That repo's `docs/skills/` — create if absent |
+| Cross-cutting (affects multiple repos) | Local first, then open propagation issue in `projectbluefin/actions` |
+| `ublue-os/*` repos | **NEVER write to these repos** — no issues, PRs, comments, forks, webhooks, or automated reports. Tell the human to report manually. |
+
 ---
 
 ## Data donation

--- a/docs/skills/actionadon.md
+++ b/docs/skills/actionadon.md
@@ -1,3 +1,8 @@
+---
+name: actionadon
+description: Dakota issue lifecycle — Actionadon pipeline stages, data donation contract, pipeline widget sentinel rules, and slash commands. Load when working on any GitHub issue, triaging bugs, or processing the contribution queue.
+---
+
 # Actionadon Lifecycle and Data Donation
 
 Load when working on any GitHub issue in this repo, triaging bugs, processing the queue, or touching `.github/workflows/actionadon.yml`.

--- a/docs/skills/add-package.md
+++ b/docs/skills/add-package.md
@@ -1,3 +1,8 @@
+---
+name: add-package
+description: End-to-end workflow for adding a new software package to the Dakota image. Covers element creation, deps.bst wiring, systemd service installation, and common mistakes. Load for any "add package to Dakota" task.
+---
+
 # Adding a Package
 
 Entry-point workflow for adding any software package to the Dakota image.

--- a/docs/skills/bst-overrides.md
+++ b/docs/skills/bst-overrides.md
@@ -1,3 +1,8 @@
+---
+name: bst-overrides
+description: Governs when and how to create junction overrides in dakota. Upstream-first principle — local overrides are last resort. Covers patch_queue overrides, exit conditions, and how to evaluate whether an override is justified.
+---
+
 # BST Junction Overrides
 
 Load when creating, evaluating, or removing BuildStream junction element overrides in `projectbluefin/dakota`.
@@ -72,5 +77,40 @@ gh api repos/freedesktop-sdk/freedesktop-sdk/releases/latest | jq '.tag_name'
 
 ## Lessons Learned
 
-> Add entries here when you discover a new pattern or fix a recurring mistake.
-> Format: `### <pattern name> (YYYY-MM-DD)`
+### Alphabetical patch ordering matters — 0004 is higher priority than 0003 (2026-06-07)
+
+Patch files in `patches/<junction>/` apply in alphabetical (filename) order. Gaps in numbering
+are intentional — they leave room to insert patches between existing ones without renaming. Do
+not fill gaps just to make the sequence look clean:
+
+```
+patches/freedesktop-sdk/
+  0001-project-Specify-more-limits-to-the-CAS-configs.patch
+  0002-project.conf-Add-GNOME-CAS-servers.patch
+  0004-openssh-Use-etc-ssh-as-sysconfdir.patch   ← gap is intentional
+  0005-openssh-Include-ssh-_config.d-.conf.patch
+```
+
+When inserting a new patch between 0004 and 0005, name it `0004b-...` or `0004c-...` so the
+alphabetical order is preserved without renaming `0005+`.
+
+### `gnome-build-meta` currently has only one patch — it's not a typo (2026-06-07)
+
+`patches/gnome-build-meta/disable-lorry-mirrors.patch` is the only GBM patch. Dakota tracks
+the most recent GBM ref (latest nightly), which means most fixes are already upstream. The
+single-patch state is healthy — it means minimal maintenance debt.
+
+### Verify upstream before adding a patch (2026-06-07)
+
+Before adding a new patch to `patches/<junction>/`:
+```bash
+# Check if fdsdk already has the fix on their latest tag:
+gh api repos/freedesktop-sdk/freedesktop-sdk/releases/latest | jq '.tag_name'
+
+# Check if GBM gnome-50 already has the fix:
+git -C ~/.cache/buildstream/sources/git_repo/<gbm-mirror>.git \
+  log --oneline origin/gnome-50 | head -20
+```
+
+Adding a patch for something already upstream wastes maintenance cycles — junction bump is
+cheaper.

--- a/docs/skills/buildstream.md
+++ b/docs/skills/buildstream.md
@@ -1,3 +1,8 @@
+---
+name: buildstream-reference
+description: Reference for BuildStream 2 element syntax, variables, kinds, source kinds, and command hooks. Load when writing or reviewing .bst element files, not for end-to-end packaging workflows (use add-package.md for that).
+---
+
 # BuildStream Element Reference
 
 Load when writing, editing, or reviewing BuildStream `.bst` element files.

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -1,3 +1,8 @@
+---
+name: ci
+description: Dakota CI pipeline reference. Covers workflow files, trigger behavior, remote cache architecture, common failures, and promotion flow. Load when debugging CI failures, understanding why a build was or wasn't triggered, or running a manual promotion.
+---
+
 # CI Pipeline Operations
 
 Load when debugging CI failures, understanding the build pipeline, or working with the remote CAS cache.
@@ -174,9 +179,6 @@ gh run list --repo projectbluefin/dakota --limit 5
 | `update-refs.md` | Understanding the source tracking workflow |
 
 ## Lessons Learned
-
-> Add entries here when you discover a new pattern or fix a recurring mistake.
-> Format: `### <pattern name> (YYYY-MM-DD)`
 
 ### publish.yml startup_failure = :testing is stale (2026-06-04)
 

--- a/docs/skills/debugging.md
+++ b/docs/skills/debugging.md
@@ -1,3 +1,8 @@
+---
+name: debugging
+description: Diagnoses BST element build failures, YAML errors, source fetch failures, compile failures, and image build failures. Load when a `just bst build` fails or when reading CI build logs.
+---
+
 # Debugging Build Failures
 
 Load when a BST element build fails, or when diagnosing element errors from CI logs.

--- a/docs/skills/installer.md
+++ b/docs/skills/installer.md
@@ -1,3 +1,8 @@
+---
+name: installer
+description: bootc-installer (GTK4/Adwaita Flatpak) for Dakota. Covers two-component architecture (Python GUI + Go fisherman backend), dev setup, demo mode, and the dakota/dakota-iso boundary. Load when working on installer UI, recipe, or firstboot installer-cleanup behavior.
+---
+
 # Installer (bootc-installer)
 
 Load when working on the Bluefin Dakota installer or debugging ISO installer integration.

--- a/docs/skills/local-ota.md
+++ b/docs/skills/local-ota.md
@@ -1,3 +1,8 @@
+---
+name: local-ota
+description: Tests bootc upgrades via a local zot registry — QEMU VM or physical hardware. Covers registry setup, insecure registry configuration, and the build-push-upgrade loop. Load when validating image changes without pushing to GHCR.
+---
+
 # Local & Hardware OTA Testing
 
 Load when testing bootc upgrades via a local registry — QEMU VM or physical hardware.

--- a/docs/skills/merge-queue.md
+++ b/docs/skills/merge-queue.md
@@ -1,3 +1,8 @@
+---
+name: merge-queue
+description: Clears stuck dependency-update PRs, rebases chore branches against main, and handles fork PRs. Covers rebase loops, merge command, e2e retrigger, and cross-repository PR handling. Load when PRs are stuck, conflicting, or blocked.
+---
+
 # Merge Queue Operations
 
 ## When to Load

--- a/docs/skills/not-bluefin.md
+++ b/docs/skills/not-bluefin.md
@@ -1,3 +1,8 @@
+---
+name: not-bluefin
+description: Translates bluefin/RPM/dnf mental model to dakota BuildStream reality. Load FIRST on any dakota task if you have bluefin context, or if your plan mentions dnf, RPM, COPR, or Containerfile package layers.
+---
+
 # NOT Bluefin — Dakota Build Context
 
 **Load this skill FIRST before any dakota task.** Dakota is fundamentally different from bluefin.

--- a/docs/skills/oci-layers.md
+++ b/docs/skills/oci-layers.md
@@ -1,3 +1,8 @@
+---
+name: oci-layers
+description: Explains how packages flow from BST elements into the final OCI image layer. Covers compose vs stack kinds, BST weak-key caching bug, and layer verification. Load when packages go missing from the built image or when modifying layer assembly.
+---
+
 # OCI Layers and Image Assembly
 
 Load when understanding how packages flow into the final OCI image, modifying layer assembly, or debugging why files appear or are missing from the built image.

--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -1,3 +1,8 @@
+---
+name: dakota-overview
+description: Provides context on what Dakota is, how it differs from bluefin/bluefin-lts, current package gaps, and build optimization notes. Load when planning new package additions or when someone asks what Dakota is.
+---
+
 # Dakota Overview
 
 Load when you need context on what dakota is, how it differs from production Bluefin, what unique features it has, or when planning new package additions.

--- a/docs/skills/packaging-binaries.md
+++ b/docs/skills/packaging-binaries.md
@@ -1,3 +1,8 @@
+---
+name: packaging-binaries
+description: Packages a project using official pre-built static binaries (GitHub Releases). Use when upstream provides release binaries and building from source is unnecessary. Covers arch-conditional sources, kind:remote with filename, and strip-binaries placement.
+---
+
 # Packaging Pre-Built Binaries
 
 Load when packaging a project that provides official pre-built static binaries (GitHub Releases, official downloads), or when building from source is impractical.
@@ -25,11 +30,7 @@ depends:
 
 variables:
   version: '1.2.3'
-
-public:
-  bst:
-    # Required for non-ELF elements (or elements with pre-built binaries)
-    strip-binaries: ""
+  strip-binaries: ""   # required — pre-built binaries are already stripped
 
 sources:
 - kind: tar
@@ -103,5 +104,73 @@ url: releases:owner/project/releases/download/v%{version}/binary.tar.gz
 
 ## Lessons Learned
 
-> Add entries here when you discover a new pattern or fix a recurring mistake.
-> Format: `### <pattern name> (YYYY-MM-DD)`
+### `strip-binaries: ""` belongs under `variables:`, not `public: bst:` (2026-06-07)
+
+Real elements (`tailscale.bst`, `glow.bst`, `gum.bst`, `fzf.bst`, `tealdeer.bst`) all declare
+`strip-binaries: ""` under `variables:`. `public: bst:` is for `overlap-whitelist` entries only.
+Placing `strip-binaries` under `public: bst:` causes a YAML error at element parse time.
+
+```yaml
+# ✅ correct
+variables:
+  strip-binaries: ""
+
+# ❌ wrong — YAML parse error
+public:
+  bst:
+    strip-binaries: ""
+```
+
+### `base-dir: ""` required when tarball has no wrapping directory (2026-06-07)
+
+Some projects (e.g., `fzf`) release tarballs where the binary sits at the archive root with no
+wrapping directory. Without `base-dir: ""`, BST expects a top-level directory and fails. Example
+from `fzf.bst`:
+
+```yaml
+sources:
+- kind: tar
+  base-dir: ""
+  url: github_files:junegunn/fzf/releases/download/v0.73.1/fzf-0.73.1-linux_amd64.tar.gz
+  ref: f3252c2c366bc1700d3c85781ec8c9695998927ac127870eb049ceea2d540f8a
+```
+
+### Multiple `kind: remote` sources for binary + completions (2026-06-07)
+
+When an upstream release provides separate files for the binary and shell completions, use one
+`kind: remote` source per file. Give each a `filename:` to rename it on extraction. Example from
+`tealdeer.bst`:
+
+```yaml
+sources:
+  - kind: remote
+    filename: tealdeer          # renames the download
+    url: github_files:tealdeer-rs/tealdeer/releases/download/v1.8.1/tealdeer-linux-x86_64-musl
+    ref: sha256hex...
+  - kind: remote
+    filename: completions_bash
+    url: github_files:tealdeer-rs/tealdeer/releases/download/v1.8.1/completions_bash
+    ref: sha256hex...
+```
+
+The `filename:` field is required when the URL path has no recognizable extension or conflicts
+with another source file in the same staging directory.
+
+### Arch-conditional sources use `(?)` inside the source block, not at top level (2026-06-07)
+
+Architecture-specific download URLs live inside the `(?):` conditional directly within the
+`sources:` list item. The `kind:` is outside the conditional:
+
+```yaml
+sources:
+- kind: tar
+  (?):
+  - arch == "x86_64":
+      url: alias:project_1.0_amd64.tgz
+      ref: sha256hex...
+  - arch == "aarch64":
+      url: alias:project_1.0_arm64.tgz
+      ref: sha256hex...
+```
+
+This pattern is used in `tailscale.bst`, `glow.bst`, `gum.bst`, and `fzf.bst`.

--- a/docs/skills/packaging-gnome-extensions.md
+++ b/docs/skills/packaging-gnome-extensions.md
@@ -1,3 +1,8 @@
+---
+name: packaging-gnome-extensions
+description: Packages GNOME Shell extensions for BuildStream in dakota. Covers UUID discovery, install path, extension stack wiring, GSettings schema compilation, and dconf keyfile last-writer-wins behavior.
+---
+
 # Packaging GNOME Shell Extensions
 
 Load when packaging a GNOME Shell extension for BuildStream in dakota.

--- a/docs/skills/packaging-go.md
+++ b/docs/skills/packaging-go.md
@@ -1,3 +1,8 @@
+---
+name: packaging-go
+description: Packages a Go project from source using BST go_module sources or a vendored GOPATH tarball. Note: all current Go tools in Dakota use pre-built binaries — load packaging-binaries.md first to confirm source build is truly needed.
+---
+
 # Packaging Go Projects
 
 Load when packaging a Go project for dakota/Bluefin BuildStream, or when setting up GOPATH vendoring in BuildStream.
@@ -131,5 +136,21 @@ install-commands:
 
 ## Lessons Learned
 
-> Add entries here when you discover a new pattern or fix a recurring mistake.
-> Format: `### <pattern name> (YYYY-MM-DD)`
+### All current Go tools in Dakota are pre-built binaries — not Go-from-source builds (2026-06-07)
+
+As of June 2026, every Go-based tool in Dakota uses `kind: manual` with pre-built binaries
+from GitHub Releases. `glow.bst`, `gum.bst`, and `fzf.bst` are all pre-built binary elements,
+not Go source builds. See `packaging-binaries.md` for the pre-built pattern.
+
+Go-from-source build infrastructure (this skill) exists for future use when a required tool
+doesn't provide static binaries. Do not reach for this skill unless upstream truly has no
+release binaries — pre-built is simpler and faster to maintain.
+
+### Vendored GOPATH tarball requires a build host with Go to generate (2026-06-07)
+
+Pattern 2 (vendored GOPATH tarball) requires running `go mod vendor` on the host to create
+the tarball before the element can be written. Unlike cargo2 (where the generator script
+reads from the source), the Go vendor tarball must be generated offline and uploaded
+separately. Factor in this extra maintenance step when deciding between Pattern 1 and
+Pattern 2 — Pattern 1 (go_module sources) is more maintainable long-term because refs
+can be updated in-place.

--- a/docs/skills/packaging-rust.md
+++ b/docs/skills/packaging-rust.md
@@ -1,3 +1,8 @@
+---
+name: packaging-rust
+description: Packages a Rust/Cargo project from source using BST cargo2 sources. Covers cargo2 generation, overlap-whitelist for conflicting binaries, and tracking group assignment. Use sudo-rs.bst as the reference template.
+---
+
 # Packaging Rust Projects
 
 Load when packaging a Rust project with Cargo for dakota/Bluefin BuildStream.
@@ -17,7 +22,7 @@ Rust elements use `kind: make` with a `cargo2` source block that vendors all cra
 There is no scaffold command. Copy an existing Rust element as a starting point:
 
 ```bash
-cp elements/bluefin/tailscale.bst elements/bluefin/<name>.bst
+cp elements/bluefin/sudo-rs.bst elements/bluefin/<name>.bst
 # Edit name, URL, version, binary name, and regenerate cargo2 sources
 ```
 
@@ -131,5 +136,41 @@ install-commands:
 
 ## Lessons Learned
 
-> Add entries here when you discover a new pattern or fix a recurring mistake.
-> Format: `### <pattern name> (YYYY-MM-DD)`
+### Wrong template: copy `tailscale.bst` (pre-built binary), not for Rust-from-source (2026-06-07)
+
+The "Scaffolding" section above said to copy `tailscale.bst` as a starting point for Rust
+elements. That's wrong — `tailscale.bst` is a pre-built binary element (`kind: manual` without
+cargo). The correct Rust-from-source template is `sudo-rs.bst`:
+
+```bash
+cp elements/bluefin/sudo-rs.bst elements/bluefin/<name>.bst
+```
+
+`sudo-rs.bst` uses `kind: make` + `cargo build --release` and has the correct `cargo2` source
+structure.
+
+### `overlap-whitelist` required when binary conflicts with another element (2026-06-07)
+
+`sudo-rs` replaces the system sudo, so it needs an explicit whitelist for the paths it shares
+with the upstream sudo element from fdsdk. Without it, the OCI image build fails with an
+overlap error:
+
+```yaml
+public:
+  bst:
+    overlap-whitelist:
+    - /usr/bin/sudo
+    - /usr/bin/sudoedit
+    - /usr/lib/debug/usr/bin/sudo.debug
+```
+
+Any Rust element replacing a binary that already exists in fdsdk or gnome-build-meta will need
+this. Use `just bst show --format '%{name}: %{overlap-whitelist}' oci/bluefin.bst` to audit.
+
+### `cargo build --release` alone (no `--locked --offline`) works because cargo2 provides deps (2026-06-07)
+
+The `cargo2` source block vendors all crates offline. BST's hermetic sandbox means no network
+access is possible, so `--offline` is redundant (it will succeed either way). `--locked` is
+still recommended as best practice but `sudo-rs.bst` omits it without issue. The build will
+still fail with a clear error if cargo2 sources are missing or mismatched — treat that as a
+signal to regenerate cargo2 sources, not a reason to add `--offline`.

--- a/docs/skills/packaging-zig.md
+++ b/docs/skills/packaging-zig.md
@@ -1,3 +1,8 @@
+---
+name: packaging-zig
+description: Packages a Zig build system project from source. Covers two-stage cache population (zig fetch for HTTP deps, manual placement for git deps), DESTDIR pattern, and -Dcpu=baseline requirement. ghostty.bst is the reference implementation.
+---
+
 # Packaging Zig Projects
 
 Load when packaging a project that uses the Zig build system for dakota/Bluefin BuildStream.
@@ -10,97 +15,169 @@ Load when packaging a project that uses the Zig build system for dakota/Bluefin 
 
 ## Overview
 
-Zig builds are network-isolated in BST. Dependencies declared in `build.zig.zon` must be pre-fetched and provided as source entries. The Zig compiler itself is available from freedesktop-sdk, or can be bootstrapped via a pre-built binary (see `packaging-binaries.md`).
+Zig builds are network-isolated in BST. Dependencies declared in `build.zig.zon` must be
+pre-fetched and provided as source entries. The real-world pattern (from `ghostty.bst`) uses
+`kind: remote` sources staged under `zig-deps/`, followed by a two-stage build that populates
+the Zig cache before calling `zig build`.
 
-## Element Structure
+## Actual Pattern — From ghostty.bst
+
+Dakota's Ghostty element is the reference implementation. It uses `bluefin/zig.bst` (a local
+wrapper around fdsdk's Zig) and this two-stage cache approach:
 
 ```yaml
 kind: manual
 
+variables:
+  strip-binaries: ""  # ghostty uses this; set when installing non-standard files
+
 build-depends:
-- freedesktop-sdk.bst:components/zig.bst
-- freedesktop-sdk.bst:bootstrap-import.bst
+  - bluefin/zig.bst                              # or fdsdk:components/zig.bst
+  - freedesktop-sdk.bst:components/pkg-config.bst
+  - gnome-build-meta.bst:sdk/gtk.bst
 
 depends:
-- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
-
-variables:
-  version: '0.1.0'
-  zig-cache: '%{build-root}/.zig-cache'
-  install-prefix: '%{install-root}%{prefix}'
-
-config:
-  install-commands:
-  - |
-    zig build \
-      --prefix "%{install-prefix}" \
-      --cache-dir "%{zig-cache}" \
-      --global-cache-dir "%{zig-cache}" \
-      -Doptimize=ReleaseSafe \
-      install
-  - '%{install-extra}'
+  - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 sources:
-- kind: git_repo
-  url: github:owner/project.git
-  track: main
-  ref: abc123...
-# zig fetch dependencies (one remote or tar source per dep):
-- kind: tar
-  url: alias:releases/some-dep/0.1.0/dep.tar.gz
-  ref: sha256hex...
-  directory: zig-deps/dep
+  # Main source
+  - kind: tar
+    url: project_releases:1.3.1/project-1.3.1.tar.gz
+    ref: sha256hex...
+
+  # Each zig.zon HTTP dep: one kind: remote per dep, all staged under zig-deps/
+  - kind: remote
+    url: ghostty_deps:libxev-34fa50878aec6e5fa8f532867001ab3c36fae23e.tar.gz
+    ref: sha256hex...
+    directory: zig-deps
+
+  # Git deps (can't be resolved via zig fetch) go under zig-deps-git/
+  - kind: remote
+    url: github_files:owner/repo/archive/sha.tar.gz
+    ref: sha256hex...
+    directory: zig-deps-git
+```
+
+**Build stage — populate cache, then build:**
+
+```yaml
+config:
+  build-commands:
+    # Stage 1: Populate ZIG_GLOBAL_CACHE_DIR from each HTTP dep tarball
+    - |
+      export ZIG_GLOBAL_CACHE_DIR="/tmp/zig-cache"
+      export ZIG_LIB_DIR="%{libdir}/zig"
+      mkdir -p "$ZIG_GLOBAL_CACHE_DIR/p"
+      for dep in zig-deps/*; do
+        zig fetch --global-cache-dir "$ZIG_GLOBAL_CACHE_DIR" "$dep"
+      done
+
+    # Stage 2: Manually place git deps that zig fetch can't resolve
+    - |
+      export ZIG_GLOBAL_CACHE_DIR="/tmp/zig-cache"
+      # Each git dep must be placed at the exact hash path the build expects:
+      local dest="$ZIG_GLOBAL_CACHE_DIR/p/<zig-hash>"
+      mkdir -p "$dest"
+      tar xf "zig-deps-git/<sha>.tar.gz" --strip-components=1 -C "$dest"
+
+  install-commands:
+    - |
+      export ZIG_GLOBAL_CACHE_DIR="/tmp/zig-cache"
+      export ZIG_LIB_DIR="%{libdir}/zig"
+      DESTDIR="%{install-root}" \
+      zig build \
+        --prefix /usr \
+        --global-cache-dir "$ZIG_GLOBAL_CACHE_DIR" \
+        -Doptimize=ReleaseFast \
+        -Dcpu=baseline \
+        -Dpie=true \
+        install
+    - '%{install-extra}'
 ```
 
 ## Generating Dependency Sources
 
-Zig dependencies (`build.zig.zon` `dependencies:` block) must be pre-fetched. For each dependency:
+No automated generator script exists (unlike `cargo2`). Manual process per dep:
 
-1. Get the URL from `build.zig.zon`
-2. Download and hash it:
+1. Get the URL from `build.zig.zon`'s `dependencies:` block
+2. Download and hash with `zig fetch`:
    ```bash
    zig fetch --global-cache-dir /tmp/zig-cache <url>
    ```
-3. Add to element sources with the corresponding hash
-
-No automated generator script exists yet (unlike `cargo2`). Manual work is required for each dep.
+3. Add as `kind: remote` source with `directory: zig-deps`
+4. For git deps referenced as `git+https://...`, download the commit tarball and stage under `zig-deps-git/`
 
 ## Offline Build Flags
 
 | Flag | Purpose |
 |------|---------|
-| `--cache-dir` | Per-project Zig cache |
-| `--global-cache-dir` | Override global Zig cache location (required for reproducibility) |
-| `-Doptimize=ReleaseSafe` | Optimized with safety checks |
-| `-Doptimize=ReleaseFast` | Maximum optimization, no safety checks |
-| `install` | Default install step |
+| `--global-cache-dir` | Override Zig global cache (required for reproducibility) |
+| `-Doptimize=ReleaseFast` | Max optimization; use `ReleaseSafe` for safety-critical code |
+| `-Dcpu=baseline` | Don't use host-CPU extensions — produces portable binaries |
+| `-Dpie=true` | Position-independent executable (security hardening) |
 
-Always set both `--cache-dir` and `--global-cache-dir` to controlled paths inside `%{build-root}`.
+**Note:** Use `DESTDIR="%{install-root}"` with `--prefix /usr` (not `--prefix "%{install-root}/usr"`).
+The Zig build system applies `DESTDIR` correctly — `--prefix` must be the final install path.
 
-## Using fdsdk's Zig vs. Bootstrapped Zig
+## Using fdsdk's Zig vs. Local Wrapper
 
 | Option | When |
 |--------|------|
-| `freedesktop-sdk.bst:components/zig.bst` | When fdsdk ships a compatible Zig version |
-| Pre-built Zig binary (see `packaging-binaries.md`) | When the project requires a specific Zig version not in fdsdk |
+| `bluefin/zig.bst` | Dakota's current approach — local wrapper that pins Zig version |
+| `freedesktop-sdk.bst:components/zig.bst` | When fdsdk ships a compatible version |
 
-Check the required Zig version in `build.zig.zon`:
+Check required Zig version in `build.zig.zon`:
 ```bash
-# Look for minimum_zig_version field
 grep minimum_zig_version path/to/build.zig.zon
 ```
 
 ## Checklist
 
-- [ ] All `build.zig.zon` dependencies are provided as BST sources
-- [ ] `--cache-dir` and `--global-cache-dir` point inside `%{build-root}`
+- [ ] All `build.zig.zon` dependencies provided as BST sources
+- [ ] HTTP deps staged under `directory: zig-deps`
+- [ ] Git deps staged under `directory: zig-deps-git` with manual placement in build commands
 - [ ] Zig version compatibility confirmed
-- [ ] `strip-binaries: ""` not needed (Zig produces ELF)
+- [ ] `DESTDIR` used with `--prefix /usr` (not `--prefix "%{install-root}/usr"`)
+- [ ] `-Dcpu=baseline` set for portable binary
 - [ ] Element added to `elements/bluefin/deps.bst`
 - [ ] `just validate` passes
 - [ ] `just bst build bluefin/<name>.bst` passes
 
 ## Lessons Learned
 
-> Add entries here when you discover a new pattern or fix a recurring mistake.
-> Format: `### <pattern name> (YYYY-MM-DD)`
+### git deps cannot be resolved by `zig fetch` — must be manually placed in cache (2026-06-07)
+
+Zig dependencies declared as `git+https://...` in `build.zig.zon` cannot be fetched by
+`zig fetch` from a tarball. `zig fetch` works for HTTP tarballs and archives with a content
+hash, but not for raw git URLs. The solution: download the commit tarball (GitHub archive),
+stage it under `zig-deps-git/`, and manually extract it into the Zig global cache at the
+exact hash path the build expects:
+
+```bash
+local dest="$ZIG_GLOBAL_CACHE_DIR/p/<expected-zig-hash>"
+mkdir -p "$dest"
+tar xf "zig-deps-git/<commit-sha>.tar.gz" --strip-components=1 -C "$dest"
+```
+
+The expected `<zig-hash>` is the content-addressed hash Zig computes — it appears in
+`build.zig.zon` as the `hash:` field for that dep. See `ghostty.bst` for the reference pattern.
+
+### `DESTDIR + --prefix /usr` not `--prefix %{install-root}/usr` (2026-06-07)
+
+Zig's build system respects the POSIX `DESTDIR` convention correctly. Use:
+```bash
+DESTDIR="%{install-root}" zig build --prefix /usr
+```
+Not:
+```bash
+zig build --prefix "%{install-root}/usr"
+```
+The second form bakes the staging path into installed file contents (e.g., .desktop files,
+pkg-config `.pc` files), which breaks the final image.
+
+### `-Dcpu=baseline` is required for cross-arch portable builds (2026-06-07)
+
+Without `-Dcpu=baseline`, Zig detects and optimizes for the build host's CPU extensions
+(AVX-512, etc.). The resulting binary may work on the build machine but crash on other
+x86_64 hardware. Always set `-Dcpu=baseline` for Dakota builds to match fdsdk's portability
+baseline.

--- a/docs/skills/patch-junctions.md
+++ b/docs/skills/patch-junctions.md
@@ -1,3 +1,8 @@
+---
+name: patch-junctions
+description: Lifecycle for patches applied to upstream junctions (freedesktop-sdk, gnome-build-meta). Covers adding patches, required Upstream-Status headers, rebasing after junction bumps, and dropping upstreamed patches.
+---
+
 # Patching Junction Elements
 
 Load when modifying upstream freedesktop-sdk or gnome-build-meta elements in dakota, or when fixing bugs in junction dependencies.

--- a/docs/skills/pr-review.md
+++ b/docs/skills/pr-review.md
@@ -1,3 +1,8 @@
+---
+name: pr-review
+description: Consolidated review workflow for dakota pull requests. Covers review priorities, common rejection reasons, dep-update PR review, and ghost (agent-assisted PR) handling. Load when asked to review any PR in projectbluefin/dakota.
+---
+
 # PR Review
 
 Consolidated review workflow for dakota pull requests.

--- a/docs/skills/quickstart.md
+++ b/docs/skills/quickstart.md
@@ -1,3 +1,8 @@
+---
+name: quickstart
+description: Zero-context entry point for routine dakota maintenance. Provides 5 always-rules, 6 never-rules, task routing table, and the end-to-end PR workflow. Load first for add/remove/update tasks when you have no other context.
+---
+
 # Agent Quickstart
 
 Zero-context entry point for routine dakota maintenance — add package, remove package, update refs.

--- a/docs/skills/remove-package.md
+++ b/docs/skills/remove-package.md
@@ -1,3 +1,8 @@
+---
+name: remove-package
+description: Workflow for removing a software package from the Dakota image. Covers element deletion, deps.bst unwiring, dangling reference checks, and validation. Load for any "remove package from Dakota" task.
+---
+
 # Removing a Package
 
 Load when removing a software package from the Dakota image in `projectbluefin/dakota`.
@@ -54,5 +59,23 @@ just build
 
 ## Lessons Learned
 
-> Add entries here when you discover a new pattern or fix a recurring mistake.
-> Format: `### <pattern name> (YYYY-MM-DD)`
+### Grep all four locations before removing — elements/, workflows/, files/, Justfile (2026-06-07)
+
+A package can be referenced in up to four separate places beyond the element file itself:
+1. `elements/bluefin/deps.bst` (or gnome-shell-extensions.bst) — dependency stack entry
+2. `.github/workflows/track-bst-sources.yml` — tracking matrix entry
+3. `.github/renovate.json5` — Renovate config entry (if tracked there)
+4. `files/<name>/` — static assets directory
+
+Missing any of these causes a dangling reference. Always run:
+```bash
+grep -r "<name>" elements/ .github/workflows/ files/ patches/ Justfile include/
+```
+before opening the PR.
+
+### `just validate` may pass even with a dangling dep entry (2026-06-07)
+
+If you remove the element file but forget to remove it from `deps.bst`, `just validate`
+exits successfully (BST resolves deps lazily from the graph — missing elements are only
+caught at the `bst show --deps all` level). Always run `just bst show oci/bluefin.bst`
+(not just `just validate`) to catch missing element references before committing.

--- a/docs/skills/update-refs.md
+++ b/docs/skills/update-refs.md
@@ -1,3 +1,8 @@
+---
+name: update-refs
+description: Workflow for updating an existing package version in dakota. Covers tarball ref tracking, git ref tracking, and cargo2 regeneration for Rust elements. Load for any "update package version" task.
+---
+
 # Updating Package Refs
 
 Load when updating an existing package's version in `projectbluefin/dakota`.


### PR DESCRIPTION
## Summary

Complete the skill audit started in 461dec5. This PR:

1. **Adds YAML frontmatter** to all 22 skill files — name + description in third person per Claude agent-skills best practices. Enables skill discovery and lazy loading.

2. **Fixes correctness bugs** found by rubber-ducking actual BST elements:
   - `packaging-binaries.md`: `strip-binaries` belongs under `variables:`, not `public: bst:` (verified against tailscale, glow, gum, fzf, tealdeer)
   - `packaging-rust.md`: wrong scaffold template pointed to `tailscale.bst` (pre-built binary) — corrected to `sudo-rs.bst`
   - `packaging-zig.md`: full rewrite to match `ghostty.bst`'s actual two-stage cache pattern (zig fetch for HTTP deps, manual placement for git deps, DESTDIR pattern, `-Dcpu=baseline`)

3. **Fills all remaining empty Lessons Learned stubs** with real codebase evidence:
   - `packaging-binaries.md`: base-dir pattern, kind:remote filename field, arch-conditional sources
   - `packaging-rust.md`: overlap-whitelist for conflicting binaries, --locked rationale
   - `packaging-zig.md`: git-dep manual placement, DESTDIR vs --prefix, -Dcpu=baseline
   - `bst-overrides.md`: alphabetical patch ordering gaps, single-patch GBM health, verify-upstream-first rule
   - `packaging-go.md`: all current Go tools are pre-built (not from source) — documented so future agents don't unnecessarily reach for this skill
   - `remove-package.md`: four-location grep, `just validate` gap with missing element refs

4. **Adds 'Where learnings live' table** to `AGENTS.md` from org-wide pattern.

## Checklist
- [x] `just validate` — docs-only change, no BST graph affected
- [x] Skill file update committed in same PR
- [x] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added metadata structure to skill documentation files for better organization
  * Clarified guidelines on how to document learnings based on repository scope
  * Expanded lessons learned sections across skill guides with concrete examples and actionable guidance for packaging workflows, debugging, and development tasks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->