### PR TITLE
chore(ci): migrate promote-testing-to-main to reusable-promote-squash

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -1,7 +1,9 @@
 name: Promote testing to main
-
-# Thin caller — logic lives in projectbluefin/actions/reusable-promote.yml
-# Replaces the previous 183-line promote-testing-to-main.yml.
+# Thin caller — logic lives in projectbluefin/actions/reusable-promote-squash.yml
+#
+# Migrated from reusable-promote.yml which is now deleted.
+# Key improvement: squash branch is always rebuilt fresh on every run —
+# no staleness, no conflict drift, no merge friction.
 
 on:
   push:
@@ -16,13 +18,15 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
+  issues: write
 
 jobs:
   promote:
-    uses: projectbluefin/actions/.github/workflows/reusable-promote.yml@v1
+    uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@6c2278adfcde0818079173b40f6c0f07a68c7198 # v1
     with:
-      variants: '["dakota","dakota-nvidia"]'
+      variants: '[{"image":"dakota"},{"image":"dakota-nvidia"}]'
       cosign_identity_regexp: >-
         ^https://github\.com/projectbluefin/(dakota|actions)/\.github/workflows/
       run_e2e: false


### PR DESCRIPTION
## Summary

Migrates dakota from the deprecated `reusable-promote.yml` to `reusable-promote-squash.yml`.

bluefin and bluefin-lts already use `reusable-promote-squash`. This completes the migration and unblocks deletion of the old 12KB workflow from actions.

**Why squash is better:** branch always rebuilt fresh from main — no staleness, no conflict drift, no merge friction.

Assisted-by: Claude Sonnet 4.5 via pi
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration to improve release promotion processes with enhanced permissions and updated integration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->