### PR TITLE
fix(justfile): add seccomp=unconfined to just sbom podman invocations

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -944,6 +944,7 @@ sbom variant="default":
     echo "==> Priming BST generated source cache (${ELEMENT})..."
     podman run --rm \
         --privileged \
+        --security-opt seccomp=unconfined \
         --device /dev/fuse \
         --network=host \
         -v "{{justfile_directory()}}:/src:rw" \
@@ -960,6 +961,7 @@ sbom variant="default":
     # once the project publishes one.
     podman run --rm \
         --privileged \
+        --security-opt seccomp=unconfined \
         --device /dev/fuse \
         --network=host \
         -v "{{justfile_directory()}}:/src:rw" \


### PR DESCRIPTION
## Problem

`just sbom` fails in CI with:
```
Error: crun: linkat `.cache/seccomp/...` to `container-id/seccomp.bpf`: Permission denied: OCI permission denied
```

## Root cause

crun 1.15+ caches compiled seccomp BPF programs via `linkat()`. Newer podman (installed via `update-podman: true` in setup-runner) no longer implies `seccomp=unconfined` from `--privileged`. When `buildstream-sbom` calls `bst show` inside the bst2 container, the generated source plugin triggers a nested crun invocation, and crun fails with EPERM trying to cache its seccomp BPF profile.

## Fix

Add `--security-opt seccomp=unconfined` to both `podman run` calls in the `sbom` recipe (prime step + generate step).

Fixes: https://github.com/projectbluefin/dakota/actions/runs/27141921221/job/80109170683

---

- [ ] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container runtime configuration for internal build processes.

---

**Note:** This release contains infrastructure-level updates with no direct impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->