### PR TITLE
ci: harden release.yml and publish.yml pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -240,7 +240,9 @@ jobs:
   # prevent the default :testing from landing.
   promote:
     needs: [setup, publish, e2e-gate]
-    if: needs.e2e-gate.result == 'success'
+    if: >-
+      needs.e2e-gate.result == 'success' &&
+      (github.event_name == 'workflow_run' || github.ref_name == 'main')
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,31 +58,41 @@ jobs:
             SHA="${INPUT_SHA}"
             echo "Using provided source SHA: ${SHA}"
           else
-            # workflow_dispatch with no sha — resolve from the promoted :stable tag
-            SHA=$(skopeo inspect --format '{{index .Labels "org.opencontainers.image.revision"}}' \
+            # workflow_dispatch with no sha — resolve from the promoted :stable tag.
+            # One skopeo call extracts both SHA and digest atomically to avoid a
+            # TOCTOU window if :stable is re-tagged between two separate lookups.
+            INSPECT=$(skopeo inspect --format '{{index .Labels "org.opencontainers.image.revision"}} {{.Digest}}' \
               docker://ghcr.io/${{ github.repository_owner }}/dakota:stable 2>/dev/null || echo "")
-            if [[ -z "${SHA}" ]]; then
-              echo "::error::Could not resolve source SHA from :stable — pass source_sha explicitly"
+            SHA=$(echo "${INSPECT}" | awk '{print $1}')
+            STABLE_DIGEST=$(echo "${INSPECT}" | awk '{print $2}')
+            if [[ -z "${SHA}" || -z "${STABLE_DIGEST}" ]]; then
+              echo "::error::Could not resolve source SHA/digest from :stable — pass source_sha explicitly"
               exit 1
             fi
-            echo "Resolved source SHA from :stable: ${SHA}"
+            echo "STABLE_DIGEST=${STABLE_DIGEST}" >> "$GITHUB_ENV"
+            echo "Resolved source SHA from :stable: ${SHA}, digest: ${STABLE_DIGEST}"
           fi
 
           SHA7="${SHA:0:7}"
 
           # Find the matching publish run for this exact SHA.
-          # Scanning up to 50 runs ensures we find it even if many builds ran recently.
+          # No --branch filter: publish.yml accepts both main and gh-readonly-queue/main/**
+          # branches, so filtering by branch would miss merge-queue-triggered runs whose
+          # promoted SHA later lands on :stable.
           RUN=$(gh run list \
             --workflow "Publish Bluefin dakota" \
-            --branch main \
             --status success \
-            --limit 50 \
-            --json headSha,createdAt,databaseId \
+            --limit 100 \
+            --json headSha,headBranch,createdAt,databaseId \
             --repo "${{ github.repository }}" \
-            | jq -r --arg sha "$SHA" 'map(select(.headSha == $sha)) | .[0] // empty')
+            | jq -r --arg sha "$SHA" '
+                map(select(
+                  .headSha == $sha and
+                  (.headBranch == "main" or (.headBranch | test("^gh-readonly-queue/main/")))
+                )) | .[0] // empty')
 
           if [[ -z "${RUN}" || "${RUN}" == "null" ]]; then
-            echo "::error::No successful publish run found for SHA ${SHA}"
+            echo "::error::No successful publish run found for SHA ${SHA} on main or merge-queue"
             exit 1
           fi
 
@@ -99,7 +109,8 @@ jobs:
 
       # ── Resolve image digest ──────────────────────────────────────────────
       # For workflow_call, the caller passes the exact promoted digest — no
-      # skopeo probe needed. For workflow_dispatch, resolve from :stable.
+      # skopeo probe needed. For workflow_dispatch, reuse the digest captured
+      # atomically alongside SHA in the step above (no second skopeo call).
       - name: Resolve image digest
         id: digest
         env:
@@ -111,14 +122,20 @@ jobs:
           if [[ -n "${PROVIDED_DIGEST}" ]]; then
             DIGEST="${PROVIDED_DIGEST}"
             echo "Using provided digest: ${DIGEST}"
+          elif [[ -n "${STABLE_DIGEST:-}" ]]; then
+            # Captured atomically with SHA in the previous step — no TOCTOU risk.
+            DIGEST="${STABLE_DIGEST}"
+            echo "Using atomically resolved digest: ${DIGEST}"
           else
+            # workflow_dispatch with explicit source_sha but no digest —
+            # inspect the SHA-tagged image directly.
             DIGEST=$(skopeo inspect --format '{{.Digest}}' \
-              docker://ghcr.io/${{ github.repository_owner }}/dakota:stable 2>/dev/null || echo "")
+              docker://ghcr.io/${{ github.repository_owner }}/dakota:"${SHA}" 2>/dev/null || echo "")
             if [[ -z "${DIGEST}" ]]; then
-              echo "::error::Could not resolve digest from :stable — cannot create release"
+              echo "::error::Could not resolve digest for :${SHA} — the SHA-tagged image may have expired"
               exit 1
             fi
-            echo "Resolved digest from :stable: ${DIGEST}"
+            echo "Resolved digest from :${SHA}: ${DIGEST}"
           fi
 
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
@@ -156,17 +173,23 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: sbom-current
 
+      - name: Install Syft (fallback — artifact expired or unavailable)
+        if: steps.sbom_artifact.outcome == 'failure'
+        id: syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          syft-version: v1.44.0
+
       - name: Generate SBOM with Syft (fallback — artifact expired or unavailable)
         if: steps.sbom_artifact.outcome == 'failure'
         env:
           DIGEST: ${{ steps.digest.outputs.digest }}
+          SYFT_CMD: ${{ steps.syft.outputs.cmd }}
         run: |
           set -euo pipefail
           echo "::warning::Build artifact expired or unavailable — generating SBOM with Syft from promoted image"
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
-            | sh -s -- -b /usr/local/bin v1.44.0
           mkdir -p sbom-current
-          syft "ghcr.io/${{ github.repository_owner }}/dakota@${DIGEST}" \
+          "${SYFT_CMD}" "ghcr.io/${{ github.repository_owner }}/dakota@${DIGEST}" \
             -o spdx-json=sbom-current/dakota.spdx.json
 
       # ── Create GitHub Release ─────────────────────────────────────────────

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -368,9 +368,79 @@ so a regexp without a trailing `$` matches any URL with that prefix. Always anch
   id: sbom_artifact
   continue-on-error: true
   uses: actions/download-artifact@...
+- name: Install Syft (fallback)
+  if: steps.sbom_artifact.outcome == 'failure'
+  id: syft
+  uses: anchore/sbom-action/download-syft@<SHA> # v0
+  with:
+    syft-version: v1.44.0
 - name: Generate SBOM with Syft (fallback)
   if: steps.sbom_artifact.outcome == 'failure'
-  run: syft "ghcr.io/.../dakota@${DIGEST}" -o spdx-json=sbom-current/dakota.spdx.json
+  env:
+    SYFT_CMD: ${{ steps.syft.outputs.cmd }}
+  run: "${SYFT_CMD}" "ghcr.io/.../dakota@${DIGEST}" -o spdx-json=sbom-current/dakota.spdx.json
+```
+Use `anchore/sbom-action/download-syft` (SHA-pinned) instead of `curl .../main/install.sh | sh`.
+The `@main` install script is a mutable supply-chain input even when the version flag is pinned.
+
+### release.yml publish run search must include merge-queue branches (2026-06-07)
+
+`gh run list --branch main` only returns runs whose triggering branch was exactly
+`main`. Publish runs triggered by `workflow_run` from `gh-readonly-queue/main/**`
+(i.e., merge queue builds) are associated with the queue branch, not `main`, in
+the GitHub API. If the promoted `:stable` SHA came from a merge-queue run, the
+`--branch main` filter silently misses it and `release.yml` exits with "no
+successful publish run found."
+
+**Fix:** Drop the `--branch filter and filter by `headBranch` in jq instead:
+```bash
+gh run list \
+  --workflow "Publish Bluefin dakota" \
+  --status success \
+  --limit 100 \
+  --json headSha,headBranch,createdAt,databaseId \
+  | jq -r --arg sha "$SHA" '
+      map(select(
+        .headSha == $sha and
+        (.headBranch == "main" or (.headBranch | test("^gh-readonly-queue/main/")))
+      )) | .[0] // empty'
+```
+
+### workflow_dispatch on publish.yml can promote non-main refs to :testing (2026-06-07)
+
+`publish.yml` has no branch guard on the `promote` job. A manual dispatch from a
+non-main branch flows through e2e and promotes to `:testing`, fast-forwarding the
+`testing` branch to an unmerged commit.
+
+**Fix:** Add a branch guard to the `promote` job:
+```yaml
+promote:
+  needs: [setup, publish, e2e-gate]
+  if: >-
+    needs.e2e-gate.result == 'success' &&
+    (github.event_name == 'workflow_run' || github.ref_name == 'main')
+```
+`workflow_run` events are always safe (they trigger from completed `main`/merge-queue
+builds per the trigger filter in `publish.yml`). Only manual dispatches need the
+`github.ref_name == 'main'` guard.
+
+### release.yml manual dispatch TOCTOU (2026-06-07)
+
+In `workflow_dispatch` mode with no `source_sha`, the original code resolved SHA
+and digest in two separate `skopeo inspect` calls. If `:stable` moved between
+them, the release would pair a wrong SHA with a wrong digest.
+
+**Fix:** One `skopeo inspect --format '{{index .Labels "org.opencontainers.image.revision"}} {{.Digest}}'`
+call extracts both values atomically. Write the digest to `$GITHUB_ENV` and read
+it in the next step — no second skopeo call.
+
+```bash
+INSPECT=$(skopeo inspect --format \
+  '{{index .Labels "org.opencontainers.image.revision"}} {{.Digest}}' \
+  docker://ghcr.io/.../dakota:stable)
+SHA=$(echo "${INSPECT}" | awk '{print $1}')
+STABLE_DIGEST=$(echo "${INSPECT}" | awk '{print $2}')
+echo "STABLE_DIGEST=${STABLE_DIGEST}" >> "$GITHUB_ENV"
 ```
 
 


### PR DESCRIPTION
Fixes four issues found in rubber-duck review comparing Dakota's release
pipeline against bluefin/bluefin-lts.

## Changes

### 1. release.yml: drop \`--branch main\` from publish run search
\`gh run list --branch main\` misses publish runs triggered by
\`gh-readonly-queue/main/**\` (merge queue). Replaced with a \`headBranch\`
filter in jq that accepts both \`main\` and \`gh-readonly-queue/main/*\`.
Limit bumped to 100 to accommodate higher run volume.

### 2. release.yml: fix TOCTOU in \`workflow_dispatch\` with no \`source_sha\`
SHA and digest were resolved by two separate \`skopeo inspect\` calls.
If \`:stable\` moved between calls, the release would pair a mismatched
SHA and digest. One call now extracts both atomically and passes the
digest through \`GITHUB_ENV\`.

### 3. release.yml: replace mutable Syft install script with pinned action
The \`curl .../main/install.sh | sh\` fallback is a mutable supply-chain
input even when the version flag is pinned. Replaced with
\`anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610\`
(same SHA used in bluefin-lts).

### 4. publish.yml: guard \`promote\` job against non-main \`workflow_dispatch\`
A manual dispatch from a feature branch could flow through e2e and
promote unmerged code to \`:testing\`. Added:
\`\`\`
if: needs.e2e-gate.result == 'success' &&
    (github.event_name == 'workflow_run' || github.ref_name == 'main')
\`\`\`

## Testing

CI-only change: no BST element, filemap, or image structure changes.

- [ ] I am using an agent and I take responsibility for this PR