### PR TITLE
fix(ci): revert promote SHA to 6c2278 — release-gate@5f8abb not found

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   promote:
-    uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@5f3cabacecd1a7b95b7f64b03aa4c298ff73f918 # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@6c2278adfcde0818079173b40f6c0f07a68c7198 # v1
     with:
       variants: >-
         [{"image":"dakota"},{"image":"dakota-nvidia"}]


### PR DESCRIPTION
## Problem

PR #817 fixed the permissions but used the wrong SHA for `reusable-promote-squash.yml` (the bluefin SHA `5f3cab` internally calls `reusable-release-gate@5f8abb` which no longer exists in the actions repo). This caused:

```
failed to parse workflow: error parsing called workflow
--> "projectbluefin/actions/.github/workflows/reusable-release-gate.yml@5f8abb3eb76390e634fd8c543d21f524d4f5f60f"
: failed to fetch workflow: workflow was not found.
```

## Fix

Reverts to the original `6c2278adfcde0818079173b40f6c0f07a68c7198` SHA which internally calls `reusable-release-gate.yml@v1` (the managed tag), keeping the permissions fix from #817.

## Verified

Run `27429540768` on this branch: **no startup_failure**. Workflow ran and correctly detected "nothing to squash" (new `:testing` digest not yet published from today's build). The startup loop is broken.

Assisted-by: Claude Sonnet 4.5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow infrastructure to use the latest version of the promotion workflow. No changes to functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->