### PR TITLE
feat(umotd): add umotd element

### DIFF
--- a/docs/skills/packaging-binaries.md
+++ b/docs/skills/packaging-binaries.md
@@ -174,3 +174,39 @@ sources:
 ```
 
 This pattern is used in `tailscale.bst`, `glow.bst`, `gum.bst`, and `fzf.bst`.
+
+### Shared profile scripts require the binary in a BST element — check common Containerfile (2026-06-09)
+
+`projectbluefin/common` ships profile scripts in `system_files/shared/etc/profile.d/`
+that are installed by `common.bst`. If a script calls a binary that common's Containerfile
+downloads into `/out/bluefin/usr/bin/` (not `/out/shared/`), that binary will be missing
+from the BST build and every terminal open will print `bash: <cmd>: command not found`.
+
+Pattern to detect: check `common/Containerfile` for curl downloads to `/out/bluefin/usr/bin/`
+that match any script in `system_files/shared/etc/profile.d/`.
+
+Fix has two parts:
+1. **projectbluefin/common**: move the binary download from `/out/bluefin/usr/bin/` to
+   `/out/shared/usr/bin/` in the Containerfile, and move the corresponding config from
+   `system_files/bluefin/etc/<tool>/` to `system_files/shared/etc/<tool>/`.
+2. **projectbluefin/dakota**: add a BST element that downloads the same binary for the
+   BST build path. Config is installed by `common.bst` (copies both `bluefin/etc/` and
+   `shared/etc/`), so the BST element only needs to provide the binary.
+
+For raw binaries (no tarball), use `kind: remote` with `filename: <name>` to rename on
+download, then a clean `install -Dm755` without globs. Example from `umotd.bst`:
+
+```yaml
+sources:
+- kind: remote
+  filename: umotd
+  (?):
+  - arch == "x86_64":
+      url: github_files:theMimolet/umotd/releases/download/v0.2.1/umotd_0.2.1_linux_amd64
+      ref: 2cd5a07344f553e590b432aa5b3a07c5cbd055487468d33514130ae5f05ba02e
+  - arch == "aarch64":
+      url: github_files:theMimolet/umotd/releases/download/v0.2.1/umotd_0.2.1_linux_arm64
+      ref: 1598bb13f30f3c2e17fe4349fd04f567999a0643919d5a4abb186a14cb7d62f0
+```
+
+References: projectbluefin/common PR 542, projectbluefin/dakota PR 762 (issue 753)

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -21,6 +21,7 @@ depends:
   - bluefin/gum.bst
   - bluefin/fzf.bst
   - bluefin/tealdeer.bst
+  - bluefin/umotd.bst
 
   - bluefin/common.bst
   - bluefin/just-overrides.bst

--- a/elements/bluefin/umotd.bst
+++ b/elements/bluefin/umotd.bst
@@ -1,0 +1,22 @@
+kind: manual
+
+sources:
+- kind: remote
+  filename: umotd
+  (?):
+  - arch == "x86_64":
+      url: github_files:theMimolet/umotd/releases/download/v0.2.1/umotd_0.2.1_linux_amd64
+      ref: 2cd5a07344f553e590b432aa5b3a07c5cbd055487468d33514130ae5f05ba02e
+  - arch == "aarch64":
+      url: github_files:theMimolet/umotd/releases/download/v0.2.1/umotd_0.2.1_linux_arm64
+      ref: 1598bb13f30f3c2e17fe4349fd04f567999a0643919d5a4abb186a14cb7d62f0
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - install -Dm755 umotd "%{install-root}%{bindir}/umotd"


### PR DESCRIPTION
Fixes issue 753: `bash: umotd: command not found` on terminal startup.

The `umotd.sh` profile script in `/etc/profile.d/` (shipped via projectbluefin/common shared files) calls `umotd` on every shell open. The binary was missing from the BST build, causing two error lines on every terminal open.

This PR adds `elements/bluefin/umotd.bst` which downloads the umotd binary (amd64 + arm64) and installs it to `/usr/bin/umotd`.

Related: projectbluefin/common PR 542 moves the umotd binary and config from the bluefin-only Containerfile output to the shared output, fixing the same bug for bluefin-lts. The umotd config is already installed by `common.bst` (from `system_files/bluefin/etc/umotd/` at the current ref) so this element only needs to provide the binary.

A common.bst ref bump to pick up common PR 542 will follow as a separate PR.