### PR TITLE
docs: expand CONTRIBUTING.md with BST build context and AGENTS.md reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,33 @@
 
 Thanks for helping out!
 
-Check the [Contributing Guide](https://docs.projectbluefin.io/contributing) for contribution information.
+## ⚠️ Dakota uses BuildStream 2 — not Containerfiles
 
-This repository is for building the images, you are probably looking for [@projectbluefin/common](https://github.com/projectbluefin/common) to change something in Bluefin. Make sure you check [the architecture diagram](https://docs.projectbluefin.io/contributing#understanding-bluefins-architecture).
+Dakota is built with **[BuildStream 2](https://buildstream.build/)** (BST), not a Containerfile or DNF/RPM like mainline Bluefin. If you're here to change something in the Bluefin image, you probably want [`projectbluefin/common`](https://github.com/projectbluefin/common) instead.
+
+If you're here to package new software for the BST-based image, read [`AGENTS.md`](AGENTS.md) first — all build instructions, BST workflow, PR checklist, branch conventions, and mandatory gates live there. The README also references AGENTS.md.
+
+Check the [Contributing Guide](https://docs.projectbluefin.io/contributing) for general contribution information and [the architecture diagram](https://docs.projectbluefin.io/contributing#understanding-bluefins-architecture).
+
+## Prerequisites
+
+- [`bst`](https://buildstream.build/) (BuildStream 2) — `pip install buildstream`
+- `podman` — required for BST sandbox execution
+- `just` — `brew install just` or your OS package manager
+
+## Pull requests
+
+- Open PRs against the `testing` branch
+- Run `just check` before opening a PR
+- Follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages
+
+## Where things live
+
+```
+project.conf          # BST project configuration
+elements/             # BST element files (.bst) — one per package
+junctions/            # BST junction manifests (upstream source pins)
+system_files/         # Files overlaid into the final OCI image
+```
+
+Full build reference and BST workflow: [`AGENTS.md`](AGENTS.md)


### PR DESCRIPTION
Addresses hive advisory finding from [projectbluefin/common#557](https://github.com/projectbluefin/common/issues/557).

CONTRIBUTING.md was 3–5 lines with no BST context. A contributor arriving from mainline Bluefin would try to edit a Containerfile. The critical "not-bluefin" context lived only in AGENTS.md and docs/skills/not-bluefin.md, not in the human-facing CONTRIBUTING.md.

### Changes
- Added prominent warning that dakota uses BuildStream 2, not Containerfiles
- Added BST prerequisites (`bst`, `podman`, `just`)
- Added PR target (`testing` branch)
- Added repo structure overview
- Added explicit pointer to AGENTS.md (where all build instructions live)