### PR TITLE
fix(ci): fire build on main push; auto-merge PRs target main; force-sync testing mirror

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
   merge_group:
     branches: [main, next, testing]
   push:
-    branches: [testing]
+    branches: [main, next]
   workflow_dispatch:
     # WARNING: Do not manually dispatch immediately after auto/track-* ref bumps
     # (e.g. Renovate PRs updating gnome-build-meta.bst). Cold builds of GNOME

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -341,5 +341,5 @@ jobs:
             gh api repos/${{ github.repository }}/git/refs/heads/testing \
               --method PATCH \
               --field sha="$BUILD_SHA" \
-              --field force=false
+              --field force=true
           fi

--- a/.github/workflows/track-bst-sources.yml
+++ b/.github/workflows/track-bst-sources.yml
@@ -209,13 +209,9 @@ jobs:
           OLD_SHA=$(echo "$OLD_REF" | grep -oP '(?<=g)[0-9a-f]+$' || echo "$OLD_REF")
           NEW_SHA=$(echo "$NEW_REF" | grep -oP '(?<=g)[0-9a-f]+$' || echo "$NEW_REF")
 
-          # auto-merge PRs target testing; manual-merge PRs target main.
-          # Determine this BEFORE the git checkout so the branch starts from the
-          # correct base, preventing main-only commits from appearing in the PR.
+          # All PRs target main. Every merge to main triggers a build and
+          # publishes :testing immediately — no staging branch needed.
           BASE_BRANCH="main"
-          if [ "${{ matrix.group }}" = "auto-merge" ]; then
-            BASE_BRANCH="testing"
-          fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Problem

Users have been waiting days for `bootc 1.16` (and other updates) to land on `:testing`. Multiple agents claimed the pipeline was fixed, but the image never updated. Root cause was three compounding bugs:

## Root causes

**1. `build.yml` — build never fired on `main` merges**
`push: branches: [testing]` was the only push trigger. Direct PR merges to `main` (not going through the merge queue) never triggered a build. Result: nothing published.

**2. `track-bst-sources.yml` — auto-merge PRs targeted `testing`, not `main`**
All package-bump PRs (common layer, gnome-build-meta, bootc, etc.) were branching from and merging into `testing` instead of `main`. This caused `main` and `testing` to diverge with different content on each branch. `bootc 1.16` landed in `main`; the common layer updates landed in `testing`. Neither was complete.

**3. `publish.yml` — fast-forward used `force=false`**
The `Fast-forward testing branch` step silently failed whenever `testing` had diverged from `main` (which it always did, due to bug 2). So `testing` was never synced even when a build did run.

## Intended design

```
PR → main → push triggers build → :testing published immediately
                                         ↓
                              weekly gate: :testing → :stable
```

No intermediate staging branch. The weekly promotion is the only gate.

## Changes

| File | Change |
|---|---|
| `build.yml` | `push` trigger: `[testing]` → `[main, next]` |
| `publish.yml` | fast-forward: `force=false` → `force=true` |
| `track-bst-sources.yml` | auto-merge group `BASE_BRANCH`: `testing` → `main` |

## Verification

After merge:
- A workflow_dispatch on `build.yml` targeting `main` will publish a fresh `:testing` image with bootc 1.16
- Future Renovate and track-bst PRs will open against `main` and auto-merge there
- The `testing` git branch becomes a strict mirror of `main` (force-synced after each publish)

- [ ] I am using an agent and I take responsibility for this PR