### PR TITLE
ci: relax TOCTOU guards from exact-equality to ancestor check

### DIFF
--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -150,15 +150,33 @@ jobs:
         run: |
           set -euo pipefail
           CURRENT_SHA=$(gh api repos/${{ github.repository }}/git/ref/heads/main --jq '.object.sha')
-          if [[ "${CURRENT_SHA}" != "${SOURCE_SHA}" ]]; then
-            echo "::error::main has advanced since :testing was built."
-            echo "  Built from: ${SOURCE_SHA}"
-            echo "  Current:    ${CURRENT_SHA}"
-            echo "Aborting promotion — re-run after the next testing build completes."
+
+          if [[ "${CURRENT_SHA}" == "${SOURCE_SHA}" ]]; then
+            echo "locked_sha=${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
+            echo "Locked main SHA: ${SOURCE_SHA} (exact match)"
+            exit 0
+          fi
+
+          # With continuous builds, main may have advanced since :testing was built
+          # (a new PR could have merged whose build hasn't completed yet). That is
+          # expected and fine — the :testing image is still a valid ancestor of main.
+          # Only fail if the histories have diverged (force-push or accidental reset).
+          COMPARE_JSON=$(gh api "repos/${{ github.repository }}/compare/${SOURCE_SHA}...${CURRENT_SHA}")
+          COMPARE=$(echo "${COMPARE_JSON}" | jq -r '.status')
+          AHEAD_BY=$(echo "${COMPARE_JSON}" | jq -r '.ahead_by')
+
+          if [[ "${COMPARE}" == "ahead" ]]; then
+            echo "main is ${AHEAD_BY} commit(s) ahead of :testing source — :testing is a valid ancestor"
+            echo "locked_sha=${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
+            echo "Locked source SHA: ${SOURCE_SHA} (${AHEAD_BY} commits behind main HEAD)"
+          else
+            echo "::error::Cannot promote: compare status is '${COMPARE}'"
+            echo "  :testing source: ${SOURCE_SHA}"
+            echo "  main HEAD:       ${CURRENT_SHA}"
+            echo "Expected 'ahead' (main moved forward) or 'identical', got '${COMPARE}'."
+            echo "main may have diverged — manual investigation required."
             exit 1
           fi
-          echo "locked_sha=${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
-          echo "Locked main SHA: ${SOURCE_SHA} (matches tested source)"
 
   # ── Check diff — skip if already promoted ────────────────────────────────
   check-diff:
@@ -295,12 +313,26 @@ jobs:
         run: |
           set -euo pipefail
           CURRENT_SHA=$(gh api repos/${{ github.repository }}/git/ref/heads/main --jq '.object.sha')
-          if [ "$CURRENT_SHA" != "$LOCKED_SHA" ]; then
-            echo "ERROR: main advanced during promotion ($LOCKED_SHA → $CURRENT_SHA). Aborting."
-            echo "Untested commits would reach latest/stable. Rerun next cycle."
+          if [[ "${CURRENT_SHA}" == "${LOCKED_SHA}" ]]; then
+            echo "✅ SHA unchanged: ${CURRENT_SHA}"
+            exit 0
+          fi
+
+          # main may have advanced during e2e (expected with continuous builds).
+          # The promotion is digest-pinned so the image content cannot change.
+          # Only abort if histories have diverged — that would indicate a force-push.
+          COMPARE=$(gh api "repos/${{ github.repository }}/compare/${LOCKED_SHA}...${CURRENT_SHA}" \
+            --jq '.status')
+          if [[ "${COMPARE}" == "ahead" ]]; then
+            AHEAD_BY=$(gh api "repos/${{ github.repository }}/compare/${LOCKED_SHA}...${CURRENT_SHA}" \
+              --jq '.ahead_by')
+            echo "✅ main is ${AHEAD_BY} commit(s) ahead of locked SHA (continuous build expected)"
+            echo "  Locked: ${LOCKED_SHA}  Current: ${CURRENT_SHA}"
+          else
+            echo "ERROR: unexpected compare status '${COMPARE}' ($LOCKED_SHA → $CURRENT_SHA)"
+            echo "main may have diverged — manual investigation required."
             exit 1
           fi
-          echo "✅ SHA unchanged: $CURRENT_SHA"
 
       - name: Promote to :latest and :stable
         env:

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -202,6 +202,19 @@ The e2e gate at the weekly promotion prevents regressions from reaching `:stable
 **If :testing breaks:** look at the last few merge SHAs and bisect with
 `gh run list --workflow "Publish Bluefin dakota" --limit 10`.
 
+**TOCTOU guard interaction:** the weekly promotion's lock-sha step uses a GitHub
+compare API ancestor check rather than exact equality. With continuous builds,
+main will often be 1–2 commits ahead of `:testing` by Tuesday 06:00 UTC. An
+exact-equality check would cause every promotion to fail. The ancestor check
+allows promotion as long as `:testing` is a valid ancestor of main (i.e.,
+histories have not diverged):
+
+```bash
+COMPARE=$(gh api "repos/${REPO}/compare/${SOURCE_SHA}...${CURRENT_SHA}" --jq '.status')
+# "ahead" = main advanced past :testing = normal and fine
+# anything else = diverged = abort
+```
+
 ### publish.yml startup_failure = :testing is stale (2026-06-04)
 
 `startup_failure` on `publish.yml` nightly runs means the BST artifact or


### PR DESCRIPTION
## Problem

With continuous :testing builds (every PR merge from #731), main will
regularly be 1–2 commits ahead of `:testing` at Tuesday 06:00 UTC when
the weekly promotion fires. The existing exact-equality TOCTOU check
aborts if main != :testing source SHA — breaking every promotion when
there's been any recent development.

## Fix

Replace both exact-equality checks in `weekly-testing-promotion.yml`
with GitHub compare API ancestor checks.

**lock-sha step (resolve job):**
```bash
COMPARE=$(gh api "repos/.../compare/${SOURCE_SHA}...${CURRENT_SHA}" --jq '.status')
# "ahead" = main moved forward = expected and fine, proceed
# anything else = diverged = abort
```

**verify-sha-not-advanced step (promote job):** same pattern.

Both checks still abort on `diverged` status (force-push / history
reset), which is the actual threat. An `ahead` result just means new
commits landed since :testing was last built — normal for continuous
builds. The image content is already digest-pinned so no untested code
can reach :stable regardless.

## Testing

CI-only. No BST elements or image changes.

- [ ] I am using an agent and I take responsibility for this PR