### PR TITLE
ci: ship :testing on every merge, drop nightly schedule and e2e gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,6 @@
 name: Build Bluefin dakota
 
 on:
-  schedule:
-    # 13:00 UTC daily — gnome-build-meta nightly starts ~02:00 UTC and typically
-    # finishes by ~08:00 UTC (worst-case ~11:30). The 2-hour buffer here handles
-    # normal build-time fluctuations so dakota always picks up the freshest artifacts.
-    - cron: '0 13 * * *'
   pull_request:
     branches: [main]
   merge_group:
@@ -13,8 +8,8 @@ on:
   workflow_dispatch:
     # WARNING: Do not manually dispatch immediately after auto/track-* ref bumps
     # (e.g. Renovate PRs updating gnome-build-meta.bst). Cold builds of GNOME
-    # require gbm.gnome.org to have built the new ref first. The 13:00 UTC
-    # schedule above provides this buffer. Early dispatch = cold build = timeout.
+    # require gbm.gnome.org to have built the new ref first — dispatch too early
+    # and you get a cold build that times out.
 
 permissions: read-all
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -216,32 +216,17 @@ jobs:
           cosign sign -y \
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}@${SBOM_DIGEST}"
 
-  # ── E2E gate ─────────────────────────────────────────────────────────────
-  # Smoke-tests the freshly pushed :$sha before promoting to :testing.
-  # Only runs on schedule and workflow_dispatch — merge_group does not
-  # produce :testing so there is nothing to gate.
-  e2e-gate:
-    needs: [setup, publish]
-    if: >-
-      needs.publish.result == 'success' &&
-      (needs.setup.outputs.event == 'schedule' ||
-       needs.setup.outputs.event == 'workflow_dispatch')
-    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@e7f9c65095a0cbf62689a8cd64a471ee4824630c # main
-    with:
-      image: ghcr.io/projectbluefin/dakota:${{ needs.setup.outputs.sha }}
-      suites: smoke
-    secrets: inherit
-
   # ── Promote :testing ──────────────────────────────────────────────────────
-  # Re-tags :$sha as :testing once e2e passes.
-  # Weekly promotion (weekly-testing-promotion.yml) later promotes :testing
-  # to :latest and :stable via digest-pinned re-tagging.
+  # Re-tags :$sha as :testing immediately after a successful publish on any
+  # main or merge-queue build. No e2e gate here — every merged PR ships to
+  # :testing so users always get the latest code.
+  # e2e only gates the weekly :testing → :stable promotion.
   # NVIDIA is continue-on-error so a failing NVIDIA promote does not
   # prevent the default :testing from landing.
   promote:
-    needs: [setup, publish, e2e-gate]
+    needs: [setup, publish]
     if: >-
-      needs.e2e-gate.result == 'success' &&
+      needs.publish.result == 'success' &&
       (github.event_name == 'workflow_run' || github.ref_name == 'main')
     runs-on: ubuntu-24.04
     strategy:

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -26,27 +26,29 @@ Load when debugging CI failures, understanding the build pipeline, or working wi
 | Published image | `ghcr.io/projectbluefin/dakota:{testing,latest,stable}` and `:$SHA` |
 | Build logs artifact | `buildstream-logs-x86_64-<variant>` (7-day retention) |
 | Trigger (validate) | `pull_request` — `bst show --deps all`, no CAS |
-| Trigger (build) | `merge_group`, `schedule` (13:00 UTC), `workflow_dispatch` |
-| Nightly schedule rationale | gnome-build-meta nightly finishes ~08:00–11:30 UTC; 13:00 UTC picks up fresh artifacts |
+| Trigger (build) | `merge_group`, `workflow_dispatch` (no daily schedule) |
+**Nightly schedule rationale** — no longer applicable; schedule trigger was removed in favour of continuous builds on every merge.
+
+**Merge queue path:** `build` fires on `merge_group` — full OCI build, real CI gate before merge. On success, `publish.yml` immediately promotes the new image to `:testing`.
 
 ## Workflow Files
 
 | File | Role |
 |---|---|
 | `.github/workflows/build.yml` | BST build + push artifacts to remote CAS. Fires on merge_group/schedule/dispatch. Does NOT push to GHCR directly. |
-| `.github/workflows/publish.yml` | 4-stage pipeline: setup → publish → e2e-gate → promote. Pulls artifact from CAS, exports OCI, pushes `:$sha`, signs, attests, smoke-tests, then promotes to `:testing`. |
+| `.github/workflows/publish.yml` | 3-stage pipeline: setup → publish → promote. Pulls artifact from CAS, exports OCI, pushes `:$sha`, signs, attests, then immediately promotes to `:testing` on every successful merge. No e2e gate — that lives only in the weekly promotion. |
 | `.github/workflows/release.yml` | Called from `weekly-testing-promotion.yml` after a successful promotion. Creates GitHub Release with card image, SBOM diff, and package changelog. Also available as `workflow_dispatch` for out-of-band cuts. |
 | `.github/workflows/weekly-testing-promotion.yml` | Weekly Tuesday promotion (06:00 UTC): 7-day floor check → verify `:testing` digests → cosign verify → e2e → promote to `:latest`+`:stable` → fast-forward branches → call `release.yml`. Has `environment: production` gate requiring human approval. |
 | `.github/workflows/e2e.yml` | Smoke test via projectbluefin/testsuite. Fires on PR; `should-run` job skips the test when no image-affecting paths changed. |
 
 ## Trigger Behavior
 
-| Behavior | pull_request | merge_group | schedule | workflow_dispatch |
-|---|---|---|---|---|
-| `validate` job | Yes | No | No | No |
-| `e2e` job | Yes (change-detected) | No | No | Yes |
-| `build` job | No | Yes | Yes | Yes |
-| Push to GHCR? | No | Via publish.yml | Via publish.yml | Via publish.yml |
+| Behavior | pull_request | merge_group | workflow_dispatch |
+|---|---|---|---|
+| `validate` job | Yes | No | No |
+| `e2e` job | Yes (change-detected) | No | Yes |
+| `build` job | No | Yes | Yes |
+| Push to GHCR? | No | Via publish.yml | Via publish.yml |
 
 **PR path:** `validate` + `e2e` (change-detected) — zero remote execution. ~15 min cached, ~30 min cold.
 
@@ -179,6 +181,26 @@ gh run list --repo projectbluefin/dakota --limit 5
 | `update-refs.md` | Understanding the source tracking workflow |
 
 ## Lessons Learned
+
+### Continuous :testing model — every merge ships immediately (2026-06-07)
+
+The pipeline was redesigned so every PR merge produces a new `:testing` image
+without any e2e gate in the publish path. The schedule trigger was removed from
+`build.yml`; builds now only fire on `merge_group` and `workflow_dispatch`.
+
+**New flow:**
+```
+PR merge_group → build.yml → publish.yml → :$sha → :testing  (no e2e)
+                                                           │
+                     weekly-testing-promotion.yml ─────────┘
+                     (e2e gate here, then :stable)
+```
+
+**Implication:** `:testing` may briefly be broken if a PR introduces a regression.
+The e2e gate at the weekly promotion prevents regressions from reaching `:stable`.
+
+**If :testing breaks:** look at the last few merge SHAs and bisect with
+`gh run list --workflow "Publish Bluefin dakota" --limit 10`.
 
 ### publish.yml startup_failure = :testing is stale (2026-06-04)
 


### PR DESCRIPTION
## What

Redesigns the publish pipeline so `:testing` gets a new image on every
PR merge, without a daily schedule or e2e gate in the publish path.

## Why

The old model gated `:testing` on a nightly 13:00 UTC schedule + an
e2e smoke test. This meant:
- `:testing` was always 0–24 hours stale
- merged PRs never directly produced a `:testing` image
- users had to wait overnight to see a fix land in testing

## New flow

```
PR merge_group → build.yml → publish.yml → :$sha → :testing  (no e2e)
                                                         │
                   weekly-testing-promotion.yml ─────────┘
                   (e2e smoke+common, then :stable)
```

**e2e is NOT removed** — it stays in `weekly-testing-promotion.yml` as
the gate before `:stable`. Only the per-build smoke is removed.

## Changes

- `build.yml`: drop `schedule` trigger. Builds fire on `merge_group`
  and `workflow_dispatch` only.
- `publish.yml`: remove `e2e-gate` job. `promote` runs immediately
  after `publish` succeeds (on `workflow_run` from main/merge-queue,
  or manual `workflow_dispatch` on `main`).

## Testing

CI-only change. No BST elements, filemap, or image structure changes.

- [ ] I am using an agent and I take responsibility for this PR