### PR TITLE
docs: add image streams section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,24 @@ Leave a comment, push back on the design, or share how your hardware is affected
 
 Ready to build something? See the [agent-ready queue](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Aqueue%2Fagent-ready+no%3Aassignee) for issues with clear acceptance criteria and no open questions.
 
+## Image streams
+
+| Tag | Stream | What it is |
+|---|---|---|
+| `:latest` | Stable | GNOME 50 — production. Weekly promotion from `:testing`. |
+| `:testing` | Dev | GNOME 50 — daily builds from `main`. Gated by e2e before promotion. |
+| `:next` | Rolling | **GNOME master — the bleeding edge.** Tracks gnome-build-meta `master` daily. Auto-updates, zero maintenance. |
+| `:btw` | Rolling | Alias for `:next`. |
+
+`:next` / `:btw` is the arch competitor stream — latest GNOME the moment it lands upstream, built from source with memory-safe defaults (sudo-rs, uutils-coreutils). If you want to run GNOME before everyone else and help find regressions before they reach stable, this is your image.
+
+```bash
+# Switch to the rolling stream
+sudo bootc switch ghcr.io/projectbluefin/dakota:next
+# or
+sudo bootc switch ghcr.io/projectbluefin/dakota:btw
+```
+
 ## ISO Download
 
 [dakota-live-latest.iso](https://projectbluefin.dev/dakota-live-latest.iso) · [Checksum](https://projectbluefin.dev/dakota-live-latest.iso-CHECKSUM)


### PR DESCRIPTION
Adds an **Image streams** section to the README so users know about `:next`/`:btw`.

## Changes
- Table of all four tags (`:latest`, `:testing`, `:next`, `:btw`) with descriptions
- One-paragraph pitch for the rolling stream
- `bootc switch` commands to opt in

No code changes — docs only.

- [ ] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Image streams" section describing Docker image tags (`:latest`, `:testing`, `:next`, `:btw`) and guidance for switching between different release streams using `bootc switch` commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->