### PR TITLE
chore(lifecycle): call lifecycle.yml from projectbluefin/actions

### DIFF
--- a/.github/workflows/lifecycle-caller.yml
+++ b/.github/workflows/lifecycle-caller.yml
@@ -6,7 +6,7 @@ on:
   issue_comment:
     types: [created]
   pull_request:
-    types: [opened]
+    types: [opened, labeled]
   schedule:
     - cron: '0 9 * * *'
 
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   lifecycle:
-    uses: projectbluefin/common/.github/workflows/lifecycle.yml@233102e81ce425839dc5dcf00f830f14b9631d71
+    uses: projectbluefin/actions/.github/workflows/lifecycle.yml@7df3176a8449ba1db2c2b38ea18c0d9b3687a4f0 # chore/lifecycle-from-common — update SHA after actions PR merges
     with:
       brand_name: "Dakota"
     secrets: inherit


### PR DESCRIPTION
## Summary

Updates the lifecycle caller to reference `lifecycle.yml` from its new home in `projectbluefin/actions` (moved from `projectbluefin/common`).

## Changes

- **Update** SHA pin in `lifecycle-caller.yml` to reference `projectbluefin/actions`
- **Fix** `pull_request: types: [opened, labeled]` — `labeled` was missing; `on-pr-lgtm` auto-merge on `lgtm` label was **silently never firing** in this repo

## ⚠️ Merge order

Merge `projectbluefin/actions` [chore/lifecycle-from-common PR](https://github.com/projectbluefin/actions/pull/150) first, then update the SHA:

```yaml
uses: projectbluefin/actions/.github/workflows/lifecycle.yml@7df3176a8449ba1db2c2b38ea18c0d9b3687a4f0
```

Replace `7df3176a...` with HEAD SHA of `actions/main` after that PR merges.

## Token audit

No PATs. `github.token` only — `github.repository` resolves to `projectbluefin/dakota` at runtime.

Assisted-by: Claude Sonnet 4.5 via pi