### PR TITLE
ci: harden promotion pipeline and fix lifecycle workflow

### DIFF
--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   lifecycle:
-    uses: projectbluefin/common/.github/workflows/lifecycle.yml@c978e1ea5457a605da112b41b5e717b16d06e817
+    uses: projectbluefin/common/.github/workflows/lifecycle.yml@025ec29f68aa919d1d90a3d4bb04b3e5e4777158 # main
     with:
       brand_name: "Dakota"
     secrets: inherit

--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -20,5 +20,4 @@ jobs:
     uses: projectbluefin/common/.github/workflows/lifecycle.yml@c978e1ea5457a605da112b41b5e717b16d06e817
     with:
       brand_name: "Dakota"
-      brand_emoji: "🏔️"
     secrets: inherit

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -42,6 +42,21 @@ jobs:
     needs: ensure-labels
     runs-on: ubuntu-24.04
     steps:
+      - name: Block PRs not targeting main
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$BASE_REF" != "main" ]; then
+            echo "ERROR: PRs must target 'main', not '$BASE_REF'."
+            echo "Branches like 'stable' and 'latest' are managed by the promotion pipeline — never target them directly."
+            gh pr comment "$PR_URL" --body \
+              "This PR targets \`${BASE_REF}\` instead of \`main\`. Please retarget it to \`main\` — the \`${BASE_REF}\` branch is managed by the promotion pipeline and must not receive direct PRs." \
+              2>/dev/null || true
+            exit 1
+          fi
+
       - name: Add pr/needs-review and post instructions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,32 @@ name: Release Bluefin dakota
 
 # Called automatically from weekly-testing-promotion.yml after a successful
 # stable promotion. workflow_dispatch is available for out-of-band cuts.
+#
+# workflow_call callers MUST pass source_sha + promoted_digest so release.yml
+# doesn't re-discover the publish run independently (race-free).
 on:
   workflow_call:
+    inputs:
+      source_sha:
+        description: "Git SHA of the promoted source (from resolve.outputs.source_sha)"
+        type: string
+        required: true
+      promoted_digest:
+        description: "OCI digest of the promoted image (from resolve.outputs.default_digest)"
+        type: string
+        required: true
   workflow_dispatch:
+    inputs:
+      source_sha:
+        description: "Git SHA to release (leave blank to use latest :stable)"
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: write   # create GitHub releases
-  actions:  read    # download artifacts from the latest publish run
+  actions:  read    # download SBOM artifact from publish run
+  packages: read    # pull image for Syft SBOM fallback
 
 concurrency:
   group: scheduled-release
@@ -18,58 +37,118 @@ jobs:
   release:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    permissions:
+      contents: write
+      actions:  read
+      packages: read
     steps:
-      - name: Find latest publish run
+      # ── Resolve SHA and publish run ───────────────────────────────────────
+      # When called from the promotion pipeline, source_sha is locked to the
+      # exact SHA that was promoted — no re-discovery race possible.
+      # For workflow_dispatch, resolve from :stable if source_sha is not given.
+      - name: Resolve source SHA and publish run
         id: publish_run
         env:
           GH_TOKEN: ${{ github.token }}
+          INPUT_SHA: ${{ inputs.source_sha }}
         run: |
           set -euo pipefail
+
+          if [[ -n "${INPUT_SHA}" ]]; then
+            SHA="${INPUT_SHA}"
+            echo "Using provided source SHA: ${SHA}"
+          else
+            # workflow_dispatch with no sha — resolve from the promoted :stable tag
+            SHA=$(skopeo inspect --format '{{index .Labels "org.opencontainers.image.revision"}}' \
+              docker://ghcr.io/${{ github.repository_owner }}/dakota:stable 2>/dev/null || echo "")
+            if [[ -z "${SHA}" ]]; then
+              echo "::error::Could not resolve source SHA from :stable — pass source_sha explicitly"
+              exit 1
+            fi
+            echo "Resolved source SHA from :stable: ${SHA}"
+          fi
+
+          SHA7="${SHA:0:7}"
+
+          # Find the matching publish run for this exact SHA.
+          # Scanning up to 50 runs ensures we find it even if many builds ran recently.
           RUN=$(gh run list \
             --workflow "Publish Bluefin dakota" \
             --branch main \
             --status success \
-            --limit 1 \
+            --limit 50 \
             --json headSha,createdAt,databaseId \
-            --repo ${{ github.repository }} \
-            --jq '.[0]')
-          SHA=$(echo "$RUN" | jq -r '.headSha')
+            --repo "${{ github.repository }}" \
+            | jq -r --arg sha "$SHA" 'map(select(.headSha == $sha)) | .[0] // empty')
+
+          if [[ -z "${RUN}" || "${RUN}" == "null" ]]; then
+            echo "::error::No successful publish run found for SHA ${SHA}"
+            exit 1
+          fi
+
           CREATED_AT=$(echo "$RUN" | jq -r '.createdAt')
           RUN_ID=$(echo "$RUN" | jq -r '.databaseId')
-          SHA7="${SHA:0:7}"
+
           {
-            echo "sha=$SHA"
-            echo "sha7=$SHA7"
-            echo "created_at=$CREATED_AT"
-            echo "run_id=$RUN_ID"
+            echo "sha=${SHA}"
+            echo "sha7=${SHA7}"
+            echo "created_at=${CREATED_AT}"
+            echo "run_id=${RUN_ID}"
           } >> "$GITHUB_OUTPUT"
+          echo "Found publish run ${RUN_ID} for SHA ${SHA}"
 
-      - name: Checkout repository at published SHA
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          ref: ${{ steps.publish_run.outputs.sha }}
-
-      - name: Resolve release metadata
-        id: meta
+      # ── Resolve image digest ──────────────────────────────────────────────
+      # For workflow_call, the caller passes the exact promoted digest — no
+      # skopeo probe needed. For workflow_dispatch, resolve from :stable.
+      - name: Resolve image digest
+        id: digest
+        env:
+          PROVIDED_DIGEST: ${{ inputs.promoted_digest }}
+          SHA: ${{ steps.publish_run.outputs.sha }}
         run: |
           set -euo pipefail
-          SHA="${{ steps.publish_run.outputs.sha }}"
-          SHA7="${{ steps.publish_run.outputs.sha7 }}"
-          # Use the publish workflow's start time, not wall-clock now.
+
+          if [[ -n "${PROVIDED_DIGEST}" ]]; then
+            DIGEST="${PROVIDED_DIGEST}"
+            echo "Using provided digest: ${DIGEST}"
+          else
+            DIGEST=$(skopeo inspect --format '{{.Digest}}' \
+              docker://ghcr.io/${{ github.repository_owner }}/dakota:stable 2>/dev/null || echo "")
+            if [[ -z "${DIGEST}" ]]; then
+              echo "::error::Could not resolve digest from :stable — cannot create release"
+              exit 1
+            fi
+            echo "Resolved digest from :stable: ${DIGEST}"
+          fi
+
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      # ── Release metadata ──────────────────────────────────────────────────
+      - name: Resolve release metadata
+        id: meta
+        env:
+          SHA: ${{ steps.publish_run.outputs.sha }}
+          SHA7: ${{ steps.publish_run.outputs.sha7 }}
+          CREATED_AT: ${{ steps.publish_run.outputs.created_at }}
+        run: |
+          set -euo pipefail
+          # Use the publish workflow's start time for the date in the tag.
           # A publish that starts at 23:45 UTC and completes past midnight
-          # would otherwise get tomorrow's date in the tag.
-          DATE="$(date -u -d '${{ steps.publish_run.outputs.created_at }}' +%Y-%m-%d)"
+          # would otherwise get tomorrow's date.
+          DATE="$(date -u -d "${CREATED_AT}" +%Y-%m-%d)"
           {
-            echo "sha=$SHA"
-            echo "sha7=$SHA7"
-            echo "date=$DATE"
+            echo "date=${DATE}"
             echo "tag=${DATE}-${SHA7}"
             echo "title=Bluefin Dakota ${DATE}"
           } >> "$GITHUB_OUTPUT"
 
-      # publish.yml uploads dakota.spdx.json (default variant) as
-      # "sbom-<sha>" with 30-day retention.
-      - name: Download current SBOM from publish run
+      # ── SBOM: download artifact, fall back to Syft ───────────────────────
+      # Primary: download BST-generated SBOM from the publish run artifact
+      # (30-day retention). Fallback: generate with Syft from the promoted
+      # image if the artifact has expired (out-of-band manual release).
+      - name: Download SBOM from publish run
+        id: sbom_artifact
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: sbom-${{ steps.publish_run.outputs.sha }}
@@ -77,27 +156,27 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: sbom-current
 
-      - name: Get image digest
-        id: digest
+      - name: Generate SBOM with Syft (fallback — artifact expired or unavailable)
+        if: steps.sbom_artifact.outcome == 'failure'
         env:
-          SHA: ${{ steps.publish_run.outputs.sha }}
+          DIGEST: ${{ steps.digest.outputs.digest }}
         run: |
           set -euo pipefail
-          DIGEST=$(skopeo inspect --format '{{.Digest}}' \
-            docker://ghcr.io/projectbluefin/dakota:"${SHA}" 2>/dev/null || echo "")
-          if [[ -z "${DIGEST}" ]]; then
-            echo "::warning::Could not fetch digest for dakota:${SHA} — using sha as digest"
-            DIGEST="sha256:${SHA}"
-          fi
-          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "::warning::Build artifact expired or unavailable — generating SBOM with Syft from promoted image"
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
+            | sh -s -- -b /usr/local/bin v1.44.0
+          mkdir -p sbom-current
+          syft "ghcr.io/${{ github.repository_owner }}/dakota@${DIGEST}" \
+            -o spdx-json=sbom-current/dakota.spdx.json
 
+      # ── Create GitHub Release ─────────────────────────────────────────────
       - name: Create release
         uses: projectbluefin/actions/bootc-build/create-release@622073d27a051f1eed7b874b9b71710141a5e60e
         with:
           sbom-path:            sbom-current/dakota.spdx.json
           tag:                  ${{ steps.meta.outputs.tag }}
           title:                ${{ steps.meta.outputs.title }}
-          image:                ghcr.io/projectbluefin/dakota
+          image:                ghcr.io/${{ github.repository_owner }}/dakota
           digest:               ${{ steps.digest.outputs.digest }}
           repo:                 ${{ github.repository }}
           project-name:         "Bluefin Dakota"
@@ -105,7 +184,7 @@ jobs:
           badge-label:          Alpha
           sbom-filename:        dakota.spdx.json
           cert-identity-regexp: >-
-            ^https://github\.com/projectbluefin/dakota/\.github/workflows/publish\.yml
+            ^https://github\.com/projectbluefin/dakota/\.github/workflows/publish\.yml@refs/heads/(main|gh-readonly-queue/main/.+)$
           notable-packages: >-
             [
               {"sbom_name": "linux",             "label": "Kernel", "spdxid_filter": "components-linux.bst"},

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,9 @@
 name: Release Bluefin dakota
 
-# Weekly gated release — fires every Tuesday at 06:00 UTC.
-# Maintainers must approve via the production environment gate before the
-# release is created. workflow_dispatch is available for out-of-band cuts.
+# Called automatically from weekly-testing-promotion.yml after a successful
+# stable promotion. workflow_dispatch is available for out-of-band cuts.
 on:
-  schedule:
-    - cron: '0 6 * * 2'  # Weekly on Tuesday at 6 AM UTC
+  workflow_call:
   workflow_dispatch:
 
 permissions:
@@ -20,9 +18,6 @@ jobs:
   release:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    environment:
-      name: production
-      url: https://ghcr.io/projectbluefin/dakota
     steps:
       - name: Find latest publish run
         id: publish_run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,12 @@ jobs:
           CREATED_AT=$(echo "$RUN" | jq -r '.createdAt')
           RUN_ID=$(echo "$RUN" | jq -r '.databaseId')
           SHA7="${SHA:0:7}"
-          echo "sha=$SHA"          >> "$GITHUB_OUTPUT"
-          echo "sha7=$SHA7"        >> "$GITHUB_OUTPUT"
-          echo "created_at=$CREATED_AT" >> "$GITHUB_OUTPUT"
-          echo "run_id=$RUN_ID"    >> "$GITHUB_OUTPUT"
+          {
+            echo "sha=$SHA"
+            echo "sha7=$SHA7"
+            echo "created_at=$CREATED_AT"
+            echo "run_id=$RUN_ID"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository at published SHA
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -14,9 +14,62 @@ permissions:
   packages: write
 
 jobs:
+  # ── Enforce a minimum 7-day floor between promotions ─────────────────────
+  # Prevents churn when main receives only docs or trivial fixes.
+  # workflow_dispatch bypasses the floor so maintainers can force a promotion
+  # (e.g. after a hotfix or a failed previous run).
+  check-promotion-floor:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      should_promote: ${{ steps.floor.outputs.should_promote }}
+    steps:
+      - name: Check days since last stable release
+        id: floor
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "Manual dispatch — bypassing promotion floor."
+            echo "should_promote=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          LAST_RELEASE=$(gh release list \
+            --repo "${{ github.repository }}" \
+            --limit 1 \
+            --json createdAt \
+            --jq '.[0].createdAt // empty')
+
+          if [[ -z "$LAST_RELEASE" ]]; then
+            echo "No previous release found — first promotion, proceeding."
+            echo "should_promote=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          LAST_TS=$(date -d "$LAST_RELEASE" +%s)
+          NOW_TS=$(date +%s)
+          DAYS_SINCE=$(( (NOW_TS - LAST_TS) / 86400 ))
+
+          echo "Last stable release: $LAST_RELEASE (${DAYS_SINCE} days ago)"
+
+          if [[ "$DAYS_SINCE" -lt 7 ]]; then
+            echo "Floor not met (${DAYS_SINCE}/7 days) — skipping promotion this cycle."
+            echo "should_promote=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Floor met (${DAYS_SINCE} days) — proceeding with promotion."
+            echo "should_promote=true" >> "$GITHUB_OUTPUT"
+          fi
+
   # ── Resolve current :testing digests ─────────────────────────────────────
   # Pins the exact digests and verifies both variants share the same source SHA.
   resolve:
+    needs: [check-promotion-floor]
+    if: needs.check-promotion-floor.outputs.should_promote == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     outputs:
@@ -326,3 +379,86 @@ jobs:
               echo "Fast-forwarded ${BRANCH} to ${SOURCE_SHA}"
             fi
           done
+
+  # ── Generate release notes ────────────────────────────────────────────────
+  generate-release:
+    needs: [update-branches]
+    if: needs.update-branches.result == 'success'
+    permissions:
+      contents: write
+      actions: read
+    uses: ./.github/workflows/release.yml
+
+  # ── Close stale failure issue on success ─────────────────────────────────
+  close-failure-issue:
+    needs: [update-branches]
+    if: needs.update-branches.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Close open failure issue if present
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const title = 'ci: weekly promotion failure';
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'area/testing,kind/bug',
+              state: 'open',
+            });
+            const open = existing.data.find(i => i.title === title);
+            if (open) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: open.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+              core.info(`Closed stale failure issue #${open.number}`);
+            }
+
+  # ── Open or update failure issue ─────────────────────────────────────────
+  report-failure:
+    needs: [resolve, check-diff, verify-signatures, e2e, promote, update-branches]
+    if: always() && failure()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update failure issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const title = 'ci: weekly promotion failure';
+            const body = `## Weekly Promotion Failure\n\n**Run:** ${runUrl}\n\n_Automatically opened by weekly-testing-promotion.yml_`;
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'area/testing,kind/bug',
+              state: 'open',
+            });
+            const dup = existing.data.find(i => i.title === title);
+            if (dup) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: dup.number,
+                body,
+              });
+              core.info(`Updated existing failure issue #${dup.number}`);
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['area/testing', 'kind/bug', 'priority/p1'],
+              });
+            }

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -382,12 +382,16 @@ jobs:
 
   # ── Generate release notes ────────────────────────────────────────────────
   generate-release:
-    needs: [update-branches]
+    needs: [resolve, update-branches]
     if: needs.update-branches.result == 'success'
     permissions:
       contents: write
       actions: read
+      packages: read
     uses: ./.github/workflows/release.yml
+    with:
+      source_sha:      ${{ needs.resolve.outputs.source_sha }}
+      promoted_digest: ${{ needs.resolve.outputs.default_digest }}
 
   # ── Close stale failure issue on success ─────────────────────────────────
   close-failure-issue:

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -35,8 +35,8 @@ Load when debugging CI failures, understanding the build pipeline, or working wi
 |---|---|
 | `.github/workflows/build.yml` | BST build + push artifacts to remote CAS. Fires on merge_group/schedule/dispatch. Does NOT push to GHCR directly. |
 | `.github/workflows/publish.yml` | 4-stage pipeline: setup → publish → e2e-gate → promote. Pulls artifact from CAS, exports OCI, pushes `:$sha`, signs, attests, smoke-tests, then promotes to `:testing`. |
-| `.github/workflows/release.yml` | Auto-fires after every successful publish. Creates GitHub Release with card image, SBOM diff, and package changelog. |
-| `.github/workflows/weekly-testing-promotion.yml` | Weekly promotion (Sun 06:00 UTC): verifies `:testing` digests, re-tags as `:latest` + `:stable`, fast-forwards `latest`/`stable` branches. |
+| `.github/workflows/release.yml` | Called from `weekly-testing-promotion.yml` after a successful promotion. Creates GitHub Release with card image, SBOM diff, and package changelog. Also available as `workflow_dispatch` for out-of-band cuts. |
+| `.github/workflows/weekly-testing-promotion.yml` | Weekly Tuesday promotion (06:00 UTC): 7-day floor check → verify `:testing` digests → cosign verify → e2e → promote to `:latest`+`:stable` → fast-forward branches → call `release.yml`. Has `environment: production` gate requiring human approval. |
 | `.github/workflows/e2e.yml` | Smoke test via projectbluefin/testsuite. Fires on PR; `should-run` job skips the test when no image-affecting paths changed. |
 
 ## Trigger Behavior
@@ -331,7 +331,48 @@ projects:
           CARGO_PROFILE_RELEASE_LTO: "thin"
 ```
 
-### Manual stable promotion flow (2026-06-04)
+### Promotion pipeline hardening — bonedigger and release race (2026-06-07)
+
+**bonedigger "workflow file issue":** The lifecycle caller (`bonedigger.yml`) was
+pinned to a common SHA that pre-dated `lifecycle.yml` existing in that repo. Also,
+the `brand_emoji` input is not declared by the reusable workflow — passing an
+undeclared input causes a GitHub workflow validation failure. Fix: update the SHA
+pin to a commit where the file exists and remove undeclared inputs.
+
+```bash
+# Find commits that contain the target workflow file
+gh api "repos/projectbluefin/common/commits?path=.github/workflows/lifecycle.yml&per_page=3" \
+  --jq '.[].sha'
+```
+
+**release.yml must not re-discover the publish run independently:** If `release.yml`
+queries `gh run list --limit 1` after the promotion pipeline completes, a concurrent
+publish run for a new SHA can land first and be picked up instead. Always pass the
+promoted `source_sha` and `promoted_digest` as `workflow_call` inputs from the
+promotion pipeline so `release.yml` filters by exact headSha.
+
+**Invalid OCI digest fallback:** Never synthesize an OCI digest from a git SHA
+(`sha256:${git_sha}`). If `skopeo inspect` fails, fail the job — a release with
+a fake digest has wrong verification commands in the release notes.
+
+**`cert-identity-regexp` must be fully anchored:** Cosign uses `MatchString` semantics,
+so a regexp without a trailing `$` matches any URL with that prefix. Always anchor:
+```
+^https://github\.com/projectbluefin/dakota/\.github/workflows/publish\.yml@refs/heads/(main|gh-readonly-queue/main/.+)$
+```
+
+**SBOM artifact expiry fallback:** Build artifacts expire after 30 days. For
+`workflow_dispatch` out-of-band cuts, add a Syft fallback:
+```yaml
+- name: Download SBOM
+  id: sbom_artifact
+  continue-on-error: true
+  uses: actions/download-artifact@...
+- name: Generate SBOM with Syft (fallback)
+  if: steps.sbom_artifact.outcome == 'failure'
+  run: syft "ghcr.io/.../dakota@${DIGEST}" -o spdx-json=sbom-current/dakota.spdx.json
+```
+
 
 Full pipeline to promote `testing` → `stable` manually:
 


### PR DESCRIPTION
## Summary

Brings dakota's CI/release pipeline to parity with bluefin and bluefin-lts, and fixes the bonedigger regression.

## Changes

### `weekly-testing-promotion.yml`
- **7-day promotion floor** — matches bluefin/LTS; skips if last release was <7 days ago; `workflow_dispatch` bypasses
- **`report-failure` job** — auto-opens/updates a `kind/bug` tracking issue when promotion fails
- **`close-failure-issue` job** — auto-closes that issue on next successful promotion
- **`generate-release` job** — calls `release.yml` via `workflow_call` after branches fast-forward; eliminates the decoupled Tuesday schedule

### `release.yml`
- Added `workflow_call` trigger so promotion drives release notes automatically
- Removed standalone `schedule:` (now called from promotion)
- Removed redundant `environment: production` gate (the `promote` job already requires human approval)

### `pr-triage.yml`
- Closes #716 — blocks PRs targeting anything other than `main`; posts an explanatory comment and exits 1

### `bonedigger.yml`
- Removes `brand_emoji` input — not declared in `common/lifecycle.yml`; was causing all lifecycle workflow runs to fail with "workflow file issue"

## Verification

- [ ] YAML syntax: all 4 files pass `yaml.safe_load`
- [ ] bonedigger fix is mechanical — `brand_emoji` is not a valid input to the reusable workflow
- [ ] Promotion floor mirrors the bluefin implementation exactly
- [ ] Release notes call mirrors the bluefin `generate-release` post-promotion pattern

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull requests targeting non-main branches are now blocked with guidance to retarget to main
  * Weekly promotion enforces a 7-day minimum between releases
  * Automated failure tracking and issue management for promotion workflows

* **Changes**
  * Release process switched from weekly-only to on-demand/reusable invocation with improved SBOM fallback and image resolution
  * Removed an unused brand configuration and the production environment gate
<!-- end of auto-generated comment: release notes by coderabbit.ai -->