### PR TITLE
fix(uutils-coreutils): override LTO to thin to fix SIGABRT on ghost

### DIFF
--- a/elements/bluefin/uutils-coreutils.bst
+++ b/elements/bluefin/uutils-coreutils.bst
@@ -1,5 +1,13 @@
 kind: make
 
+environment:
+  # uutils Cargo.toml sets lto=true (fat LTO) + codegen-units=1 in the release
+  # profile. Fat LTO with codegen-units=1 causes heap corruption in rustc's LLVM
+  # codegen pass when building inside BST's btrfs overlay sandbox on ghost
+  # (realloc(): invalid next size / SIGABRT). Override to thin LTO which uses far
+  # less memory per compilation unit and is stable in this environment.
+  CARGO_PROFILE_RELEASE_LTO: "thin"
+
 config:
   build-commands:
   - cargo build --release --features feat_os_unix --no-default-features


### PR DESCRIPTION
## Problem

`uutils-coreutils.bst` fails consistently on ghost (lab build system) with:

```
realloc(): invalid next size
rustc ... -C linker-plugin-lto -C codegen-units=1 (signal: 6, SIGABRT)
```

The upstream `Cargo.toml` release profile sets `lto = true` (fat LTO) + `codegen-units = 1`. In BST's btrfs overlay sandbox environment (ghost), LLVM's fat LTO codegen pass corrupts its own allocator. This has been blocking ghost's daily cache warm since at least June 5.

## Fix

Add `CARGO_PROFILE_RELEASE_LTO=thin` to the element environment. Thin LTO uses significantly less memory per codegen unit and avoids the LLVM memory corruption path.

## Ghost lab verification

Build confirmed on ghost before opening PR:

```
[00:01:02] SUCCESS bluefin/uutils-coreutils.bst: Running commands
[00:01:05] SUCCESS bluefin/bluefin-uutils-coreutils/08afdf62-build.20260607-162440.log
[00:01:10] SUCCESS Build

Pipeline Summary
  Build Queue: processed 1, skipped 58, failed 0
EXIT:0
```

- [x] I am using an agent and I take responsibility for this PR