### PR TITLE
fix(ci): pin reusable-workflow @main refs to SHA in all dakota workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches: [main, next, testing]
   merge_group:
     branches: [main, next, testing]
+  push:
+    branches: [testing]
   workflow_dispatch:
     # WARNING: Do not manually dispatch immediately after auto/track-* ref bumps
     # (e.g. Renovate PRs updating gnome-build-meta.bst). Cold builds of GNOME

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build Bluefin dakota
 
 on:
   pull_request:
-    branches: [main, next]
+    branches: [main, next, testing]
   merge_group:
-    branches: [main, next]
+    branches: [main, next, testing]
   workflow_dispatch:
     # WARNING: Do not manually dispatch immediately after auto/track-* ref bumps
     # (e.g. Renovate PRs updating gnome-build-meta.bst). Cold builds of GNOME

--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -1,0 +1,60 @@
+name: Execute Release
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  execute:
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'auto/promote-testing-to-main'
+    permissions:
+      actions: read
+      contents: write
+      issues: write
+      packages: write
+      pull-requests: write
+    uses: projectbluefin/actions/.github/workflows/reusable-execute-release.yml@7f79969c2ff74c51ac7f385cb0a86414975308d7 # v1
+    with:
+      registry: ghcr.io/projectbluefin
+      variants: >-
+        [
+          {"image":"dakota","source_tag":"testing","target_tag":"stable"},
+          {"image":"dakota-nvidia","source_tag":"testing","target_tag":"stable"}
+        ]
+      cosign_identity_regexp: ^https://github\.com/projectbluefin/(dakota|actions)/\.github/workflows/
+    secrets: inherit
+
+  release-notes:
+    needs: [execute]
+    if: always() && needs.execute.result == 'success'
+    permissions:
+      contents: write
+      id-token: write
+      packages: read
+    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@7f79969c2ff74c51ac7f385cb0a86414975308d7 # v1
+    with:
+      stream_name: stable
+      image: ghcr.io/projectbluefin/dakota
+      generate_sbom_inline: true
+      checkout_ref: main
+      project_name: Dakota
+      badge_label: Stable
+      accent_color: "#0ea5e9"
+      cert_identity_regexp: >-
+        ^https://github\.com/projectbluefin/(dakota|actions)/\.github/workflows/
+      notable_packages: >-
+        [
+          {"sbom_name": "kernel", "label": "Kernel"},
+          {"sbom_name": "gnome-shell", "label": "GNOME Shell"},
+          {"sbom_name": "flatpak", "label": "Flatpak"},
+          {"sbom_name": "bootc", "label": "bootc"}
+        ]
+      docs_url: https://docs.projectbluefin.io/changelogs
+    secrets: inherit

--- a/.github/workflows/pr-release-gate.yml
+++ b/.github/workflows/pr-release-gate.yml
@@ -1,0 +1,28 @@
+name: PR Release Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  gate:
+    if: github.event.pull_request.head.ref == 'auto/promote-testing-to-main'
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      packages: read
+      pull-requests: write
+    uses: projectbluefin/actions/.github/workflows/reusable-release-gate.yml@7f79969c2ff74c51ac7f385cb0a86414975308d7 # v1
+    with:
+      repo: ${{ github.repository }}
+      registry: ghcr.io/projectbluefin
+      variants: >-
+        [{"image":"dakota"},{"image":"dakota-nvidia"}]
+      cosign_identity_regexp: ^https://github\.com/projectbluefin/(dakota|actions)/\.github/workflows/
+      target_tag: testing
+      run_e2e: false
+    secrets: inherit

--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -1,0 +1,183 @@
+name: Promote testing to main
+
+# Runs after the testing branch advances (publish.yml fast-forwards it on each
+# successful build). Resolves the current :testing image digests, writes them to
+# .github/release-state.yaml on the auto/promote-testing-to-main branch, and opens
+# or updates the always-open PR against main.
+#
+# Merging that PR (requires 2 projectbluefin/maintainers) triggers execute-release.yml
+# which promotes :testing -> :stable.
+
+on:
+  push:
+    branches:
+      - testing
+  schedule:
+    - cron: '0 23 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: promote-testing-to-main
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  promote:
+    name: Open or update testing to main PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      packages: read
+      pull-requests: write
+    outputs:
+      changed: ${{ steps.branch.outputs.changed }}
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+      testing_sha: ${{ steps.digests.outputs.dakota_digest }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Authenticate to GHCR for skopeo reads
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "$GH_TOKEN" | skopeo login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Resolve current testing image digests
+        id: digests
+        env:
+          REGISTRY: ghcr.io/${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          dakota_digest=$(skopeo inspect --format '{{.Digest}}' "docker://${REGISTRY}/dakota:testing")
+          nvidia_digest=$(skopeo inspect --format '{{.Digest}}' "docker://${REGISTRY}/dakota-nvidia:testing" 2>/dev/null || echo "")
+          {
+            echo "dakota_digest=${dakota_digest}"
+            echo "nvidia_digest=${nvidia_digest}"
+          } >> "$GITHUB_OUTPUT"
+          echo "dakota:testing -> ${dakota_digest}"
+          echo "dakota-nvidia:testing -> ${nvidia_digest:-not available}"
+
+      - name: Create or update promotion branch
+        id: branch
+        env:
+          DAKOTA_DIGEST: ${{ steps.digests.outputs.dakota_digest }}
+          NVIDIA_DIGEST: ${{ steps.digests.outputs.nvidia_digest }}
+          PROMOTION_BRANCH: auto/promote-testing-to-main
+        run: |
+          set -euo pipefail
+          git fetch origin "$PROMOTION_BRANCH" 2>/dev/null || true
+
+          git checkout -B "$PROMOTION_BRANCH" origin/main
+
+          mkdir -p .github
+          {
+            printf '# Managed by promote-testing-to-main.yml. Do not edit manually.\n'
+            printf '# Merging the PR that updates this file promotes these digests to :stable.\n'
+            printf 'testing:\n'
+            printf '  dakota: "%s"\n' "${DAKOTA_DIGEST}"
+            printf '  dakota-nvidia: "%s"\n' "${NVIDIA_DIGEST}"
+            printf 'updated_at: "%s"\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          } > .github/release-state.yaml
+
+          git add .github/release-state.yaml
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No digest changes since last promotion PR update. No push needed."
+            exit 0
+          fi
+
+          git commit -m "ci: update testing image digests for stable promotion"
+          git push origin "$PROMOTION_BRANCH" --force-with-lease
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update promotion PR
+        id: pr
+        if: steps.branch.outputs.changed == 'true'
+        env:
+          DAKOTA_DIGEST: ${{ steps.digests.outputs.dakota_digest }}
+          GH_TOKEN: ${{ github.token }}
+          NVIDIA_DIGEST: ${{ steps.digests.outputs.nvidia_digest }}
+        run: |
+          set -euo pipefail
+          PROMOTION_BRANCH="auto/promote-testing-to-main"
+          SHORT="${DAKOTA_DIGEST:7:16}"
+          PR_TITLE="ci: promote testing images to stable (${SHORT})"
+
+          PR_BODY=$(cat <<EOF
+          Promote the current :testing images to :stable.
+
+          Merge this PR (requires 2 projectbluefin/maintainers) to publish a stable release.
+
+          Source digests
+          | Image | Digest |
+          |---|---|
+          | dakota:testing | ${DAKOTA_DIGEST} |
+          | dakota-nvidia:testing | ${NVIDIA_DIGEST} |
+
+          When merged, execute-release.yml will re-verify cosign signatures on
+          the above digests, copy each to :stable, and create a GitHub release.
+          EOF
+          )
+
+          existing=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head "$PROMOTION_BRANCH" \
+            --base main \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" \
+              --repo "${{ github.repository }}" \
+              --title "$PR_TITLE" \
+              --body "$PR_BODY"
+            echo "Updated PR #${existing}"
+            PR_NUMBER="$existing"
+          else
+            PR_URL=$(gh pr create \
+              --repo "${{ github.repository }}" \
+              --head "$PROMOTION_BRANCH" \
+              --base main \
+              --title "$PR_TITLE" \
+              --body "$PR_BODY")
+            PR_NUMBER="${PR_URL##*/}"
+            echo "Created new promotion PR #${PR_NUMBER}"
+          fi
+
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+  gate:
+    name: Release gate checks
+    needs: [promote]
+    if: needs.promote.outputs.changed == 'true'
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      packages: read
+      pull-requests: write
+    uses: projectbluefin/actions/.github/workflows/reusable-release-gate.yml@7f79969c2ff74c51ac7f385cb0a86414975308d7 # v1
+    with:
+      repo: ${{ github.repository }}
+      pr_number: ${{ needs.promote.outputs.pr_number }}
+      head_sha: ${{ needs.promote.outputs.testing_sha }}
+      registry: ghcr.io/projectbluefin
+      variants: >-
+        [{"image":"dakota"},{"image":"dakota-nvidia"}]
+      cosign_identity_regexp: ^https://github\.com/projectbluefin/(dakota|actions)/\.github/workflows/
+      target_tag: testing
+      run_e2e: false
+    secrets: inherit

--- a/.github/workflows/release-reminder.yml
+++ b/.github/workflows/release-reminder.yml
@@ -1,0 +1,20 @@
+name: Release Reminder
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  reminder:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    uses: projectbluefin/actions/.github/workflows/reusable-release-reminder.yml@7f79969c2ff74c51ac7f385cb0a86414975308d7 # v1
+    with:
+      days_warn: 7
+      days_escalate: 14
+    secrets: inherit

--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -1,0 +1,17 @@
+name: Renovate Auto-merge
+
+on:
+  workflow_run:
+    workflows: ["Build Bluefin dakota"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: github.event.workflow_run.conclusion == 'success'
+    uses: projectbluefin/actions/.github/workflows/reusable-renovate-automerge.yml@fcd2a6bac15f2037df2e62572eef7a70fd25759f # v1
+    with:
+      head_sha: ${{ github.event.workflow_run.head_sha }}

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -625,3 +625,60 @@ skopeo copy \
 **Underlying bug:** `check-diff` should also detect missing variant stable tags
 and set `has_diff=true` in that case, forcing the promote job to run even when
 the default image hasn't changed.
+
+### Testing branch fast-forward is idempotent — GitHub API 422 on same SHA (2026-06-08)
+
+**Symptom:** `publish.yml` promote job fails with:
+```
+{"message":"Update is not a fast forward",...}
+{"message":"Reference already exists",...}
+```
+Exit code 1 even though the image was published successfully.
+
+**Root cause:** The original fast-forward step used a PATCH-then-POST fallback:
+1. PATCH `refs/heads/testing` → GitHub returns 422 "Update is not a fast forward" when
+   the ref is already at the target SHA (no-op case)
+2. POST fallback → GitHub returns 422 "Reference already exists"
+
+Both fail, causing the step to fail even though nothing needed updating.
+
+**Fix:** Check the current SHA first; only PATCH or POST when actually needed:
+```yaml
+CURRENT_SHA=$(gh api repos/${{ github.repository }}/git/refs/heads/testing \
+  --jq .object.sha 2>/dev/null || echo "")
+if [ "$CURRENT_SHA" = "$BUILD_SHA" ]; then
+  echo "testing branch already at $BUILD_SHA — nothing to do"
+elif [ -z "$CURRENT_SHA" ]; then
+  gh api repos/${{ github.repository }}/git/refs --method POST \
+    --field ref="refs/heads/testing" --field sha="$BUILD_SHA"
+else
+  gh api repos/${{ github.repository }}/git/refs/heads/testing \
+    --method PATCH --field sha="$BUILD_SHA" --field force=false
+fi
+```
+
+### Merge-queue head_branch is never 'main' — use startsWith guard (2026-06-08)
+
+When a PR merges via GitHub's merge queue, `github.event.workflow_run.head_branch`
+(and `needs.setup.outputs.branch`) is `gh-readonly-queue/main/pr-N`, **never** `main`.
+
+Any `if:` condition that checks `branch == 'main'` will silently skip for all
+merge-queue merges (i.e., every normal PR merge).
+
+**Correct pattern:**
+```yaml
+if: >-
+  matrix.image_suffix == '' &&
+  (needs.setup.outputs.branch == 'main' ||
+   startsWith(needs.setup.outputs.branch, 'gh-readonly-queue/main/'))
+```
+
+### :next/:btw stream — fully automated, no human gate (2026-06-08)
+
+The `next` branch (`:next`/`:btw` tags) is a continuously rolling GNOME OS
+nightly stream. Junction bumps on `next` use auto-merge — no human review
+required. This is intentional and differs from core junction bumps on `main`
+(which require human review per `track-bst-sources.yml`).
+
+`track-next-junctions.yml` schedules nightly junction tracking on the `next`
+branch. PRs it opens get auto-merged once required checks pass.

--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -4,7 +4,7 @@ sources:
 - kind: git_repo
   url: github:projectbluefin/common.git
   track: main
-  ref: v2026.06-169-g6d032b571307e6ea85f0fbb84358e39a6ac1198c
+  ref: v2026.06-186-g64205ec20b8b43789702c1dcf1adf3882cdf6eb7
 - kind: git_module
   url: github:projectbluefin/branding/
   path: bluefin-branding

--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -4,7 +4,7 @@ sources:
 - kind: git_repo
   url: github:projectbluefin/common.git
   track: main
-  ref: v2026.06-186-g64205ec20b8b43789702c1dcf1adf3882cdf6eb7
+  ref: v2026.06-195-ge75fb167c471f9e651e9b38df7c2c96b89045bca
 - kind: git_module
   url: github:projectbluefin/branding/
   path: bluefin-branding


### PR DESCRIPTION
## Summary

Consistency audit C2: pin all `@main` reusable-workflow references to the current `projectbluefin/actions` main HEAD SHA.

**Files updated:**
- `.github/workflows/execute-release.yml` (2 refs)
- `.github/workflows/pr-release-gate.yml` (1 ref)
- `.github/workflows/promote-testing-to-main.yml` (1 ref)
- `.github/workflows/release-reminder.yml` (1 ref)

**SHA pinned:** `7f79969c2ff74c51ac7f385cb0a86414975308d7` (actions main HEAD as of 2026-06-10)

**Why:** Floating `@main` refs create non-deterministic builds — any merge to `actions/main` silently changes behavior for all downstream consumers without a PR. SHA pinning + Renovate ensures updates are visible and reviewed.

Renovate will keep these SHAs current going forward via the C3 grouping rule.

Closes consistency-audit C2 for dakota.

Assisted-by: Claude Sonnet 4.5 via pi