### PR TITLE
fix(ci): gh pr create has no --json flag — capture URL instead

### DIFF
--- a/.github/workflows/track-next-junctions.yml
+++ b/.github/workflows/track-next-junctions.yml
@@ -69,20 +69,19 @@ jobs:
 
           EXISTING=$(gh pr list --head auto/track-next-junction --json number --jq '.[0].number' 2>/dev/null || true)
           if [ -n "$EXISTING" ]; then
-            PR_NUMBER="$EXISTING"
-            echo "Existing PR #${PR_NUMBER} — re-enabling auto-merge"
+            PR_URL=$(gh pr view "$EXISTING" --json url --jq '.url')
+            echo "Existing PR: $PR_URL — re-enabling auto-merge"
           else
             PR_BODY=$(printf '%s\n\n%s' \
             "Bumps \`gnome-build-meta.bst\` (master) and \`freedesktop-sdk.bst\` atomically on the \`next\` branch. Auto-merges once \`bst show\` validation passes." \
             "> **Note:** When gnome-build-meta cuts a stable branch (e.g. \`gnome-51\`), update \`track: master\` → \`track: <branch>\` in \`elements/gnome-build-meta.bst\` on \`next\`. No CI changes needed.")
-          PR_NUMBER=$(gh pr create \
-            --base next \
-            --head auto/track-next-junction \
-            --title "chore(deps): update core junctions (next branch)" \
-            --body "$PR_BODY" \
-            --json number --jq '.number')
-            echo "Created PR #${PR_NUMBER}"
+            PR_URL=$(gh pr create \
+              --base next \
+              --head auto/track-next-junction \
+              --title "chore(deps): update core junctions (next branch)" \
+              --body "$PR_BODY")
+            echo "Created PR: $PR_URL"
           fi
 
           # Enable auto-merge — merges automatically once required checks pass.
-          gh pr merge "$PR_NUMBER" --auto --squash
+          gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
## Problem

The `track-core-junctions-next` job in `track-next-junctions.yml` (run [#27306033055](https://github.com/projectbluefin/dakota/actions/runs/27306033055/job/80663968499)) was failing at the "Create or update PR against next (auto-merge)" step with:

```
unknown flag: --json
Process completed with exit code 1.
```

**Root cause:** `gh pr create` does **not** support `--json`/`--jq` flags. The workflow was capturing the PR number like this:

```bash
PR_NUMBER=$(gh pr create ... --json number --jq '.number')
```

Those flags only exist on read subcommands (`gh pr list`, `gh pr view`, etc.). The branch push succeeded but no PR was ever created and auto-merge was never enabled.

## Fix

Capture the URL that `gh pr create` outputs to stdout — the same pattern used in the working `track-core-junctions` job in `track-bst-sources.yml`:

```bash
PR_URL=$(gh pr create --base next --head auto/track-next-junction --title "..." --body "$PR_BODY")
gh pr merge "$PR_URL" --auto --squash
```

In the existing-PR path, use `gh pr view "$EXISTING" --json url --jq '.url'` to get the URL consistently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request automation workflow for handling existing and newly created pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->