### PR TITLE
fix(ci): point Renovate at main, exempt bonedigger from pinning

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,13 +3,11 @@
   "extends": [
     "config:recommended",
   ],
-  // Renovate targets the testing branch for dependency updates.
-  // testing is a git pointer fast-forwarded to the last deployed SHA —
-  // action SHA pin PRs merge here, are validated by Renovate's built-in
-  // automerge (no merge queue on testing), and reach main on the next PR.
+  // Renovate targets main. All PRs must target main — the CI gate
+  // (on-pr-opened-or-updated) blocks any PR not targeting main.
   // Note: track-bst-sources.yml manages BuildStream refs directly and
   // intentionally targets main — it is not Renovate-managed.
-  "baseBranchPatterns": ["testing"],
+  "baseBranchPatterns": ["main"],
   "branchPrefix": "renovate/",
   "schedule": ["* 0-3 * * 1"],
 
@@ -25,6 +23,12 @@
       "matchManagers": ["github-actions"],
       "matchDepTypes": ["action"],
       "pinDigests": true
+    },
+    {
+      // projectbluefin/bonedigger has no versioned releases; @main is intentional.
+      // See .github/workflows/bonedigger.yml and docs/skills/ci-tooling.md.
+      "matchPackageNames": ["projectbluefin/bonedigger"],
+      "enabled": false
     },
     {
       "automerge": true,


### PR DESCRIPTION
## Problem

`baseBranchPatterns` in `.github/renovate.json5` was set to `["testing"]`, but:

1. The `testing` branch has diverged from `main` with no common ancestor — Renovate PRs targeting it can never merge cleanly into `main`
2. The CI gate (`on-pr-opened-or-updated`) blocks **any** PR not targeting `main` — so these PRs could never pass CI either

This caused PRs #738 and #739 to be broken from birth.

## Fix

1. **`baseBranchPatterns: ["testing"] → ["main"]`** — Renovate PRs now target `main` and will pass the CI gate
2. **Exempt `projectbluefin/bonedigger` from digest pinning** — `@main` is an intentional managed floating tag (documented in `bonedigger.yml` and `docs/skills/ci-tooling.md`); Renovate should not override it

## Verification

- [ ] I am using an agent and I take responsibility for this PR

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to direct automated updates to the `main` branch instead of `testing`.
  * Disabled automated dependency updates for a specific GitHub Actions tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->