### PR TITLE
ci: fix Renovate to target testing branch and add runner workflow

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,13 @@
   "extends": [
     "config:recommended",
   ],
-  "baseBranchPatterns": ["main"],
+  // Renovate targets the testing branch for dependency updates.
+  // testing is a git pointer fast-forwarded to the last deployed SHA —
+  // action SHA pin PRs merge here, are validated by Renovate's built-in
+  // automerge (no merge queue on testing), and reach main on the next PR.
+  // Note: track-bst-sources.yml manages BuildStream refs directly and
+  // intentionally targets main — it is not Renovate-managed.
+  "baseBranchPatterns": ["testing"],
   "branchPrefix": "renovate/",
   "schedule": ["* 0-3 * * 1"],
 

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,34 @@
+name: Renovate
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (log only, no PRs created or updated)'
+        type: boolean
+        default: false
+  schedule:
+    - cron: '0 */6 * * *'
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: ${{ inputs.dry_run == true && 'debug' || 'info' }}
+          RENOVATE_DRY_RUN: ${{ inputs.dry_run == true && 'full' || '' }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Run Renovate
         uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14

--- a/docs/skills/add-package.md
+++ b/docs/skills/add-package.md
@@ -138,4 +138,3 @@ install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/systemd/system-preset/
 # ❌ wrong — ignored at boot
 install -Dm644 /dev/stdin "%{install-root}%{sysconfdir}/systemd/system-preset/80-name.preset"
 ```
-

--- a/docs/skills/buildstream.md
+++ b/docs/skills/buildstream.md
@@ -130,4 +130,3 @@ The `(>):` syntax appends to the inherited command list from the element kind. I
 ### `kind: stack` elements produce no filesystem output — they are dep aggregators only (2026-06-07)
 
 `deps.bst` is intentionally `kind: stack`. That means it has zero filesystem output. Only `kind: compose` and `kind: script` elements produce filesystem artifacts. If a new layer element is accidentally typed as `kind: stack`, it will build successfully but the image layer will be empty. Always verify with `grep '^kind:' elements/oci/layers/bluefin.bst`.
-

--- a/docs/skills/oci-layers.md
+++ b/docs/skills/oci-layers.md
@@ -143,4 +143,3 @@ The OCI assembly script in `elements/oci/bluefin.bst` must run steps in this exa
 4. `build-oci` (assemble image)
 
 Running `ldconfig` after `build-oci` has no effect. Running `build-oci` before `dconf update` produces an image with stale/missing dconf databases.
-

--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -147,4 +147,3 @@ The BST export includes `/sysroot/` artifacts (OSTree build tooling leftover). T
 ### Hardware confirmation is required — CI green is not sufficient (2026-06-07)
 
 The validation gate is: `bootc upgrade` on test hardware succeeds + reboot + GDM active. CI passing confirms the image was built and passes `bootc container lint`. It does not confirm the image boots correctly on real hardware. Do not mark issues resolved without hardware evidence, and do not state something is "fixed" based on CI alone.
-

--- a/docs/skills/update-refs.md
+++ b/docs/skills/update-refs.md
@@ -113,4 +113,3 @@ python3 files/scripts/generate_cargo_sources.py /host/Cargo.lock
 ### `just bst source track` only updates `ref:` — it does not regenerate derived sources (2026-06-07)
 
 `bst source track` updates the `ref:` field of `git_repo` and `tar` sources. It does NOT regenerate `cargo2`, `go_module`, or other derived source blocks. Those must be regenerated manually after tracking. Omitting this step is the most common cause of "build passes locally (from cache) but fails from scratch."
-


### PR DESCRIPTION
## Summary

Fixes the Renovate pipeline in dakota so action SHA pin updates flow through the testing branch instead of landing directly on main.

## Problems fixed

### 1. `.github/renovate.json5` — `baseBranchPatterns: ["testing"]`

Was targeting `["main"]`. Renovate manages **only** GitHub Actions SHA pins in this repo (BuildStream sources are tracked by `track-bst-sources.yml`, which intentionally targets main — that is BST-correct and unchanged here). Action SHA bump PRs should stage in testing first, be auto-merged by Renovate's built-in automerge (testing has no merge queue, so GitHub's native automerge works directly), and reach main via the next PR.

### 2. `.github/workflows/renovate.yml` added

Renovate had no per-repo workflow to control its execution. Without this:
- Renovate runs (if at all) are entirely org-level with no per-repo override
- `workflow_dispatch` dry runs for debugging are impossible

This mirrors the pattern in `projectbluefin/bluefin` and `bluefin-lts`.

## What's NOT changed

- `track-bst-sources.yml` — intentionally targets `main` for BST source ref bumps. This is correct BST discipline and is not Renovate-managed.
- The Renovate `packageRules` for action pins — `automerge: true` with `automergeStrategy: squash` (from org-inherited config) handles merging.

## Testing

- [x] `pre-commit run --all-files` passes
- [ ] CI passes on this branch

_This PR was generated by an automated release process audit._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified that passing CI doesn't confirm hardware boot correctness; real hardware validation required.
  * Enhanced guidance on handling dependency updates and OCI build execution order.
  * Improved service configuration examples for clarity.

* **Chores**
  * Updated development infrastructure automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->