### PR TITLE
fix(ci): pin reusable-workflow @main refs to SHA

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -20,7 +20,7 @@ jobs:
       issues: write
       packages: write
       pull-requests: write
-    uses: projectbluefin/actions/.github/workflows/reusable-execute-release.yml@main
+    uses: projectbluefin/actions/.github/workflows/reusable-execute-release.yml@7f79969c2ff74c51ac7f385cb0a86414975308d7 # v1
     with:
       registry: ghcr.io/projectbluefin
       variants: >-
@@ -38,7 +38,7 @@ jobs:
       contents: write
       id-token: write
       packages: read
-    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@main
+    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@7f79969c2ff74c51ac7f385cb0a86414975308d7 # v1
     with:
       stream_name: stable
       image: ghcr.io/projectbluefin/dakota

--- a/.github/workflows/pr-release-gate.yml
+++ b/.github/workflows/pr-release-gate.yml
@@ -16,7 +16,7 @@ jobs:
       issues: write
       packages: read
       pull-requests: write
-    uses: projectbluefin/actions/.github/workflows/reusable-release-gate.yml@main
+    uses: projectbluefin/actions/.github/workflows/reusable-release-gate.yml@7f79969c2ff74c51ac7f385cb0a86414975308d7 # v1
     with:
       repo: ${{ github.repository }}
       registry: ghcr.io/projectbluefin

--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -169,7 +169,7 @@ jobs:
       issues: write
       packages: read
       pull-requests: write
-    uses: projectbluefin/actions/.github/workflows/reusable-release-gate.yml@main
+    uses: projectbluefin/actions/.github/workflows/reusable-release-gate.yml@7f79969c2ff74c51ac7f385cb0a86414975308d7 # v1
     with:
       repo: ${{ github.repository }}
       pr_number: ${{ needs.promote.outputs.pr_number }}

--- a/.github/workflows/release-reminder.yml
+++ b/.github/workflows/release-reminder.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: projectbluefin/actions/.github/workflows/reusable-release-reminder.yml@main
+    uses: projectbluefin/actions/.github/workflows/reusable-release-reminder.yml@7f79969c2ff74c51ac7f385cb0a86414975308d7 # v1
     with:
       days_warn: 7
       days_escalate: 14


### PR DESCRIPTION
## Summary

Consistency audit C2: pin all `@main` reusable-workflow refs to the current `projectbluefin/actions` main HEAD SHA.

**Files updated (clean branch from main):**
- `.github/workflows/execute-release.yml` (2 refs)
- `.github/workflows/pr-release-gate.yml` (1 ref)
- `.github/workflows/promote-testing-to-main.yml` (1 ref)
- `.github/workflows/release-reminder.yml` (1 ref)

**SHA pinned:** `7f79969c2ff74c51ac7f385cb0a86414975308d7` (actions main HEAD as of 2026-06-10)

Renovate will keep these SHAs current going forward via the C3 grouping rule added in common.

Supersedes #784 (same change, clean branch from main — no conflicts).

Closes automation-audit C2 for dakota.

Assisted-by: Claude Sonnet 4.5 via pi