### PR TITLE
fix(ci): bump reusable-renovate-automerge SHA — drop --auto

### DIFF
--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -12,6 +12,6 @@ permissions:
 jobs:
   automerge:
     if: github.event.workflow_run.conclusion == 'success'
-    uses: projectbluefin/actions/.github/workflows/reusable-renovate-automerge.yml@2a09e72e9be15b137392dde15f8587f35587e8eb # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-renovate-automerge.yml@33a6406631eb6d933a7ea7667c510890b5069cc8 # v1
     with:
       head_sha: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
## Problem

All Renovate PRs targeting `testing` were silently failing to automerge. The `renovate-automerge.yml` workflow would find the PR, call `gh pr merge --auto --squash`, and get back:

```
GraphQL: Pull request Protected branch rules not configured for this branch (enablePullRequestAutoMerge)
```

Root cause: `gh pr merge --auto` uses GitHub's `enablePullRequestAutoMerge` GraphQL mutation, which **requires at least one branch protection rule on the target branch**. `testing` has no branch protection — so every call fails.

Same root cause was already fixed for `track-bst-sources.yml` in #820 ("bypass not honoured by --auto"). This is the same fix applied to the Renovate automerge path.

## Fix

Picks up [`projectbluefin/actions@33a6406`](https://github.com/projectbluefin/actions/commit/33a6406631eb6d933a7ea7667c510890b5069cc8) which drops `--auto` and merges directly. CI success is already guaranteed by the `workflow_run` trigger condition (`conclusion == 'success'`).

## Tonight

This PR fixes the workflow going forward. **PRs #825 and #827 are still stuck** — they ran against the broken workflow and won't auto-retry. Merge them manually:

```bash
gh pr merge 825 --squash --repo projectbluefin/dakota
gh pr merge 827 --squash --repo projectbluefin/dakota
```
