### PR TITLE
docs: document :next/:btw stream, export CAS fix, and next branch ops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ common ────────────────────────�
 bluefin  (main→stable)       ←── images ──→ testsuite (e2e gate)
 bluefin-lts (main→lts)       ←── images ──→ testsuite (e2e gate)
 dakota  (main→testing→latest/stable) ←── images ──→ testsuite (e2e gate)
+dakota  (next→:next/:btw, rolling nightly, no stable promotion)
                                  │
                                  ▼
                                 iso (installation media)
@@ -22,6 +23,10 @@ dakota  (main→testing→latest/stable) ←── images ──→ testsuite (e
 
 Each image repo pulls `ghcr.io/projectbluefin/common:latest` as a base layer.
 testsuite gates `:testing` promotion nightly and `:latest`/`:stable` promotion weekly.
+
+**Dakota image streams:**
+- `:testing` / `:latest` / `:stable` — `main` branch, GNOME 50 stable, e2e-gated weekly promotion
+- `:next` / `:btw` — `next` branch, GNOME 51 master, fully automated rolling nightly, **no promotion to stable ever**
 
 **`elements/bluefin/common.bst` strips bluefin-only content from common.** Any file added to `common/system_files/shared/` that does not apply to a fresh dakota install must be explicitly `rm -f`'d in the `install-commands` block of that element. Current stripped files: `rechunker-group-fix` script, service, and preset (chunka migration aid — not needed on fresh dakota).
 

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -33,6 +33,7 @@ Every agent session produces two outputs: **the work** (the PR) and **the learni
 | Local OTA testing (QEMU or physical hardware) | [`local-ota.md`](local-ota.md) |
 | CI pipeline, remote cache, GHCR | [`ci.md`](ci.md) |
 | Manual promotion (testing → stable) and release | [`ci.md`](ci.md) — *Manual stable promotion flow* |
+| `:next`/`:btw` rolling GNOME 51 stream | [`overview.md`](overview.md) — *Image Streams* + [`ci.md`](ci.md) |
 | Clearing stuck merge queue | [`merge-queue.md`](merge-queue.md) |
 | Actionadon lifecycle, issue queue, data donation | [`actionadon.md`](actionadon.md) |
 | Project overview and what Dakota is | [`overview.md`](overview.md) |

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -682,3 +682,78 @@ required. This is intentional and differs from core junction bumps on `main`
 
 `track-next-junctions.yml` schedules nightly junction tracking on the `next`
 branch. PRs it opens get auto-merged once required checks pass.
+
+### export/publish jobs must skip storage-service — remote CAS quota too small for GNOME 51 (2026-06-09)
+
+**Symptom:** `bst export` in the publish job fails with:
+```
+OutOfSpaceException: Insufficient storage quota
+errMsg = "Insufficient storage quota" (buildboxcommon_lrulocalcas.cpp:383)
+```
+The blob is `~8.5 GB` (GNOME 51 root artifact is significantly larger than GNOME 50).
+
+**Root cause:** `cache.storage-service` in the BST config routes the local casd
+through `cache.projectbluefin.io`. The remote server's per-client storage quota
+is exceeded when materialising the full artifact for export. Build jobs are fine
+because they write blobs incrementally as they are built; export pulls the entire
+artifact at once.
+
+**Fix (already in `generate-bst-ci-config/action.yml`):**
+`cache.storage-service` is only written when `enable-push: true` (build jobs).
+Export/publish jobs (`enable-push: false`) use local disk for the casd.
+The runner's BTRFS volume has sufficient space for export.
+
+**Do not revert this.** Any future regression will show this same symptom on
+the `next`/`:btw` stream, which produces the largest artifacts.
+
+### First cold build of next branch will timeout — retrigger until cache warms (2026-06-09)
+
+The `next` branch tracks gnome-build-meta `master` (GNOME 51+). The first build
+after branching or a major gnome-build-meta ref bump is a **full cold build** of
+the entire GNOME stack — ~700+ elements. This exceeds the 330-minute GHA timeout.
+
+**This is expected and normal.** Each run pushes built artifacts to
+`cache.projectbluefin.io`. Simply retrigger the build — each run picks up from
+where the previous one left off:
+
+```bash
+gh workflow run build.yml --repo projectbluefin/dakota --ref next
+```
+
+Typically takes 2–3 runs to warm the full cache. Subsequent builds (after
+junction bumps) are incremental (~3–25 min).
+
+**Indicator that cache is warm:** build jobs complete in <5 minutes — all
+artifacts are cache hits and no compilation occurs.
+
+### next branch needs manual cherry-picks of main fixes (2026-06-09)
+
+`next` is a long-lived parallel branch. Bug fixes merged to `main`
+(e.g., sbom crun fixes, CI improvements) do **not** automatically land on `next`.
+
+Before debugging a failure on `next`, check if the same fix is already on `main`:
+
+```bash
+git log upstream/next..upstream/main --oneline -- Justfile .github/
+```
+
+Cherry-pick selectively:
+```bash
+git checkout upstream/next -b fix/next-sync
+git cherry-pick <sha1> <sha2> <sha3>
+git push upstream fix/next-sync:next
+```
+
+Commits to watch for: any `fix(sbom):`, `fix(ci):`, or `fix(publish):` commits
+on `main` that touch `Justfile` or `.github/`.
+
+### :next build only fires on junction bumps — not a guaranteed nightly (2026-06-09)
+
+`build.yml` has no `schedule:` trigger. The `next` branch builds when:
+1. `track-next-junctions.yml` bumps gnome-build-meta master (20:00 UTC nightly,
+   only if upstream advanced that day) → auto-merge PR → merge_group build
+2. Manual `workflow_dispatch`
+
+On days where gnome-build-meta `master` does not advance, **no build fires**.
+For a guaranteed nightly, a `schedule:` trigger on `next` is needed in
+`build.yml`. This is a known gap — track it if builds go stale.

--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -31,6 +31,7 @@ Load when you need context on what dakota is, how it differs from production Blu
 
 **Production image = `ghcr.io/projectbluefin/dakota:stable`.**
 - Streams: `:testing` (nightly, e2e-gated), `:latest` + `:stable` (weekly promotion)
+- Rolling nightly stream: `:next` / `:btw` (GNOME 51 master — see below)
 - When someone says "is X in the image", check the GHCR image via `skopeo inspect` or `podman run --rm` — not a local machine unless explicitly asked.
 
 **Verify hypothesis before stating root cause.**
@@ -44,7 +45,44 @@ freedesktop-sdk provides glibc/systemd/kernel, gnome-build-meta provides GNOME S
 
 **Key positioning:** Dakota is a **curated subset** of production Bluefin, not a 1:1 clone. It intentionally includes things production Bluefin doesn't have (sudo-rs, uutils-coreutils, GNOME nightly) and intentionally omits things that don't make sense for a from-source build (Nvidia drivers, ZFS, enterprise AD/Kerberos).
 
-Published image: `ghcr.io/projectbluefin/dakota:{testing,latest,stable}`
+Published image: `ghcr.io/projectbluefin/dakota:{testing,latest,stable,:next,:btw}`
+
+## Image Streams
+
+| Tag | Branch | GNOME | Cadence | Stability |
+|-----|--------|-------|---------|-----------|
+| `:testing` | `main` | GNOME 50 (stable) | Every merged PR | e2e-gated |
+| `:latest` / `:stable` | `main` | GNOME 50 (stable) | Weekly promotion | Production |
+| `:next` | `next` | GNOME 51 (master) | On junction bump (~nightly) | Experimental |
+| `:btw` | `next` | GNOME 51 (master) | Same as `:next`, nvidia variant | Experimental |
+
+### `:next` / `:btw` — Rolling GNOME 51 stream
+
+`:next` is dakota's fastest variant — tracks gnome-build-meta `master` (GNOME 51
+development branch). It is positioned as the arch-competitor stream: newest
+GNOME Shell, newest GTK, newest everything.
+
+**Key differences from `main`:**
+- `gnome-build-meta.bst` tracks `master` (not `gnome-50`)
+- No bootc override (GNOME 51 master ships current bootc)
+- Junction bumps are **fully automated** — `track-next-junctions.yml` at 20:00
+  UTC opens auto-merge PRs; no human review required
+- **No promotion to `:stable`** — ever. This stream does not feed the weekly
+  release pipeline.
+- Fixes from `main` (sbom, CI) must be **manually cherry-picked** to `next` —
+  they do not land automatically.
+
+**When working on `next`:**
+```bash
+git checkout upstream/next -b fix/my-next-fix
+git push upstream fix/my-next-fix:next   # push directly, no PR needed for fixes
+```
+
+**Sync fixes from main:**
+```bash
+git log upstream/next..upstream/main --oneline -- Justfile .github/
+git cherry-pick <shas>
+```
 
 **Historical path note:** the repo still uses `bluefin` in key filenames such as
 `elements/bluefin/*` and `oci/bluefin.bst`. Those are Dakota paths, not proof


### PR DESCRIPTION
Session learnings from launching the :next/:btw GNOME 51 rolling stream.

**AGENTS.md:** add :next/:btw to repo map and image stream summary
**overview.md:** Image Streams table + :next/:btw ops section  
**ci.md:** 4 new lessons — CAS quota fix, cold build strategy, next cherry-picks, build trigger gap  
**README.md:** routing table entry for :next/:btw

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the rolling GNOME 51 nightly stream (`:next`/`:btw` tags)
  * Documented image stream mappings, release cadence, and stability levels
  * Added CI guidance and best practices for working with the nightly stream
  * Included examples for syncing and cherry-picking changes across branches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->