### PR TITLE
fix(ci): track-bst-sources: use --squash for auto-merge, not --merge

### DIFF
--- a/.github/workflows/track-bst-sources.yml
+++ b/.github/workflows/track-bst-sources.yml
@@ -263,9 +263,9 @@ jobs:
 
           if [ "${{ matrix.group }}" = "auto-merge" ]; then
             echo "Enabling auto-merge..."
-            # Use --merge to match the merge queue's required merge_method=MERGE.
-            # --squash conflicts with the merge queue ruleset and prevents auto-queuing.
-            gh pr merge "$PR_URL" --auto --merge || echo "::warning::Could not enable auto-merge"
+            # Use --squash: the repo only allows squash merges (allowMergeCommit=false).
+            # --merge would silently fail via the '|| echo ::warning::' fallback.
+            gh pr merge "$PR_URL" --auto --squash || echo "::warning::Could not enable auto-merge"
           fi
 
   track-tarballs:


### PR DESCRIPTION
## What problem are you solving?

The repo has `allowMergeCommit=false` — only squash merges are permitted. `track-bst-sources.yml` was calling `gh pr merge --auto --merge` which silently fell through to the `|| echo ::warning::` fallback. Auto-merge was never actually enabled on any tracking PR, so they sat unmerged indefinitely.

## Changes

One-line fix: `--merge` → `--squash` in the auto-merge enable step.

## Testing

- [ ] `just validate` passes
- [ ] `just lint` passes

## Checklist

- [x] No BST element changes

---

*Assisted-by: Claude Sonnet 4.6 via pi*