### PR TITLE
fix(ci): switch execute-release to push trigger + commit-msg gate

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -1,9 +1,7 @@
 name: Execute Release
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - main
   workflow_dispatch:
@@ -17,11 +15,27 @@ permissions:
   pull-requests: write
 
 jobs:
+  check-trigger:
+    runs-on: ubuntu-latest
+    outputs:
+      is-promotion: ${{ steps.check.outputs.is-promotion }}
+    steps:
+      - id: check
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "is-promotion=true" >> "$GITHUB_OUTPUT"
+          elif echo "$COMMIT_MSG" | grep -q "^ci: promote testing images to stable"; then
+            echo "is-promotion=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-promotion=false" >> "$GITHUB_OUTPUT"
+          fi
+
   execute:
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true &&
-      github.event.pull_request.head.ref == 'auto/promote-testing-to-main')
+    needs: [check-trigger]
+    if: needs.check-trigger.outputs.is-promotion == 'true'
     permissions:
       actions: read
       contents: write
@@ -43,6 +57,7 @@ jobs:
     needs: [execute]
     if: always() && needs.execute.result == 'success'
     permissions:
+      actions: read
       contents: write
       id-token: write
       packages: read


### PR DESCRIPTION
Fixes `startup_failure` on every single run since the workflow was introduced June 9.

**Root cause:** `pull_request: closed` fires for *every* PR merged to main. When all jobs have a false `if:` condition, GitHub reports the workflow run as `startup_failure` instead of cleanly skipping. This has silently blocked all releases.

**Fix:** Adopt the `bluefin-lts` pattern:
- Trigger on `push: main` + `workflow_dispatch`
- Lightweight `check-trigger` job reads the squash-merge commit message
- `execute` only runs when the message starts with `ci: promote testing images to stable`
- `workflow_dispatch` always runs (manual re-trigger path)
- Top-level permissions set to superset of all job needs

- [ ] I am using an agent and I take responsibility for this PR