### PR TITLE
fix(ci): skip storage-service in export/publish jobs

### DIFF
--- a/.github/actions/generate-bst-ci-config/action.yml
+++ b/.github/actions/generate-bst-ci-config/action.yml
@@ -89,6 +89,14 @@ runs:
               client-key: /src/client.key
               client-cert: /src/client.crt
 
+        BSTCONFCACHE
+
+          # storage-service routes the local casd through the remote server.
+          # Export/publish jobs skip this — the remote server's per-client quota
+          # is too small to materialise large (GNOME 51+) artifacts during export.
+          # Build jobs use it so artifacts are pushed directly to the remote CAS.
+          if [[ "${ENABLE_PUSH:-true}" == "true" ]]; then
+            cat >> buildstream-ci.conf <<'BSTCONFSTORAGE'
         cache:
           storage-service:
             url: https://cache.projectbluefin.io:11002
@@ -100,7 +108,8 @@ runs:
             auth:
               client-key: /src/client.key
               client-cert: /src/client.crt
-        BSTCONFCACHE
+        BSTCONFSTORAGE
+          fi
 
           if [[ "$ENABLE_REMOTE_EXECUTION" == "true" ]]; then
             cat >> buildstream-ci.conf <<'BSTCONFREMOTE'


### PR DESCRIPTION
## Problem

GNOME 51 (`next` branch) produces ~8.5GB artifacts. During `bst export` in the publish job, the remote CAS (`cache.projectbluefin.io`) returns:

```
OutOfSpaceException: Insufficient storage quota
```

This happens because `cache.storage-service` routes the local casd through the remote server, and the remote's per-client quota is too small to materialise the full artifact.

## Fix

Skip `cache.storage-service` when `enable-push: false` (i.e., export/publish jobs). These jobs use local disk for casd storage instead — the runner's BTRFS volume has sufficient space.

Build jobs (`enable-push: true`) keep `storage-service` unchanged.

Closes the export failure seen in https://github.com/projectbluefin/dakota/actions/runs/27209658353

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration to conditionally manage storage service settings based on deployment requirements, improving build consistency and deployment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->