### PR TITLE
ci: replace inline cosign curl install with sigstore/cosign-installer

### DIFF
--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -201,13 +201,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Install cosign
-        run: |
-          if ! command -v cosign &>/dev/null; then
-            COSIGN_VERSION="v2.5.0"
-            curl -fsSL "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64" \
-              -o "$RUNNER_TEMP/cosign"
-            sudo install -m 0755 "$RUNNER_TEMP/cosign" /usr/local/bin/cosign
-          fi
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Verify signatures for all promoted variants
         env:


### PR DESCRIPTION
## Summary

The `verify-signatures` job in `weekly-testing-promotion.yml` was installing cosign via `curl` with a hardcoded `v2.5.0` version string. This:
- Bypasses Renovate (can't track inline curl installs)
- Diverges from bluefin and bluefin-lts which both use `sigstore/cosign-installer`
- Pins to an old version without a clear upgrade path

## What changes

Replace the inline `curl` install step with `sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2` — same SHA already used by bluefin and bluefin-lts. Renovate can now track and update it.

## Why now

Identified during a release process consistency audit across bluefin, bluefin-lts, and dakota.

## Verification

- pre-commit passes ✅
- actionlint passes ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow processes to improve reliability and maintainability of the testing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->