### PR TITLE
revert(uutils-coreutils): remove ghost-specific LTO override

### DIFF
--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -353,6 +353,10 @@ fix must go in ghost's local config — **never in the element itself**. Putting
 in the element invalidates the remote CAS artifact (cache-bust), forcing CI to
 rebuild an element it was already handling correctly.
 
+**Real example (2026-06-07):** Adding `CARGO_PROFILE_RELEASE_LTO: "thin"` to
+`uutils-coreutils.bst` to fix a SIGABRT on ghost caused a 626-element cold rebuild
+in CI. The build ran for 5h31m and timed out without completing (330-minute limit).
+
 **Wrong:** `elements/bluefin/foo.bst` + `environment: CARGO_PROFILE_RELEASE_LTO: "thin"`
 **Right:** ghost `~/.config/buildstream/userconfig.yaml` project/element environment override
 
@@ -365,6 +369,41 @@ projects:
         environment:
           CARGO_PROFILE_RELEASE_LTO: "thin"
 ```
+
+### Diagnosing a build timeout (330-minute limit) (2026-06-07)
+
+A build that hits the 330-minute GitHub Actions timeout shows:
+```
+The action 'Build OCI image with BuildStream' has timed out after 330 minutes.
+```
+
+No element "failed" — the build was still running. Download the logs to find what
+was active at timeout:
+
+```bash
+gh run download <run-id> --repo projectbluefin/dakota \
+  --name buildstream-logs-x86_64-default -D /tmp/bst-logs
+
+# Find elements that were waiting for remote execution when the timeout hit:
+grep -rl "Waiting for the remote build to complete" /tmp/bst-logs/ | while read f; do
+  tail -1 "$f" | grep -q "Waiting" && echo "$f"
+done
+
+# Find the latest-timestamped log files (actively building at timeout):
+find /tmp/bst-logs -name "*.log" | grep -oP '\d{8}-\d{6}' | sort | tail -10
+```
+
+**Root causes of timeouts:**
+
+| Cause | Signal | Fix |
+|---|---|---|
+| Element change invalidated CAS artifact | Many elements building from scratch (600+), cold build of all dependents | Revert the element change; put machine-local workarounds in userconfig |
+| CAS server slow / degraded | Elements stuck "Waiting for the remote build to complete" for hours | Check CAS health; re-trigger after recovery |
+| Single very slow element (e.g. webkitgtk) is a bottleneck | One element dominates build time | Normal; just needs a warm cache hit |
+
+**After fixing the root cause**, the re-triggered build will use the existing CAS
+artifacts for all elements whose cache keys are unchanged — typically a warm build
+completes in under 90 minutes.
 
 ### Promotion pipeline hardening — bonedigger and release race (2026-06-07)
 

--- a/elements/bluefin/uutils-coreutils.bst
+++ b/elements/bluefin/uutils-coreutils.bst
@@ -1,13 +1,5 @@
 kind: make
 
-environment:
-  # uutils Cargo.toml sets lto=true (fat LTO) + codegen-units=1 in the release
-  # profile. Fat LTO with codegen-units=1 causes heap corruption in rustc's LLVM
-  # codegen pass when building inside BST's btrfs overlay sandbox on ghost
-  # (realloc(): invalid next size / SIGABRT). Override to thin LTO which uses far
-  # less memory per compilation unit and is stable in this environment.
-  CARGO_PROFILE_RELEASE_LTO: "thin"
-
 config:
   build-commands:
   - cargo build --release --features feat_os_unix --no-default-features


### PR DESCRIPTION
## What

Reverts the `CARGO_PROFILE_RELEASE_LTO=thin` environment variable added in 23b92fc.

## Why

Setting it in the element changes the BST cache key, which forced a full cold rebuild of 626+ elements in CI. The nightly build timed out after 330 minutes (5h31m) with `btrfs-progs`, `dosfstools`, `samba`, and `webkitgtk-6.0` still waiting on the remote execution service.

Ghost-local workarounds belong in `~/.config/buildstream/userconfig.yaml` on the ghost machine, not in elements.

## Verification

- [x] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed a build-system environment override that could trigger large rebuilds and CI timeouts.

* **Documentation**
  * Added CI troubleshooting guidance: a ghost-specific example about local environment overrides and a “Diagnosing a build timeout (330‑minute limit)” section with symptoms, log commands, root-cause guidance, and remediation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->