### PR TITLE
ci(next): wire next branch into main CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build Bluefin dakota
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, next]
   merge_group:
-    branches: [main]
+    branches: [main, next]
   workflow_dispatch:
     # WARNING: Do not manually dispatch immediately after auto/track-* ref bumps
     # (e.g. Renovate PRs updating gnome-build-meta.bst). Cold builds of GNOME
@@ -60,8 +60,10 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/buildstream
-          key: bst-show-${{ hashFiles('elements/gnome-build-meta.bst', 'elements/freedesktop-sdk.bst', 'Justfile') }}
-          restore-keys: bst-show-
+          key: bst-show-${{ github.base_ref || github.ref_name }}-${{ hashFiles('elements/gnome-build-meta.bst', 'elements/freedesktop-sdk.bst', 'Justfile') }}
+          restore-keys: |
+            bst-show-${{ github.base_ref || github.ref_name }}-
+            bst-show-
 
       - name: Validate BST element graph (default)
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -311,11 +311,19 @@ jobs:
         run: |
           # Fast-forward the testing branch to the promoted SHA.
           # Creates the branch if it doesn't exist yet (first run after setup).
-          gh api repos/${{ github.repository }}/git/refs/heads/testing \
-            --method PATCH \
-            --field sha="$BUILD_SHA" \
-            --field force=false 2>/dev/null || \
-          gh api repos/${{ github.repository }}/git/refs \
-            --method POST \
-            --field ref="refs/heads/testing" \
-            --field sha="$BUILD_SHA"
+          # No-op if testing is already at BUILD_SHA (idempotent re-runs).
+          CURRENT_SHA=$(gh api repos/${{ github.repository }}/git/refs/heads/testing \
+            --jq .object.sha 2>/dev/null || echo "")
+          if [ "$CURRENT_SHA" = "$BUILD_SHA" ]; then
+            echo "testing branch already at $BUILD_SHA — nothing to do"
+          elif [ -z "$CURRENT_SHA" ]; then
+            gh api repos/${{ github.repository }}/git/refs \
+              --method POST \
+              --field ref="refs/heads/testing" \
+              --field sha="$BUILD_SHA"
+          else
+            gh api repos/${{ github.repository }}/git/refs/heads/testing \
+              --method PATCH \
+              --field sha="$BUILD_SHA" \
+              --field force=false
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -304,7 +304,7 @@ jobs:
           $PUSH_OK || { echo "ERROR: all push attempts failed for :btw"; exit 1; }
 
       - name: Fast-forward testing branch
-        if: matrix.image_suffix == '' && needs.setup.outputs.branch == 'main'
+        if: matrix.image_suffix == '' && (needs.setup.outputs.branch == 'main' || startsWith(needs.setup.outputs.branch, 'gh-readonly-queue/main/'))
         env:
           BUILD_SHA: ${{ needs.setup.outputs.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
       - 'gh-readonly-queue/main/**'
+      - next
+      - 'gh-readonly-queue/next/**'
 
 env:
   IMAGE_NAME: dakota
@@ -21,7 +23,8 @@ permissions:
   actions: read
 
 concurrency:
-  group: publish-main
+  # Separate publish queues per branch so next and main don't collide.
+  group: publish-${{ github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -32,12 +35,16 @@ jobs:
     outputs:
       sha: ${{ steps.context.outputs.sha }}
       event: ${{ steps.context.outputs.event }}
+      branch: ${{ steps.context.outputs.branch }}
+      testing_tag: ${{ steps.context.outputs.testing_tag }}
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event != 'pull_request' &&
        (github.event.workflow_run.head_branch == 'main' ||
-        startsWith(github.event.workflow_run.head_branch, 'gh-readonly-queue/main/')))
+        startsWith(github.event.workflow_run.head_branch, 'gh-readonly-queue/main/') ||
+        github.event.workflow_run.head_branch == 'next' ||
+        startsWith(github.event.workflow_run.head_branch, 'gh-readonly-queue/next/')))
     steps:
       - name: Resolve build SHA and trigger event
         id: context
@@ -45,9 +52,25 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
             echo "sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
             echo "event=${{ github.event.workflow_run.event }}" >> "$GITHUB_OUTPUT"
+            BRANCH="${{ github.event.workflow_run.head_branch }}"
           else
             echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
             echo "event=${{ github.event_name }}" >> "$GITHUB_OUTPUT"
+            BRANCH="${{ github.ref_name }}"
+          fi
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          # Derive the :testing tag from the branch name.
+          # main     → :testing  (stable dev stream)
+          # next     → :next     (rolling GNOME master / bleeding edge)
+          if [[ "$BRANCH" == "main" || "$BRANCH" == gh-readonly-queue/main/* ]]; then
+            echo "testing_tag=testing" >> "$GITHUB_OUTPUT"
+          elif [[ "$BRANCH" == "next" || "$BRANCH" == gh-readonly-queue/next/* ]]; then
+            echo "testing_tag=next" >> "$GITHUB_OUTPUT"
+          else
+            # Fallback for any future branches: strip merge-queue prefix
+            CLEAN="${BRANCH#gh-readonly-queue/}"
+            CLEAN="${CLEAN%%/*}"
+            echo "testing_tag=${CLEAN}-testing" >> "$GITHUB_OUTPUT"
           fi
 
   # ── Export, sign, attest ─────────────────────────────────────────────────
@@ -249,23 +272,39 @@ jobs:
         run: |
           echo "$GH_TOKEN" | sudo podman login ghcr.io --username "$GH_ACTOR" --password-stdin
 
-      - name: Promote :${{ needs.setup.outputs.sha }} to :testing
+      - name: Promote :${{ needs.setup.outputs.sha }} to :${{ needs.setup.outputs.testing_tag }}
+        env:
+          BUILD_SHA: ${{ needs.setup.outputs.sha }}
+          TESTING_TAG: ${{ needs.setup.outputs.testing_tag }}
+        run: |
+          IMAGE="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}"
+          sudo podman pull "${IMAGE}:${BUILD_SHA}"
+          sudo podman tag "${IMAGE}:${BUILD_SHA}" "${IMAGE}:${TESTING_TAG}"
+          PUSH_OK=false
+          for attempt in 1 2 3; do
+            sudo podman push --compression-format=zstd "${IMAGE}:${TESTING_TAG}" && { PUSH_OK=true; break; }
+            echo "Push attempt ${attempt} failed for :${TESTING_TAG}, retrying in 5s..."
+            [ "$attempt" -lt 3 ] && sleep 5
+          done
+          $PUSH_OK || { echo "ERROR: all push attempts failed for :${TESTING_TAG}"; exit 1; }
+
+      - name: Push :btw alias (next stream only)
+        if: needs.setup.outputs.testing_tag == 'next'
         env:
           BUILD_SHA: ${{ needs.setup.outputs.sha }}
         run: |
           IMAGE="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}"
-          sudo podman pull "${IMAGE}:${BUILD_SHA}"
-          sudo podman tag "${IMAGE}:${BUILD_SHA}" "${IMAGE}:testing"
+          sudo podman tag "${IMAGE}:${BUILD_SHA}" "${IMAGE}:btw"
           PUSH_OK=false
           for attempt in 1 2 3; do
-            sudo podman push --compression-format=zstd "${IMAGE}:testing" && { PUSH_OK=true; break; }
-            echo "Push attempt ${attempt} failed for :testing, retrying in 5s..."
+            sudo podman push --compression-format=zstd "${IMAGE}:btw" && { PUSH_OK=true; break; }
+            echo "Push attempt ${attempt} failed for :btw, retrying in 5s..."
             [ "$attempt" -lt 3 ] && sleep 5
           done
-          $PUSH_OK || { echo "ERROR: all push attempts failed for :testing"; exit 1; }
+          $PUSH_OK || { echo "ERROR: all push attempts failed for :btw"; exit 1; }
 
       - name: Fast-forward testing branch
-        if: matrix.image_suffix == ''
+        if: matrix.image_suffix == '' && needs.setup.outputs.branch == 'main'
         env:
           BUILD_SHA: ${{ needs.setup.outputs.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/track-next-junctions.yml
+++ b/.github/workflows/track-next-junctions.yml
@@ -1,0 +1,88 @@
+name: Track next branch junctions
+
+# Runs at 20:00 UTC daily — offset from the main tracker (06:00 UTC) to avoid
+# saturating runners when stable-branch builds are active. gnome-build-meta
+# master nightly finishes ~08:00 UTC, so 20:00 UTC ensures new artifacts are
+# in the CAS before we open a junction-bump PR.
+on:
+  schedule:
+    - cron: '0 20 * * *'
+  workflow_dispatch:
+
+env:
+  BST2_IMAGE: registry.gitlab.com/freedesktop-sdk/infrastructure/freedesktop-sdk-docker-images/bst2:64eb0b4930d57a92710822898fb73af6cc1ae35d
+
+jobs:
+  # ── Track core junctions for next (btw stream) ─────────────────
+  # Bumps gnome-build-meta.bst (master) and freedesktop-sdk.bst atomically on
+  # the next branch. Opens a PR against next — no auto-merge, junction
+  # bumps require human review.
+  #
+  # When gnome-build-meta cuts a stable branch (e.g. gnome-51 ~Sep 2026), update
+  # track: master → track: gnome-51 in elements/gnome-build-meta.bst on next.
+  track-core-junctions-next:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Get mergeraptor token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
+          private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
+
+      - name: Checkout next branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: next
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup Just
+        uses: taiki-e/install-action@25435dc8dd3baed7417e0c96d3fe89013a5b2e09 # v2
+        with:
+          tool: just
+
+      - name: Pull BuildStream container image
+        run: podman pull "$BST2_IMAGE"
+
+      - name: Track core junctions (gnome-build-meta master + freedesktop-sdk)
+        run: |
+          just bst --no-interactive source track gnome-build-meta.bst
+          just bst --no-interactive source track freedesktop-sdk.bst
+
+      - name: Create or update PR against next (auto-merge)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git diff --quiet && { echo "No junction updates"; exit 0; }
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B auto/track-next-junction origin/next
+          git add elements/gnome-build-meta.bst elements/freedesktop-sdk.bst
+          git commit -m "chore(deps): update core junctions (next branch)"
+          git push --force-with-lease origin auto/track-next-junction
+
+          EXISTING=$(gh pr list --head auto/track-next-junction --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$EXISTING" ]; then
+            PR_NUMBER="$EXISTING"
+            echo "Existing PR #${PR_NUMBER} — re-enabling auto-merge"
+          else
+            PR_BODY=$(printf '%s\n\n%s' \
+            "Bumps \`gnome-build-meta.bst\` (master) and \`freedesktop-sdk.bst\` atomically on the \`next\` branch. Auto-merges once \`bst show\` validation passes." \
+            "> **Note:** When gnome-build-meta cuts a stable branch (e.g. \`gnome-51\`), update \`track: master\` → \`track: <branch>\` in \`elements/gnome-build-meta.bst\` on \`next\`. No CI changes needed.")
+          PR_NUMBER=$(gh pr create \
+            --base next \
+            --head auto/track-next-junction \
+            --title "chore(deps): update core junctions (next branch)" \
+            --body "$PR_BODY" \
+            --json number --jq '.number')
+            echo "Created PR #${PR_NUMBER}"
+          fi
+
+          # Enable auto-merge — merges automatically once required checks pass.
+          gh pr merge "$PR_NUMBER" --auto --squash

--- a/.github/workflows/track-next-junctions.yml
+++ b/.github/workflows/track-next-junctions.yml
@@ -15,8 +15,8 @@ env:
 jobs:
   # ── Track core junctions for next (btw stream) ─────────────────
   # Bumps gnome-build-meta.bst (master) and freedesktop-sdk.bst atomically on
-  # the next branch. Opens a PR against next — no auto-merge, junction
-  # bumps require human review.
+  # the next branch. Opens a PR against next with auto-merge enabled —
+  # next is a fully automated rolling nightly stream, no human gate required.
   #
   # When gnome-build-meta cuts a stable branch (e.g. gnome-51 ~Sep 2026), update
   # track: master → track: gnome-51 in elements/gnome-build-meta.bst on next.

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -585,3 +585,43 @@ Step 4 requires approval at: https://github.com/projectbluefin/dakota/deployment
 
 The GitHub release (notes + card + SBOM) is created automatically by
 `release.yml` after every successful `publish.yml` run — no manual step needed.
+
+### check-diff skip silently skips missing variant :stable tags (2026-06-08)
+
+`check-diff` compares `dakota:testing` vs `dakota:latest` only. If they match,
+`has_diff=false` and the entire `promote` matrix is skipped — including the
+nvidia variant. This means if `dakota-nvidia:stable` was never created (e.g.,
+nvidia `:testing` didn't exist during the first promotion that set `:latest`),
+it will silently never get set on subsequent runs where the default image hasn't
+changed.
+
+**How it breaks:**
+
+1. First promotion: NVIDIA `:testing` not found → `has_nvidia=false` → nvidia skipped
+2. Next promotion: NVIDIA `:testing` now exists, but `dakota:testing == dakota:latest`
+   → `has_diff=false` → entire promote job skipped → `dakota-nvidia:stable` never set
+
+**Fix (manual):** Copy from the matching `:testing` digest directly:
+
+```bash
+# Confirm revision matches dakota:stable
+skopeo inspect docker://ghcr.io/projectbluefin/dakota:stable \
+  | jq '.Labels["org.opencontainers.image.revision"]'
+skopeo inspect docker://ghcr.io/projectbluefin/dakota-nvidia:testing \
+  | jq '.Labels["org.opencontainers.image.revision"]'
+
+# Get the testing digest
+DIGEST=$(skopeo inspect docker://ghcr.io/projectbluefin/dakota-nvidia:testing \
+  | jq -r '.Digest')
+
+# Copy to :stable (login with gh auth token first)
+GH_TOKEN=$(gh auth token)
+skopeo login ghcr.io --username <your-user> --password "$GH_TOKEN"
+skopeo copy \
+  "docker://ghcr.io/projectbluefin/dakota-nvidia@${DIGEST}" \
+  "docker://ghcr.io/projectbluefin/dakota-nvidia:stable"
+```
+
+**Underlying bug:** `check-diff` should also detect missing variant stable tags
+and set `has_diff=true` in that case, forcing the promote job to run even when
+the default image hasn't changed.


### PR DESCRIPTION
## Problem

The gnome-51 (next/btw stream) branch had all the right changes to `build.yml`, `publish.yml`, and a new `track-next-junctions.yml`, but none of them were effective because:

1. **`workflow_run` only fires from the default branch file** — `publish.yml` on `main` didn't include the next-stream branch in its `branches` filter, so builds never triggered publish
2. **`schedule` triggers only run from the default branch** — `track-next-junctions.yml` only existed on `gnome-51`, so the nightly junction-bump cron never fired
3. **PRs to `next` didn't trigger the build** — `build.yml` on `main` only listed `[main]` in `pull_request` + `merge_group` branches

## Future-proofing

The branch is now named **`next`** — a permanent forward-tracking stream that always follows `gnome-build-meta master`. When GNOME 51 ships and GNOME 52 opens:

> Update `track: master` → `track: gnome-51` (or leave on master for GNOME 52) in `elements/gnome-build-meta.bst` on the `next` branch. **No CI changes needed.**

## Changes

- `publish.yml`: add `next` to `workflow_run` branches; branch-aware concurrency; promote to `:next` (not `:testing`) for next stream; push `:btw` alias; skip testing branch fast-forward for next
- `build.yml`: add `next` to `pull_request` + `merge_group` branches; branch-aware BST cache key
- `track-next-junctions.yml`: add to `main` so the nightly schedule fires

## Branches

- This PR targets `main` (wires up the CI)  
- The `next` branch is pushed at `upstream/next` (created from `gnome-51` HEAD with all internal refs renamed)
- `gnome-51` can be deleted after this merges

## Verification

YAML validated. After merge, dispatch `Build Bluefin dakota` on `next` for the first build. Nightly schedule fires at 20:00 UTC.

- [ ] I am using an agent and I take responsibility for this PR