### PR TITLE
chore(ci): use reusable-vulnerability-scan from actions

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -1,4 +1,5 @@
 name: Vulnerability Scan
+# Thin caller — scan logic lives in projectbluefin/actions/reusable-vulnerability-scan.yml
 
 on:
   schedule:
@@ -14,81 +15,15 @@ permissions:
   contents: read
   security-events: write
 
-concurrency:
-  group: vulnerability-scan-${{ github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   scan:
-    name: Grype scan — ${{ matrix.image_name }}
-    # Grype scans run on GitHub-hosted runners that can be preempted mid-job
-    # by spot-instance recycling. continue-on-error prevents a runner shutdown
-    # from marking the overall workflow as failed — SARIF uploads are best-effort.
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - image_name: dakota
-          - image_name: dakota-nvidia
-    steps:
-      - name: Resolve image ref
-        id: resolve
-        run: |
-          set -euo pipefail
-          if [[ -n "${{ inputs.image_ref }}" ]]; then
-            REF="${{ inputs.image_ref }}"
-          else
-            # Resolve :latest tag to an immutable digest for reproducible scan
-            TAG="ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:latest"
-            DIGEST=$(skopeo inspect --no-tags "docker://${TAG}" | jq -r '.Digest')
-            if [[ -z "${DIGEST}" ]]; then
-              echo "::error::Could not resolve digest for ${TAG}"
-              exit 1
-            fi
-            REF="ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}@${DIGEST}"
-          fi
-          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
-          echo "Scanning: ${REF}"
-
-      - name: Scan image with Grype
-        id: scan
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
-        with:
-          image: ${{ steps.resolve.outputs.ref }}
-          fail-build: false
-          severity-cutoff: critical
-          output-format: sarif
-
-      - name: Upload SARIF results
-        if: always()
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
-        with:
-          sarif_file: ${{ steps.scan.outputs.sarif }}
-          category: grype-${{ matrix.image_name }}
-
-      - name: Check for critical CVEs
-        if: always()
-        run: |
-          set -euo pipefail
-          CRITICAL_COUNT=$(python3 -c "
-          import json, sys
-          data = json.load(open('${{ steps.scan.outputs.sarif }}'))
-          runs = data.get('runs', [])
-          criticals = sum(
-            1 for run in runs
-            for result in run.get('results', [])
-            if result.get('ruleId', '').startswith('CVE') and
-               any(prop.get('security-severity', '0') >= '9.0'
-                   for prop in [result.get('properties', {})])
-          )
-          print(criticals)
-          " 2>/dev/null || echo "0")
-
-          echo "Critical CVEs found: ${CRITICAL_COUNT}"
-
-          if [[ "${CRITICAL_COUNT}" -gt 0 ]]; then
-            echo "::warning::${CRITICAL_COUNT} critical CVE(s) found in ${{ matrix.image_name }} — see Security tab"
-          fi
+    name: Vulnerability scan
+    permissions:
+      contents: read
+      security-events: write
+    uses: projectbluefin/actions/.github/workflows/reusable-vulnerability-scan.yml@c3669632a82da4a2b4a1575656c0c641aad8ff12 # v1
+    with:
+      image_matrix: '{"include":[{"image_name":"dakota"},{"image_name":"dakota-nvidia"}]}'
+      default_tag: 'latest'
+      image_ref: ${{ inputs.image_ref || '' }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Replaces ~3.2KB of inline Grype scan logic with a thin caller to
`projectbluefin/actions/reusable-vulnerability-scan.yml`.

The scan behavior is identical — only the location of the logic changes.
Future scan tool upgrades (Grype, codeql-action) are now a single-repo change in actions.

Consumer PR: https://github.com/projectbluefin/actions/pull/207

Part of factory code reuse audit.

Assisted-by: Claude Sonnet 4.5 via pi
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>