### PR TITLE
fix(sbom): use runc runtime to bypass crun 1.21 GHA runner failures

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -944,7 +944,7 @@ sbom variant="default":
     echo "==> Priming BST generated source cache (${ELEMENT})..."
     podman run --rm \
         --network=host \
-        --security-opt seccomp=unconfined \
+        --runtime runc \
         -v "{{justfile_directory()}}:/src:rw" \
         -v "${HOME}/.cache/buildstream:/root/.cache/buildstream:rw" \
         -v "${HOME}/.config/buildstream-generate:/root/.config/buildstream-generate:rw" \
@@ -959,7 +959,7 @@ sbom variant="default":
     # once the project publishes one.
     podman run --rm \
         --network=host \
-        --security-opt seccomp=unconfined \
+        --runtime runc \
         -v "{{justfile_directory()}}:/src:rw" \
         -v "${HOME}/.cache/buildstream:/root/.cache/buildstream:rw" \
         -v "${HOME}/.config/buildstream-generate:/root/.config/buildstream-generate:rw" \

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -182,6 +182,49 @@ gh run list --repo projectbluefin/dakota --limit 5
 
 ## Lessons Learned
 
+### crun 1.21 (resolute) breaks just sbom on GHA — use --runtime runc (2026-06-08)
+
+`update-podman: true` in `setup-runner` installs crun 1.21 from Ubuntu 26.04
+(resolute). This version has two new failure modes that break `just sbom` on
+GHA runners:
+
+1. **seccomp BPF linkat EPERM** — crun caches compiled seccomp BPF programs
+   via `linkat()`. The GHA runner kernel's `fs.protected_hardlinks` or user-
+   namespace restrictions block the hard-link from `.cache/seccomp/` to the
+   container bundle path:
+   ```
+   crun: linkat `.cache/seccomp/<hash>` to `<container-id>/seccomp.bpf`: Permission denied
+   ```
+
+2. **systemd probe EACCES** — crun probes systemd presence and caches the result
+   in `$XDG_RUNTIME_DIR/crun/.cache/systemd-missing-properties`. On GHA the
+   runtime dir is either uninitialised or was created by root in a prior privileged
+   step, causing user 1001 to get EACCES:
+   ```
+   crun: opendir `/run/user/1001/crun/.cache/systemd-missing-properties`: Permission denied
+   ```
+
+**Fix:** add `--runtime runc` to both `podman run` calls in `just sbom`. runc is
+always available on ubuntu-24.04 GHA runners (Docker installs it). runc has
+neither the seccomp BPF caching nor the systemd probing.
+
+**Wrong partial fixes (both insufficient alone):**
+- Dropping `--privileged` (#745) — doesn't prevent either error
+- Adding `--security-opt seccomp=unconfined` (#747) — fixes error 1 but not error 2
+
+**Do not** add `seccomp=unconfined` as a workaround; use `--runtime runc` instead.
+`bst show` and `buildstream-sbom` are read-only BST operations; runc is fully
+sufficient.
+
+```justfile
+# ✅ correct
+podman run --rm --network=host --runtime runc ...
+
+# ❌ wrong — triggers crun 1.21 failure modes
+podman run --rm --network=host ...
+podman run --rm --network=host --security-opt seccomp=unconfined ...
+```
+
 ### Continuous :testing model — every merge ships immediately (2026-06-07)
 
 The pipeline was redesigned so every PR merge produces a new `:testing` image


### PR DESCRIPTION
## Problem

`just sbom` fails on GHA runners after `update-podman: true` upgrades crun to 1.21 (resolute/Ubuntu 26.04). Two successive failure modes:

**Run 1 (pre-fix):** `crun: linkat .cache/seccomp/... Permission denied`
**Run 2 (after #747 seccomp=unconfined):** `crun: opendir /run/user/1001/crun/.cache/systemd-missing-properties: Permission denied`

Both are crun 1.21-specific behaviours:
1. crun now caches compiled seccomp BPF via `linkat()` — fails with EPERM on GHA
2. crun probes systemd presence and caches the result in the XDG_RUNTIME_DIR — the directory is owned by root from a prior privileged step or is never initialised in the non-login GHA environment, so user 1001 gets EACCES

## Fix

Switch both `podman run` calls in `just sbom` from crun to runc via `--runtime runc`. runc is available on all ubuntu-24.04 GHA runners (installed by Docker). runc has neither the seccomp BPF caching nor the systemd probing, so both failure modes disappear.

`bst show` and `buildstream-sbom` are read-only operations on BST YAML files — runc is fully sufficient.

Supersedes the partial fixes in #745 and #747.

Failing run showing the second error: https://github.com/projectbluefin/dakota/actions/runs/27146970327/job/80127338444

---

- [x] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container runtime used during SBOM generation to improve reliability on CI runners.

* **Documentation**
  * Added a "Lessons Learned" note describing failures observed with a specific container runtime on CI, the recommended runtime change, and why previous workaround attempts were insufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->