### PR TITLE
ci: restore testing→main promotion pipeline — parity with bluefin

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,11 +3,14 @@
   "extends": [
     "local>projectbluefin/renovate-config:org-inherited-config"
   ],
-  // Renovate targets main. All PRs must target main — the CI gate
-  // (on-pr-opened-or-updated) blocks any PR not targeting main.
+  // Renovate targets the testing staging branch. PRs land on testing first,
+  // are built and validated, then the promote-testing-to-main workflow opens a
+  // squash PR to advance main (triggering :stable promotion). This matches the
+  // bluefin/bluefin-lts model. Renovate PRs targeting testing are explicitly
+  // exempted from the "must target main" gate in pr-triage.yml.
   // Note: track-bst-sources.yml manages BuildStream refs directly and
   // intentionally targets main — it is not Renovate-managed.
-  "baseBranchPatterns": ["main"],
+  "baseBranchPatterns": ["testing"],
   "branchPrefix": "renovate/",
 
   // Limit Renovate to GitHub Actions and workflow image refs.

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -54,6 +54,12 @@ jobs:
             echo "Automated next-branch junction update — skipping main-target gate."
             exit 0
           fi
+          # Allow Renovate PRs targeting testing — testing is the staging branch
+          # for the testing→main promotion pipeline (parity with bluefin).
+          if [ "$BASE_REF" = "testing" ] && [[ "$HEAD_REF" == renovate/* ]]; then
+            echo "Renovate update targeting testing staging branch — skipping main-target gate."
+            exit 0
+          fi
           if [ "$BASE_REF" != "main" ]; then
             echo "ERROR: PRs must target 'main', not '$BASE_REF'."
             echo "Branches like 'stable' and 'latest' are managed by the promotion pipeline — never target them directly."

--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   promote:
-    uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@6c2278adfcde0818079173b40f6c0f07a68c7198 # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@efa19f2c3efdcbef1c55a1730229891d781fd11b # v1
     with:
       variants: >-
         [{"image":"dakota"},{"image":"dakota-nvidia"}]

--- a/.github/workflows/sync-main-to-testing.yml
+++ b/.github/workflows/sync-main-to-testing.yml
@@ -1,0 +1,40 @@
+name: Sync main → testing
+
+# After each squash-merge promotion (testing→main), the squash commit lands
+# on main but not in testing, leaving testing BEHIND. This workflow merges
+# main back into testing automatically so the next promotion PR is not blocked.
+# Reusable logic lives in projectbluefin/actions. This is a thin caller.
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: sync-main-to-testing
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Keep testing up-to-date with main
+    uses: projectbluefin/actions/.github/workflows/reusable-sync-branches.yml@3025b5d31f34ce44c19eab41a7fa5d4d5c5b688e # v1
+    permissions:
+      contents: write
+
+  cleanup-squash-branch:
+    name: Delete squash promotion branch
+    needs: [sync]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Delete auto/promote-testing-to-main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api repos/${{ github.repository }}/git/refs/heads/auto/promote-testing-to-main \
+            -X DELETE 2>/dev/null \
+            && echo "✅ Deleted squash promotion branch" \
+            || echo "Branch already deleted or does not exist — nothing to do"

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -1200,3 +1200,61 @@ than pinned SHAs for inner dependencies.
 **Rule:** when picking a SHA to pin for a reusable workflow, verify that its
 own nested `uses:` references are either `@v1`/managed-tags or still-live
 SHAs. Prefer the version that uses managed tags internally — those age better.
+
+---
+
+## Testing→main promotion pipeline — full cycle and failure modes (2026-06-12)
+
+### How the cycle works (bluefin model)
+
+```
+Renovate PR → testing branch (automerges when build CI passes)
+    → push to testing → promote-testing-to-main fires
+    → squash PR: auto/promote-testing-to-main → main
+    → maintainer merges
+    → execute-release fires (commit msg "ci: promote testing images to stable")
+    → :testing retagged as :stable
+    → push to main → sync-main-to-testing fires
+    → main fast-forwarded into testing (testing == main again)
+    → next Renovate cycle begins
+```
+
+### Three invariants that must all hold
+
+1. **`baseBranchPatterns: ["testing"]`** in `renovate.json5` — Renovate must target
+   `testing`, not `main`. With `baseBranchPatterns: ["main"]`, `testing` is a dead
+   branch: nothing ever lands there, the promote workflow finds nothing to squash,
+   and `:stable` never updates.
+
+2. **`sync-main-to-testing.yml`** must exist — after each squash-merge promotion, the
+   squash commit lands on `main` but not `testing`. Without this workflow, `testing`
+   falls permanently behind `main`. The next promote run finds diverged trees (so
+   `sync_needed=true`), but the squash produces nothing staged → `git commit` exits 1.
+
+3. **`pr-triage.yml` must exempt `renovate/*` PRs targeting `testing`** — the triage
+   workflow blocks all PRs not targeting `main`. Without an exemption, Renovate PRs
+   to `testing` are immediately blocked and cannot automerge.
+
+### The empty-squash crash (known bug in reusable-promote-squash)
+
+When `testing` is behind `main` with no unique content:
+- `git merge --squash origin/testing` says "Already up to date"
+- Nothing is staged
+- `git commit` exits 1 → job fails with misleading error
+
+This is fixed by `projectbluefin/actions#218` (adds `git diff --cached --quiet` guard
+before `git commit`). In steady state (sync-main-to-testing present), this edge case
+doesn't occur because `testing == main` after each sync, and the next promote run gets
+`sync_needed=false` cleanly. The fix is defence-in-depth.
+
+### Root cause of 2026-06-11/12 breakage
+
+PR #741 changed `baseBranchPatterns` from `["testing"]` to `["main"]` to work around
+the triage gate — but without also adding `sync-main-to-testing.yml` or exempting
+Renovate from the gate. After promotion #797 (June 10), the cycle broke permanently:
+- `testing` fell 20+ commits behind `main` (no sync workflow)
+- Renovate stopped feeding `testing` (wrong base branch)
+- Promote workflow crashed nightly (empty squash)
+- `:stable` stopped updating
+
+**Fix: PR #822** (dakota) + **PR #218** (actions).


### PR DESCRIPTION
## Problem

The `testing → main` promotion pipeline was broken. The nightly `promote-testing-to-main` workflow produced 5× `startup_failure` and 1× `git commit exit 1` since June 11. No promotion PR has been open since PR #797 (June 10).

**Root cause chain:**
1. PR #741 changed `renovate.json5` to `baseBranchPatterns: ["main"]` — Renovate stopped feeding `testing`
2. No `sync-main-to-testing.yml` existed — after promotion #797, `testing` fell 20+ commits behind `main` forever
3. The nightly promote ran, found trees different, tried to squash `testing → main`, got "Already up to date (nothing to squash)", `git commit` exited 1 — crash
4. Without a promotion PR, `execute-release` never fires, `:stable` never updates

## Changes

### 1. `sync-main-to-testing.yml` (new)
Merges `main` back into `testing` on every push to `main`. This re-aligns the branches after each squash-merge promotion so the cycle can continue. Exact parity with `projectbluefin/bluefin` and `projectbluefin/bluefin-lts`.

### 2. `renovate.json5`: `baseBranchPatterns: ["main"]` → `["testing"]`
Renovate must target `testing` so new GHA digest updates stage there first. The promotion PR then carries them to `main`, which triggers `execute-release` to retag `:testing → :stable`. This is the bluefin model.

### 3. `pr-triage.yml`: exempt Renovate PRs targeting `testing` from the main-target gate
Without this, Renovate PRs to `testing` are immediately blocked by the triage workflow and can never automerge — breaking the staging pipeline.

### 4. `promote-testing-to-main.yml`: SHA bump `6c2278a → efa19f2c`
Picks up 9 commits of fixes in `projectbluefin/actions`:
- PR body rendering with git log and days-since-stable
- Team review request on PR create
- e2e gate SHA correctness (main HEAD, not target branch HEAD)
- `source_branch`/`target_branch` inputs for non-default branch models

A companion fix for the empty-squash crash (`git commit exit 1`) is in **projectbluefin/actions#218** — that PR should be merged and Renovate will bump this SHA further.

## Expected steady-state cycle after merge

```
Renovate PR → testing branch (automerges when CI passes)
    → testing branch push → promote-testing-to-main fires
    → squash PR opened: auto/promote-testing-to-main → main
    → maintainer merges
    → execute-release fires (commit message "ci: promote testing images to stable")
    → :testing re-tagged as :stable
    → sync-main-to-testing fires (push to main)
    → main merged back into testing (fast-forward)
    → testing == main → next Renovate cycle begins
```

## Checklist
- [x] `actionlint` passes on all modified workflows
- [x] Companion fix for empty-squash crash: projectbluefin/actions#218
- [ ] I am using an agent and I take responsibility for this PR

Assisted-by: Claude Sonnet 4.5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renovate pull requests now target the testing branch instead of main
  * Updated PR triage workflow to exempt Renovate PRs targeting the testing branch
  * Added workflow to sync main back to testing after promotions
  * Updated promotion workflow reference

* **Documentation**
  * Added documentation for the testing→main promotion pipeline, including required invariants and known issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->