### PR TITLE
fix(sbom): add seccomp=unconfined to just sbom podman invocations

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -944,6 +944,7 @@ sbom variant="default":
     echo "==> Priming BST generated source cache (${ELEMENT})..."
     podman run --rm \
         --network=host \
+        --security-opt seccomp=unconfined \
         -v "{{justfile_directory()}}:/src:rw" \
         -v "${HOME}/.cache/buildstream:/root/.cache/buildstream:rw" \
         -v "${HOME}/.config/buildstream-generate:/root/.config/buildstream-generate:rw" \
@@ -958,6 +959,7 @@ sbom variant="default":
     # once the project publishes one.
     podman run --rm \
         --network=host \
+        --security-opt seccomp=unconfined \
         -v "{{justfile_directory()}}:/src:rw" \
         -v "${HOME}/.cache/buildstream:/root/.cache/buildstream:rw" \
         -v "${HOME}/.config/buildstream-generate:/root/.config/buildstream-generate:rw" \


### PR DESCRIPTION
## Problem

`just sbom` fails in CI (both default and nvidia variants) with:
```
Error: crun: linkat `.cache/seccomp/c4b8ed...` to `container-id/seccomp.bpf`: Permission denied: OCI permission denied
error: recipe `sbom` failed with exit code 126
```

## Root cause analysis

crun 1.21 (resolute/Ubuntu 26.04) caches compiled seccomp BPF programs using `linkat()`. The linkat fails with EPERM on the GitHub Actions runner — likely due to `fs.protected_hardlinks` or user-namespace restrictions preventing the hard-link from the seccomp cache to the container bundle path.

**The previous fix (#745) dropped `--privileged` but did not address the root cause**: crun fails on any `podman run` immediately when it tries to cache the seccomp BPF filter, regardless of privilege level. Confirmed by run [27144460494](https://github.com/projectbluefin/dakota/actions/runs/27144460494/job/80118251435) which still fails after #745.

## Fix

Add `--security-opt seccomp=unconfined` to both `podman run` calls in the `sbom` recipe (prime step + generate step). This prevents crun from compiling or caching any seccomp BPF program, avoiding the `linkat` entirely. `bst show` and `buildstream-sbom` are read-only BST operations with no need for seccomp filtering.

Supersedes the incomplete fix in #745.

---

- [x] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SBOM generation process container execution settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->