### PR TITLE
feat(ci): add cache-warm scheduled workflow

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: main
+          persist-credentials: false
 
       - name: Check bst2 image pin consistency
         uses: ./.github/actions/check-bst2-pin
@@ -55,18 +56,14 @@ jobs:
             bst-warm-
             bst-show-
 
-      - name: Configure remote CAS (mTLS)
-        if: vars.CASD_CLIENT_CERT != ''
+      - name: Generate BuildStream CI config
         env:
           CASD_CLIENT_CERT: ${{ vars.CASD_CLIENT_CERT }}
           CASD_CLIENT_KEY: ${{ secrets.CASD_CLIENT_KEY }}
-        run: |
-          set -euo pipefail
-          mkdir -p ~/.config/buildstream
-          printf '%s' "$CASD_CLIENT_CERT" > ~/.config/buildstream/client.crt
-          printf '%s' "$CASD_CLIENT_KEY"  > ~/.config/buildstream/client.key
-          chmod 600 ~/.config/buildstream/client.key
-          echo "BST cache credentials installed."
+        uses: ./.github/actions/generate-bst-ci-config
+        with:
+          enable-remote-execution: false
+          enable-push: true
 
       - name: Build default variant (warm-cache mode, non-blocking)
         env:

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -1,18 +1,20 @@
-# Dakota BuildStream Cache Warm — scheduled workflow
-#
-# Prevents cold-start timeouts by keeping the BST remote cache hot.
+name: Warm BuildStream Cache
+
+# Prevents cold-start timeouts by keeping the remote BST CAS hot.
 # Runs Monday and Thursday mornings, well before typical PR merge windows.
 #
-# Context: Dakota BST builds have a 360-min timeout. When cache misses
-# (after junction ref bumps or gbm upstream rebuilds), the full GNOME
-# stack must rebuild from scratch, which can exceed 6h. This workflow
-# runs the build on schedule to ensure cache artifacts stay fresh.
-
-name: Warm BuildStream Cache
+# Context: dakota BST builds have a 360-min job timeout. When cache misses
+# (after junction ref bumps or gnome-build-meta upstream rebuilds), the full
+# GNOME stack must rebuild from scratch, which can exceed 6h. This workflow
+# triggers a build on schedule so the remote CAS at cache.projectbluefin.io
+# stays warm and merge-queue builds land on cache hits.
+#
+# Failure here is non-blocking — the warm build is best-effort.
+# Tracks: projectbluefin/common#583 (automation audit Phase 7)
 
 on:
   schedule:
-    # Monday and Thursday at 06:00 UTC — before European/US work hours
+    # Monday and Thursday at 06:00 UTC — before European/US merge windows.
     - cron: '0 6 * * 1,4'
   workflow_dispatch:
 
@@ -25,44 +27,66 @@ concurrency:
 
 jobs:
   warm-cache:
-    name: Build to warm cache
+    name: Build to warm remote CAS
     runs-on: ubuntu-24.04
-    timeout-minutes: 420
+    timeout-minutes: 360
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: testing
+          ref: main
 
       - name: Check bst2 image pin consistency
         uses: ./.github/actions/check-bst2-pin
 
       - name: Setup runner
-        uses: projectbluefin/actions/bootc-build/setup-runner@7f79969c2ff74c51ac7f385cb0a86414975308d7 # v1
+        uses: projectbluefin/actions/bootc-build/setup-runner@3025b5d31f34ce44c19eab41a7fa5d4d5c5b688e # v1.1.0
         with:
           storage-backend: btrfs
           update-podman: true
           install-tools: '["just"]'
 
-      - name: Restore BST cache
+      - name: Restore BST workspace cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/buildstream
-          key: bst-warm-${{ hashFiles('elements/gnome-build-meta.bst', 'elements/freedesktop-sdk.bst') }}
+          key: bst-warm-${{ hashFiles('elements/gnome-build-meta.bst', 'elements/freedesktop-sdk.bst', 'Justfile') }}
           restore-keys: |
             bst-warm-
+            bst-show-
 
-      - name: Build default variant (cache mode)
+      - name: Configure remote CAS (mTLS)
+        if: vars.CASD_CLIENT_CERT != ''
+        env:
+          CASD_CLIENT_CERT: ${{ vars.CASD_CLIENT_CERT }}
+          CASD_CLIENT_KEY: ${{ secrets.CASD_CLIENT_KEY }}
         run: |
           set -euo pipefail
-          # Build the default (non-nvidia) variant to warm the shared layer cache.
-          # || true makes the step non-fatal — warming is best-effort.
-          just bst build oci/bluefin.bst || true
-          echo "Cache warm complete — artifacts pushed to remote CAS"
+          mkdir -p ~/.config/buildstream
+          printf '%s' "$CASD_CLIENT_CERT" > ~/.config/buildstream/client.crt
+          printf '%s' "$CASD_CLIENT_KEY"  > ~/.config/buildstream/client.key
+          chmod 600 ~/.config/buildstream/client.key
+          echo "BST cache credentials installed."
 
-      - name: Save BST cache
+      - name: Build default variant (warm-cache mode, non-blocking)
+        env:
+          BST_FLAGS: -o x86_64_v3 true --no-interactive
+        run: |
+          set +e
+          # Build only — no checkout, no push to GHCR. Goal is to populate
+          # the remote CAS so subsequent merge-queue builds get cache hits.
+          just bst build oci/bluefin.bst
+          rc=$?
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning::Cache warm build failed (rc=${rc}) — non-blocking."
+            echo "::warning::Likely causes: gnome-build-meta upstream rebuilding, junction ref skew."
+          fi
+          exit 0
+
+      - name: Report cache state
         if: always()
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~/.cache/buildstream
-          key: bst-warm-${{ hashFiles('elements/gnome-build-meta.bst', 'elements/freedesktop-sdk.bst') }}
+        run: |
+          echo "::notice::Cache warm completed at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          CACHED=$(just bst show --deps all --format '%{name} %{state}' oci/bluefin.bst 2>/dev/null \
+            | grep -c "cached" || echo 0)
+          echo "::notice::Cached elements after warm: ${CACHED}"

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -43,18 +43,21 @@ Load when debugging CI failures, understanding the build pipeline, or working wi
 
 ## Trigger Behavior
 
-| Behavior | pull_request | merge_group | workflow_dispatch |
-|---|---|---|---|
-| `validate` job | Yes | No | No |
-| `e2e` job | Yes (change-detected) | No | Yes |
-| `build` job | No | Yes | Yes |
-| Push to GHCR? | No | Via publish.yml | Via publish.yml |
+| Behavior | pull_request | merge_group | workflow_dispatch | schedule |
+|---|---|---|---|---|
+| `validate` job | Yes | No | No | No |
+| `e2e` job | Yes (change-detected) | No | Yes | No |
+| `build` job | No | Yes | Yes | No |
+| `cache-warm` job | No | No | Yes | Yes (Mon/Thu 06:00 UTC) |
+| Push to GHCR? | No | Via publish.yml | Via publish.yml | No |
 
 **PR path:** `validate` + `e2e` (change-detected) — zero remote execution. ~15 min cached, ~30 min cold.
 
 **e2e change detection:** `e2e` uses a `should-run` job that diffs the PR branch against its base. It runs when `elements/`, `files/`, `patches/`, `Justfile`, or `project.conf` change; otherwise the `e2e` job is skipped. Skipped satisfies the required status check.
 
 **Merge queue path:** `build` fires on `merge_group` — full OCI build, real CI gate before merge.
+
+**Cache-warm path:** `cache-warm.yml` runs Monday and Thursday at 06:00 UTC and on manual dispatch. Builds the default variant against the remote CAS so merge-queue builds land on cache hits even after junction ref bumps or upstream `gnome-build-meta` rebuilds. Failures are non-blocking — the warm build is best-effort. Addresses the cold-start non-determinism documented in [common automation-audit ND1](https://github.com/projectbluefin/common/blob/main/docs/factory/automation-audit/non-deterministic-steps.md).
 
 ## Remote Cache Architecture
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/cache-warm.yml` — a scheduled workflow that builds the default variant Monday and Thursday at 06:00 UTC (and on `workflow_dispatch`) to keep the remote CAS at `cache.projectbluefin.io` warm.

## Why

Dakota BST builds have a 360-minute job timeout. After junction ref bumps or upstream `gnome-build-meta` rebuilds, the full GNOME stack must rebuild from scratch, which can exceed 6 hours. Pre-warming the cache on a schedule means merge-queue builds land on cache hits even after upstream churn.

Closes the cold-start non-determinism documented in [common automation-audit ND1](https://github.com/projectbluefin/common/blob/main/docs/factory/automation-audit/non-deterministic-steps.md) and Phase 7 of the [implementation roadmap](https://github.com/projectbluefin/common/blob/main/docs/factory/automation-audit/implementation-roadmap.md).

## Design

- **Schedule:** `0 6 * * 1,4` — twice weekly, before European/US merge windows
- **Trigger:** `schedule` + `workflow_dispatch` (no PR/push triggers)
- **Concurrency group:** `dakota-cache-warm` with `cancel-in-progress: false` — never preempts a merge-queue build
- **Failure handling:** `set +e` around the build; non-zero exit becomes a `::warning::` annotation. The warm build is best-effort by design.
- **Cache key:** mirrors `build.yml`'s key inputs (`gnome-build-meta.bst`, `freedesktop-sdk.bst`, `Justfile`) but uses a separate `bst-warm-` prefix so warm and validate caches don't fight.
- **Auth:** uses the same mTLS pattern as `build.yml` (`vars.CASD_CLIENT_CERT` + `secrets.CASD_CLIENT_KEY`); skips remote push if credentials are absent (forks).

## Verification

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` passes
- [x] `actionlint .github/workflows/cache-warm.yml` clean
- [x] `pre-commit run` clean (yaml, end-of-file-fixer, no-floating-action-tags, actionlint)
- [x] Skill update committed in same PR (`docs/skills/ci.md`)

First run after merge will be either the next Mon/Thu 06:00 UTC tick or via `gh workflow run cache-warm.yml`.

## Risk

LOW — additive, scheduled-only, non-blocking on failure. Worst case: the workflow itself fails silently and we lose the cache pre-warming benefit. No impact on PR/merge-queue paths.

## References

- Audit artifact source: https://github.com/projectbluefin/common/blob/main/docs/factory/automation-audit/dakota-cache-warm.yml
- Tracking issue: https://github.com/projectbluefin/common/issues/583

---

*Assisted-by: Claude Sonnet 4.5 via pi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI trigger behavior documentation to clarify execution schedules for validation, end-to-end testing, and cache-warming jobs.

* **Chores**
  * Improved cache-warming workflow with timeout optimization, enhanced configuration handling, and better cache state monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->