### PR TITLE
fix(ci): add workflow_dispatch to execute-release; fix if guard

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -6,6 +6,7 @@ on:
       - closed
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   actions: read
@@ -18,8 +19,9 @@ permissions:
 jobs:
   execute:
     if: >-
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.head.ref == 'auto/promote-testing-to-main'
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'auto/promote-testing-to-main')
     permissions:
       actions: read
       contents: write


### PR DESCRIPTION
Allows manual re-trigger of a release without needing a new promotion PR. Updates the `execute` job `if:` to pass on `workflow_dispatch` as well as the normal `pull_request: closed` path.

- [ ] I am using an agent and I take responsibility for this PR