### PR TITLE
fix(gnome-ponytail-daemon): use systemd.bst for systemd.pc pkgconfig

### DIFF
--- a/elements/bluefin/gnome-ponytail-daemon.bst
+++ b/elements/bluefin/gnome-ponytail-daemon.bst
@@ -13,7 +13,7 @@ variables:
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
 - freedesktop-sdk.bst:components/python3.bst
-- freedesktop-sdk.bst:components/systemd-libs.bst
+- freedesktop-sdk.bst:components/systemd.bst
 
 depends:
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst


### PR DESCRIPTION
## Problem

Nightly build (June 6) failing on `bluefin/gnome-ponytail-daemon.bst`:

```
Run-time dependency systemd found: NO (tried pkgconfig)
meson.build:13:14: ERROR: Dependency "systemd" not found, tried pkgconfig
```

Upstream `meson.build` line 13 calls `dependency('systemd')` unconditionally, which needs `systemd.pc`. The previous build dep `systemd-libs.bst` only provides `libsystemd.pc`, not `systemd.pc`.

## Fix

Swap `freedesktop-sdk.bst:components/systemd-libs.bst` → `freedesktop-sdk.bst:components/systemd.bst` in `build-depends`. The full `systemd.bst` ships `systemd.pc` which satisfies the meson dependency lookup.

## Verification

- [ ] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependencies to use an updated component version for improved system integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->