### PR TITLE
fix(ci): use direct merge for auto-merge group — bypass not honoured by --auto

### DIFF
--- a/.github/workflows/track-bst-sources.yml
+++ b/.github/workflows/track-bst-sources.yml
@@ -264,10 +264,11 @@ jobs:
           echo "PR: $PR_URL"
 
           if [ "${{ matrix.group }}" = "auto-merge" ]; then
-            echo "Enabling auto-merge..."
-            # Use --squash: the repo only allows squash merges (allowMergeCommit=false).
-            # --merge would silently fail via the '|| echo ::warning::' fallback.
-            gh pr merge "$PR_URL" --auto --squash || echo "::warning::Could not enable auto-merge"
+            # Direct merge via mergeraptor bypass. --auto uses GitHub's auto-merge
+            # queue which does NOT honour bypass_pull_request_allowances — only
+            # direct merges do. With no required status checks and mergeraptor in
+            # bypass_pull_request_allowances, this merges immediately.
+            gh pr merge "$PR_URL" --squash || echo "::warning::Could not merge PR"
           fi
 
   track-tarballs:


### PR DESCRIPTION
## Problem

All `auto-merge` group PRs from `track-bst-sources.yml` (common, distrobox, brew, shell extensions, etc.) were sitting open instead of auto-merging.

Root cause: `gh pr merge "$PR_URL" --auto --squash` enables GitHub's **auto-merge queue**, which evaluates conditions using GitHub's internal process — it does **NOT** honour `bypass_pull_request_allowances`. Only direct merges (without `--auto`) use the bypass.

Since the repo has:
- `required_approving_count: 1` — requires a review
- `bypass_pull_request_allowances: [mergeraptor]` — mergeraptor can bypass

...the auto-merge queue was waiting for a human approval that would never come automatically. The bypass only fires on direct merge.

## Fix

Remove `--auto` from `gh pr merge`. Since there are no required status checks and mergeraptor is in the bypass list, the direct merge completes immediately when the PR is created.

## Impact

All `auto-merge` group elements will now merge to `main` immediately when `track-bst-sources.yml` creates or updates their PRs. `manual-merge` group elements are unaffected.

Assisted-by: Claude Sonnet 4.5 via pi