### PR TITLE
fix(sbom): drop --privileged from bst show / buildstream-sbom runs

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -943,8 +943,6 @@ sbom variant="default":
     # cache is warm before buildstream-sbom runs.
     echo "==> Priming BST generated source cache (${ELEMENT})..."
     podman run --rm \
-        --privileged \
-        --device /dev/fuse \
         --network=host \
         -v "{{justfile_directory()}}:/src:rw" \
         -v "${HOME}/.cache/buildstream:/root/.cache/buildstream:rw" \
@@ -959,8 +957,6 @@ sbom variant="default":
     # names in SPDX output (issue #9 fix). Switch to a versioned PyPI release
     # once the project publishes one.
     podman run --rm \
-        --privileged \
-        --device /dev/fuse \
         --network=host \
         -v "{{justfile_directory()}}:/src:rw" \
         -v "${HOME}/.cache/buildstream:/root/.cache/buildstream:rw" \


### PR DESCRIPTION
## Problem

The `Generate SBOM` step in the publish workflow fails with:

```
crun: opendir `/run/user/1001/crun/.cache/systemd-missing-properties`: Permission denied: OCI permission denied
```

This is caused by the newer `crun` pulled from the `resolute` (Ubuntu 26.04) apt repo probing systemd properties during privileged container startup — something the GHA runner environment doesn't permit.

## Fix

`bst show` and `buildstream-sbom` are read-only operations on BST YAML element files. They don't mount FUSE filesystems or need elevated capabilities. Drop `--privileged` and `--device /dev/fuse` from both `podman run` calls in the `sbom` recipe.

Rootless, unprivileged podman is sufficient.

## Testing

- [ ] I am using an agent and I take responsibility for this PR

Closes the publish regression introduced by the resolute crun upgrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated software bill of materials generation workflow with cache priming enhancements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->