### PR TITLE
docs(skills): fix stale CI references and add rubber duck review pattern

### DIFF
--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -35,7 +35,7 @@ Load when debugging CI failures, understanding the build pipeline, or working wi
 
 | File | Role |
 |---|---|
-| `.github/workflows/build.yml` | BST build + push artifacts to remote CAS. Fires on merge_group/schedule/dispatch. Does NOT push to GHCR directly. |
+| `.github/workflows/build.yml` | BST build + push artifacts to remote CAS. Fires on `merge_group` and `workflow_dispatch` only (no schedule). Does NOT push to GHCR directly. |
 | `.github/workflows/publish.yml` | 3-stage pipeline: setup → publish → promote. Pulls artifact from CAS, exports OCI, pushes `:$sha`, signs, attests, then immediately promotes to `:testing` on every successful merge. No e2e gate — that lives only in the weekly promotion. |
 | `.github/workflows/release.yml` | Called from `weekly-testing-promotion.yml` after a successful promotion. Creates GitHub Release with card image, SBOM diff, and package changelog. Also available as `workflow_dispatch` for out-of-band cuts. |
 | `.github/workflows/weekly-testing-promotion.yml` | Weekly Tuesday promotion (06:00 UTC): 7-day floor check → verify `:testing` digests → cosign verify → e2e → promote to `:latest`+`:stable` → fast-forward branches → call `release.yml`. Has `environment: production` gate requiring human approval. |
@@ -447,12 +447,13 @@ gh run list \
 non-main branch flows through e2e and promotes to `:testing`, fast-forwarding the
 `testing` branch to an unmerged commit.
 
-**Fix:** Add a branch guard to the `promote` job:
+**Fix:** Add a branch guard to the `promote` job. Since `e2e-gate` no longer
+exists (continuous build model), the guard goes directly on `promote`:
 ```yaml
 promote:
-  needs: [setup, publish, e2e-gate]
+  needs: [setup, publish]
   if: >-
-    needs.e2e-gate.result == 'success' &&
+    needs.publish.result == 'success' &&
     (github.event_name == 'workflow_run' || github.ref_name == 'main')
 ```
 `workflow_run` events are always safe (they trigger from completed `main`/merge-queue

--- a/docs/skills/pr-review.md
+++ b/docs/skills/pr-review.md
@@ -67,6 +67,27 @@ See `merge-queue.md` for the full retarget/cherry-pick/merge flow.
 
 ## Lessons Learned
 
-Add new lessons below as: `### <pattern name> (YYYY-MM-DD)`
+### Rubber duck CI changes against bluefin/bluefin-lts before merging (2026-06-07)
+
+When making changes to `.github/workflows/` that touch the publish, promote,
+or release pipeline, run a rubber duck comparison against the equivalent
+workflows in `projectbluefin/bluefin` and `projectbluefin/bluefin-lts` before
+opening a PR. This surfaces inconsistencies and cross-repo bugs that pure
+code review misses.
+
+**What to compare:**
+- `cert-identity-regexp` anchoring — must be `^...$` end-anchored (dakoa is correct; bluefin/lts are not)
+- `environment: production` gate placement — should be on image **promotion**, not on release notes creation
+- SBOM handling — artifact-first with Syft fallback is stronger than always regenerating
+- TOCTOU patterns — digest-pinned promotions, single skopeo inspect calls
+
+**Invocation:**
+```
+rubber duck the release pipeline for consistency with projectbluefin/bluefin and bluefin-lts, built on projectbluefin/actions
+```
+
+Then pipe the findings directly into fixes before the PR lands. This session
+caught 4 issues from rubber duck + 1 interaction bug (TOCTOU guard) from
+doublecheck — all fixed before merging.
 
 ---


### PR DESCRIPTION
Skill-only follow-up from today's pipeline work.

## Changes

**`docs/skills/ci.md`**
- `build.yml` row: was still saying "schedule/dispatch" — schedule was
  removed in PR #731
- workflow_dispatch non-main guard lesson: code snippet still showed
  `needs: [setup, publish, e2e-gate]` — `e2e-gate` no longer exists;
  updated to reflect current `promote` job structure

**`docs/skills/pr-review.md`**
- New lesson: run a rubber duck comparison against bluefin/bluefin-lts
  before merging any CI pipeline change. This session demonstrated the
  pattern: rubber duck caught 4 issues, doublecheck caught 1 more, all
  fixed before merging.

- [ ] I am using an agent and I take responsibility for this PR