### PR TITLE
fix(ci): add missing packages: read and actions: read to promote workflow

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -1,7 +1,8 @@
 name: Promote testing to main
+
 # Thin caller — logic lives in projectbluefin/actions/reusable-promote-squash.yml
+# Replaces the previous 183-line promote-testing-to-main.yml.
 #
-# Migrated from reusable-promote.yml which is now deleted.
 # Key improvement: squash branch is always rebuilt fresh on every run —
 # no staleness, no conflict drift, no merge friction.
 
@@ -17,16 +18,22 @@ concurrency:
   group: promote-testing-to-main
   cancel-in-progress: false
 
+# The called reusable workflow needs write access to push the squash branch,
+# open/update PRs, and write issues. Caller-level permissions set the maximum
+# grants available to the called workflow's jobs.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: write       # push squash promotion branch
+  pull-requests: write  # create / update / auto-merge the promotion PR
+  issues: write         # open / close failure-tracking issues
+  packages: read        # read image digests in release-gate checks
+  actions: read         # inspect workflow-run statuses in release-gate
 
 jobs:
   promote:
-    uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@6c2278adfcde0818079173b40f6c0f07a68c7198 # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@5f3cabacecd1a7b95b7f64b03aa4c298ff73f918 # v1
     with:
-      variants: '[{"image":"dakota"},{"image":"dakota-nvidia"}]'
+      variants: >-
+        [{"image":"dakota"},{"image":"dakota-nvidia"}]
       cosign_identity_regexp: >-
         ^https://github\.com/projectbluefin/(dakota|actions)/\.github/workflows/
       run_e2e: false


### PR DESCRIPTION
## Problem

`promote-testing-to-main.yml` has had `startup_failure` since PR #811 introduced the thin caller. The workflow was missing `packages: read` and `actions: read` permissions that the `reusable-promote-squash.yml` release-gate checks require:

- `actions: read` — needed to inspect workflow-run statuses in the release gate
- `packages: read` — needed to read image digests from GHCR

The calling workflow's `permissions:` block sets the **maximum** grants available to the called reusable workflow's jobs. Without these two, the reusable's gate job fails to start.

## Evidence

Every run since PR #811 merged (2026-06-11) has been `startup_failure`:
- `27429336886` — workflow_dispatch today
- `27384189813` — scheduled (2026-06-11T23:32)
- `27366966538` — workflow_dispatch (2026-06-11T17:58)

Last successful run: `27313221192` (2026-06-10, before thin caller was introduced).

## Fix

- Add `packages: read` and `actions: read` to the workflow-level `permissions:` block
- Update SHA pin to `5f3cabacecd1a7b95b7f64b03aa4c298ff73f918` — same version as the working `projectbluefin/bluefin` thin caller
- Switch `variants` to `>-` folded scalar (consistent with bluefin)

Matches `projectbluefin/bluefin/.github/workflows/promote-testing-to-main.yml` which has been working.

Assisted-by: Claude Sonnet 4.5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow infrastructure to use a reusable workflow reference, improving maintainability and consistency across deployment automation.
  * Enhanced workflow permissions configuration for improved security controls during promotion processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->