### PR TITLE
docs(skills): 2026-06-07 lessons — CAS outage, ghost LTO, meson systemd dep

### DIFF
--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -273,6 +273,64 @@ gh run list --repo projectbluefin/dakota --workflow publish.yml --limit 10 \
 If the last successful publish run is >24 hours old, `:testing` is stale.
 Check projectbluefin/testsuite for open issues before filing a new one.
 
+### Remote CAS down = build dies immediately at element loading (2026-06-07)
+
+When `cache.projectbluefin.io:11002` is unreachable, buildbox-casd exits after
+6 connection retries (~18 seconds). BST reports this as a cryptic inner failure:
+
+```
+BUG: Message handling out of sync, unable to retrieve failure message for element plugins/buildstream-plugins-community.bst
+FAILURE Loading elements
+error: recipe `bst` failed with exit code 255
+```
+
+The real root cause is in the CASD log artifact:
+
+```
+[ERROR] Retry limit (5) exceeded for "GetCapabilities()"
+[ERROR] 14: Failed to connect to remote host: Connection refused
+```
+
+**Diagnosis:**
+
+```bash
+gh run download <run-id> --repo projectbluefin/dakota \
+  --name buildstream-logs-x86_64-default -D /tmp/bst-logs
+cat /tmp/bst-logs/_casd/*.log | grep -E "connect|refused|ERROR" | tail -10
+```
+
+**Fix:** The remote CAS is infrastructure — it needs to be restarted on the server.
+If the cache is truly down, the build cannot proceed (without the `cache.storage-service`,
+BST has no local artifact store and cold-rebuilds everything which times out).
+Re-trigger the build once the cache is back up:
+
+```bash
+gh workflow run "Build Bluefin dakota" --repo projectbluefin/dakota --ref main
+```
+
+**Ghost-local workaround:** Does not apply — ghost's userconfig has no remote CAS
+configured, so ghost builds are unaffected by cache outages.
+
+### Ghost-specific build fixes belong in userconfig, NOT elements (2026-06-07)
+
+If a BST element fails to build on ghost but works in CI (remote execution), the
+fix must go in ghost's local config — **never in the element itself**. Putting it
+in the element invalidates the remote CAS artifact (cache-bust), forcing CI to
+rebuild an element it was already handling correctly.
+
+**Wrong:** `elements/bluefin/foo.bst` + `environment: CARGO_PROFILE_RELEASE_LTO: "thin"`
+**Right:** ghost `~/.config/buildstream/userconfig.yaml` project/element environment override
+
+Ghost-specific environment overrides can go in userconfig under:
+```yaml
+projects:
+  dakota:
+    elements:
+      bluefin/uutils-coreutils.bst:
+        environment:
+          CARGO_PROFILE_RELEASE_LTO: "thin"
+```
+
 ### Manual stable promotion flow (2026-06-04)
 
 Full pipeline to promote `testing` → `stable` manually:

--- a/docs/skills/debugging.md
+++ b/docs/skills/debugging.md
@@ -131,3 +131,25 @@ just bst build bluefin/<name>.bst
 
 When two elements install the same file path, `oci/bluefin.bst` fails with an overlap error even though each element builds fine individually. Fix by adding the conflicting path to `overlap-whitelist:` in `project.conf` or in the element's `public: bst:` section. Use `just bst show --format '%{name}: %{overlap-whitelist}' oci/bluefin.bst` to inspect current whitelist state.
 
+
+### meson `dependency("systemd")` fails with systemd-libs in build-depends (2026-06-07)
+
+If a meson element fails with:
+
+```
+meson.build:N: ERROR: Dependency "systemd" not found, tried pkgconfig
+```
+
+The element has `freedesktop-sdk.bst:components/systemd-libs.bst` in `build-depends`
+but the upstream `meson.build` calls `dependency('systemd')`, which needs `systemd.pc`
+— not `libsystemd.pc`. `systemd-libs.bst` only provides the library, not the pkgconfig
+descriptor for the systemd service itself.
+
+**Fix:** Replace `systemd-libs.bst` with `systemd.bst` in `build-depends`:
+
+```yaml
+build-depends:
+- freedesktop-sdk.bst:components/systemd.bst   # was systemd-libs.bst
+```
+
+`systemd.bst` ships `systemd.pc` and is a superset of `systemd-libs.bst`.

--- a/docs/skills/packaging-rust.md
+++ b/docs/skills/packaging-rust.md
@@ -174,3 +174,33 @@ access is possible, so `--offline` is redundant (it will succeed either way). `-
 still recommended as best practice but `sudo-rs.bst` omits it without issue. The build will
 still fail with a clear error if cargo2 sources are missing or mismatched — treat that as a
 signal to regenerate cargo2 sources, not a reason to add `--offline`.
+
+### Fat LTO + codegen-units=1 causes SIGABRT in BST btrfs overlay on ghost (2026-06-07)
+
+Upstream Rust crates that set `lto = true` + `codegen-units = 1` in their `[profile.release]`
+emit `-C linker-plugin-lto -C codegen-units=1` to each `rustc` invocation. Inside BST's
+btrfs overlay sandbox on ghost (Podman container + btrfs), LLVM's fat LTO codegen pass
+corrupts its own allocator:
+
+```
+realloc(): invalid next size
+rustc ... -C linker-plugin-lto -C codegen-units=1 (signal: 6, SIGABRT)
+```
+
+This is a ghost-environment issue — CI's remote execution server handles fat LTO fine.
+
+**Do NOT fix in the element.** Put the override in ghost's userconfig to avoid
+invalidating the remote CAS artifact (see `ci.md` → *Ghost-specific build fixes*):
+
+```yaml
+# ~/.config/buildstream/userconfig.yaml on ghost
+projects:
+  dakota:
+    elements:
+      bluefin/uutils-coreutils.bst:
+        environment:
+          CARGO_PROFILE_RELEASE_LTO: "thin"
+```
+
+Thin LTO provides most cross-crate optimization benefits with far less memory per
+codegen unit and does not trigger the allocator corruption.


### PR DESCRIPTION
Session learnings from today's build triage and ghost lab setup.

**ci.md** — two new lessons:
- Remote CAS down → cryptic `Loading elements` failure (diagnosis + fix)
- Ghost-specific fixes belong in `userconfig.yaml`, not elements

**debugging.md** — new lesson:
- `dependency("systemd")` in meson needs `systemd.bst` not `systemd-libs.bst`

**packaging-rust.md** — new lesson:
- Fat LTO + codegen-units=1 triggers SIGABRT in ghost's btrfs overlay sandbox; ghost userconfig is the right fix location

- [ ] I am using an agent and I take responsibility for this PR