### PR TITLE
chore(build): upgrade chunkah v0.5.0 to v0.6.0

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -546,10 +546,11 @@ show-me-the-future:
     fi
 
 # ── Chunkah ──────────────────────────────────────────────────────────
-# Use the pre-built chunkah image from quay.io
-# TODO: once coreos/chunkah#113 lands (libc fallback for xattr reads),
-# the overlay + xattr-apply step can be removed. chunkah can then be run
-# with LD_PRELOAD=fakecap.so FAKECAP_MANIFEST=.../fakecap-manifest.tsv.
+# Use the pre-built chunkah image from quay.io (v0.6.0).
+# coreos/chunkah#113 is closed — the resolution is this physical overlay+xattr
+# approach, not a libc fallback in chunkah. The overlay+fakecap-restore path
+# remains required because chunkah's rustix xattr backend uses raw syscalls that
+# bypass LD_PRELOAD, so xattrs must be physically applied to a writable overlay.
 # See also: projectbluefin/dakota#231.
 chunkify image_ref:
     #!/usr/bin/env bash
@@ -605,9 +606,11 @@ chunkify image_ref:
     # Run chunkah against the overlay (bind-mounted read-only).
     # --max-layers 120 balances layer granularity with registry storage space.
     # CHUNKAH_CONFIG_STR preserves OCI labels (containers.bootc=1).
-    # chunkah image pinned by tag+digest for reproducibility
+    # chunkah image pinned by tag+digest for reproducibility.
     # Pre-pull with retries so transient registry 5xx errors don't abort the run.
-    CHUNKAH_REF="quay.io/coreos/chunkah:v0.5.0@sha256:352097f3d32186ac11082f8b74cd544678b00388b50c96ba5c8e79503a454fe3"
+    # Note: coreos/chunkah#113 was closed — the resolution is this overlay+xattr approach,
+    # not a libc fallback in chunkah. The overlay+fakecap path stays required.
+    CHUNKAH_REF="quay.io/coreos/chunkah:v0.6.0@sha256:ff8b8b466a942ec6000445d4001fc661e2fc5a952ad9ee29b4de9ab09d1d1708"
     for attempt in 1 2 3; do
         $SUDO_CMD podman pull "$CHUNKAH_REF" && break
         echo "==> chunkah pull attempt $attempt failed, retrying in 10s..."

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -830,3 +830,4 @@ on `main` that touch `Justfile` or `.github/`.
 On days where gnome-build-meta `master` does not advance, **no build fires**.
 For a guaranteed nightly, a `schedule:` trigger on `next` is needed in
 `build.yml`. This is a known gap — track it if builds go stale.
+

--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -4,7 +4,7 @@ sources:
 - kind: git_repo
   url: github:projectbluefin/common.git
   track: main
-  ref: v2026.06-169-g6d032b571307e6ea85f0fbb84358e39a6ac1198c
+  ref: v2026.06-186-g64205ec20b8b43789702c1dcf1adf3882cdf6eb7
 - kind: git_module
   url: github:projectbluefin/branding/
   path: bluefin-branding


### PR DESCRIPTION
## Summary

Upgrade the chunkah image reference in the `chunkify` recipe from v0.5.0 to v0.6.0.

## Changes

- Bump `CHUNKAH_REF` to `quay.io/coreos/chunkah:v0.6.0@sha256:ff8b8b466a942ec6000445d4001fc661e2fc5a952ad9ee29b4de9ab09d1d1708`
- Update TODO comment: coreos/chunkah#113 was closed April 2026 via the overlay workaround (no libc fallback added to chunkah), so the overlay+fakecap-restore path stays required

## Why

v0.6.0 includes a PAX header security fix in the tar dependency and bumps Fedora base to F44.
The stdout pipe path used by `chunkify` is unchanged in v0.6.0 (the oci: transport change
is for the Containerfile.splitter/buildah path only).

Note: Full centralization to the `chunka` composite action is deferred — the xattr/overlay
architecture is incompatible with the composite action's current interface. See #231.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build tool to v0.6.0 with improved image handling
  * Refreshed project dependency references

* **Documentation**
  * Enhanced build documentation with clarification on overlay requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->