### PR TITLE
ci: centralise Renovate runner via projectbluefin/actions reusable

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,23 +14,14 @@ concurrency:
   group: renovate
   cancel-in-progress: false
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   renovate:
-    name: Renovate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          persist-credentials: false
-
-      - name: Run Renovate
-        uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
-        with:
-          token: ${{ secrets.RENOVATE_TOKEN }}
-        env:
-          LOG_LEVEL: ${{ inputs.dry_run == true && 'debug' || 'info' }}
-          RENOVATE_DRY_RUN: ${{ inputs.dry_run == true && 'full' || '' }}
+    # BST note: Renovate targets the testing branch (see renovate.json5).
+    # The testing → main promotion follows the BST build-order discipline.
+    uses: projectbluefin/actions/.github/workflows/reusable-renovate.yml@fcd2a6bac15f2037df2e62572eef7a70fd25759f # v1
+    with:
+      dry_run: ${{ inputs.dry_run == true }}
+    secrets:
+      renovate_token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
## Summary

Delegates `renovate.yml` job logic to `reusable-renovate.yml` in `projectbluefin/actions`, eliminating local duplication and inheriting `persist-credentials: false` consistently. Pinned to `fcd2a6bac15f2037df2e62572eef7a70fd25759f` (actions v1).

BST note preserved: Renovate targets `testing` branch per `renovate.json5`.

## Pre-commit: ✅

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation workflow configuration and permissions handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->