### PR TITLE
ci: consumer validation — Design C promotion PR + release notes overflow fix (actions 9e4ba16)

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   promote:
-    uses: projectbluefin/actions/.github/workflows/reusable-promote.yml@8487dff61267ca80486164379fcfc21901d2021e # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-promote.yml@9e4ba1651f7bf050da0a3a1c527a74c666b43666 # v1
     with:
       variants: '["dakota","dakota-nvidia"]'
       cosign_identity_regexp: >-


### PR DESCRIPTION
## Consumer validation — actions#194 (gate SHA pin fix) + actions#191/193

Pins `reusable-promote.yml` to `9e4ba1651f7bf050da0a3a1c527a74c666b43666`
which is the HEAD of
[projectbluefin/actions#194](https://github.com/projectbluefin/actions/pull/194)
and includes:

1. **fix(release): release notes body truncation** (actions#191)  
   `create-release` now hard-caps the GitHub Release body at 120k chars.
   Fixes the HTTP 422 that blocked the first dakota stable promotion.

2. **feat(promote): Design C promotion PR bodies** (actions#193)  
   🦕 header · "X days since last stable release" · ⏳→✅ live gate checklist
   updated in-place via `<!-- gate-section-start/end -->` markers ·
   resolved digest table.

3. **fix(promote): gate SHA pin corrected** (actions#194)  
   Previous main pointed both promote workflows at the old `feat/retry-e2e-promote`
   branch SHA for the gate. This advances to main so the new checkout +
   gate-body-update steps actually run.

### Files changed

| File | Change |
|---|---|
| `.github/workflows/promote-testing-to-main.yml` | SHA pin: `8487dff` → `9e4ba16` |

### What CI validates here

- `promote-testing-to-main.yml` runs cleanly with the new digest workflow
- The next testing push will produce a Design C promotion PR body

---

Consumer PR: https://github.com/projectbluefin/dakota/pull/TBD
Consumer CI run: _pending_
Out-of-org consumer impact: N/A