### PR TITLE
fix(ci): grant required permissions to execute-release caller

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -7,7 +7,13 @@ on:
     branches:
       - main
 
-permissions: {}
+permissions:
+  actions: read
+  contents: write
+  id-token: write
+  issues: write
+  packages: write
+  pull-requests: write
 
 jobs:
   execute:


### PR DESCRIPTION
## Problem

`permissions: {}` at the workflow level starved the `GITHUB_TOKEN` before any job started, causing `startup_failure` on **every single run** since the workflow was introduced on 2026-06-09. Zero releases have ever actually executed.

Same root cause as the `promote-testing-to-main` permissions fix in #796.

## Fix

Replace `permissions: {}` with the superset of permissions the two reusable jobs actually need.

- [ ] I am using an agent and I take responsibility for this PR