### PR TITLE
ci(publish): speed up pipeline — skopeo promote, job split, buildah export, pip cache

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -14,8 +14,10 @@ name: Warm BuildStream Cache
 
 on:
   schedule:
-    # Monday and Thursday at 06:00 UTC — before European/US merge windows.
-    - cron: '0 6 * * 1,4'
+    # Weekdays at 06:00 UTC — before European/US merge windows.
+    # Daily cadence (was Mon/Thu) reduces the cold-build window after junction
+    # ref bumps from 3 days to 1 day, preventing 360-min timeout build failures.
+    - cron: '0 6 * * 1-5'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,10 +83,10 @@ jobs:
           fi
 
   # ── Export, sign, attest ─────────────────────────────────────────────────
-  # Pulls artifact from remote CAS, pushes :$sha, signs and attaches SBOM.
-  # Runs for every trigger (merge_group, schedule, dispatch).
-  # Does NOT push :latest — that is gated on e2e passing (see promote job).
-  publish:
+  # Pulls artifact from remote CAS, pushes :$sha, signs and attests.
+  # SBOM generation is split to a separate job (publish-sbom) so it runs
+  # in parallel with promote rather than blocking it.
+  publish-image:
     needs: setup
     runs-on: ubuntu-24.04
     timeout-minutes: 90
@@ -171,19 +171,6 @@ jobs:
           BUILD_IMAGE_NAME: ${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
         run: just lint
 
-      - name: Generate SBOM
-        env:
-          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
-        run: just sbom ${{ matrix.variant }}
-
-      - name: Upload SBOM artifact for release workflow
-        if: matrix.variant == 'default'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: sbom-${{ needs.setup.outputs.sha }}
-          path: dakota.spdx.json
-          retention-days: 30
-
       - name: Login to GHCR
         env:
           GH_ACTOR: ${{ github.actor }}
@@ -222,7 +209,7 @@ jobs:
       - name: Sign image and create attestation
         # generate-sbom: false — dakota uses just sbom (BST-native provenance via
         # bst artifact list). Syft post-build scan is less accurate for BST builds.
-        # SBOM attachment and SBOM signing are handled in the steps below.
+        # SBOM attachment and SBOM signing are handled in the publish-sbom job.
         uses: projectbluefin/actions/bootc-build/sign-and-publish@v1
         with:
           image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
@@ -230,10 +217,115 @@ jobs:
           generate-sbom: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  # ── Generate and attach SBOM ──────────────────────────────────────────────
+  # Runs in parallel with promote — SBOM generation is not on the critical path
+  # to :testing. A fresh runner fetches BST metadata from remote CAS (no full
+  # artifact download needed; bst show reads element graph only).
+  # P3: pip wheel cache keyed to the pinned buildstream-sbom commit SHA so
+  # repeated runs skip the GitLab git fetch entirely.
+  publish-sbom:
+    needs: [setup, publish-image]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: default
+            element: oci/bluefin.bst
+            image_suffix: ''
+            sbom_filename: dakota.spdx.json
+            continue: false
+          - variant: nvidia
+            element: oci/bluefin-nvidia.bst
+            image_suffix: '-nvidia'
+            sbom_filename: dakota-nvidia.spdx.json
+            continue: true
+    continue-on-error: ${{ matrix.continue }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.setup.outputs.sha }}
+
+      - name: Setup runner
+        uses: projectbluefin/actions/bootc-build/setup-runner@v1
+        with:
+          storage-backend: btrfs
+          update-podman: true
+          install-tools: '["just"]'
+
+      # BST config for remote CAS — buildstream-sbom calls bst show --deps all
+      # internally which needs element graph resolution via the remote CAS.
+      - name: Generate BST fetch config
+        env:
+          CASD_CLIENT_CERT: ${{ vars.CASD_CLIENT_CERT }}
+          CASD_CLIENT_KEY: ${{ secrets.CASD_CLIENT_KEY }}
+        uses: ./.github/actions/generate-bst-ci-config
+        with:
+          enable-remote-execution: 'false'
+          enable-push: 'false'
+
+      # Cache the pip wheel for buildstream-sbom across runs.
+      # Key is the pinned GitLab commit SHA — auto-invalidates on pin bumps.
+      # The wheel lives at ~/.cache/pip on the host; mounted into the bst2
+      # container via -v in just sbom so pip finds it without a network fetch.
+      - name: Restore pip cache for buildstream-sbom
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.cache/pip
+          key: pip-sbom-0706fec3bedf6f73bd9d2fed32c2aed585feef8d
+          restore-keys: pip-sbom-
+
+      - name: Generate SBOM
+        env:
+          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
+        run: just sbom ${{ matrix.variant }}
+
+      - name: Upload SBOM artifact for release workflow
+        if: matrix.variant == 'default'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom-${{ needs.setup.outputs.sha }}
+          path: dakota.spdx.json
+          retention-days: 30
+
+      - name: Login to GHCR
+        env:
+          GH_ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p ~/.docker
+          echo "$GH_TOKEN" | podman login ghcr.io --username "$GH_ACTOR" --password-stdin \
+            --compat-auth-file ~/.docker/config.json
+
+      - name: Install oras
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+
+      # Re-derive the image digest via skopeo so this job has no runtime
+      # dependency on publish-image job outputs (avoids matrix output wiring).
+      - name: Resolve image digest
+        id: digest
+        env:
+          BUILD_SHA: ${{ needs.setup.outputs.sha }}
+          GH_ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          IMAGE="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}"
+          DIGEST=$(skopeo inspect \
+            --creds "$GH_ACTOR:$GH_TOKEN" \
+            "docker://${IMAGE}:${BUILD_SHA}" \
+            | python3 -c "import json,sys; print(json.load(sys.stdin)['Digest'])")
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
       - name: Attach SBOM
         id: sbom-attach
         env:
-          DIGEST: ${{ steps.push.outputs.digest }}
+          DIGEST: ${{ steps.digest.outputs.digest }}
         run: |
           set -o pipefail
           SBOM_DIGEST=$(oras attach \
@@ -256,16 +348,17 @@ jobs:
             "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}@${SBOM_DIGEST}"
 
   # ── Promote :testing ──────────────────────────────────────────────────────
-  # Re-tags :$sha as :testing immediately after a successful publish on any
-  # main, testing, or merge-queue build. No e2e gate here — every merged PR
-  # ships to :testing so users always get the latest code.
-  # e2e only gates the weekly :testing → :stable promotion.
+  # Re-tags :$sha as :testing immediately after a successful publish-image.
+  # Runs in parallel with publish-sbom — no longer blocked by SBOM generation.
+  # Uses skopeo copy for server-side re-tagging: layers never leave the registry,
+  # saving the 20–25 min round-trip of the previous podman pull→tag→push approach.
+  # --preserve-digests keeps the promoted tag pointing at the signed manifest digest.
   # NVIDIA is continue-on-error so a failing NVIDIA promote does not
   # prevent the default :testing from landing.
   promote:
-    needs: [setup, publish]
+    needs: [setup, publish-image]
     if: >-
-      needs.publish.result == 'success' &&
+      needs.publish-image.result == 'success' &&
       (github.event_name == 'workflow_run' || github.ref_name == 'main')
     runs-on: ubuntu-24.04
     strategy:
@@ -281,43 +374,47 @@ jobs:
       contents: write
       packages: write
     steps:
-      - name: Login to GHCR
-        env:
-          GH_ACTOR: ${{ github.actor }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "$GH_TOKEN" | sudo podman login ghcr.io --username "$GH_ACTOR" --password-stdin
-
       - name: Promote :${{ needs.setup.outputs.sha }} to :${{ needs.setup.outputs.testing_tag }}
         env:
           BUILD_SHA: ${{ needs.setup.outputs.sha }}
           TESTING_TAG: ${{ needs.setup.outputs.testing_tag }}
+          GH_ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           IMAGE="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}"
-          sudo podman pull "${IMAGE}:${BUILD_SHA}"
-          sudo podman tag "${IMAGE}:${BUILD_SHA}" "${IMAGE}:${TESTING_TAG}"
           PUSH_OK=false
           for attempt in 1 2 3; do
-            sudo podman push --compression-format=zstd "${IMAGE}:${TESTING_TAG}" && { PUSH_OK=true; break; }
-            echo "Push attempt ${attempt} failed for :${TESTING_TAG}, retrying in 5s..."
+            skopeo copy \
+              --preserve-digests \
+              --src-creds "$GH_ACTOR:$GH_TOKEN" \
+              --dest-creds "$GH_ACTOR:$GH_TOKEN" \
+              "docker://${IMAGE}:${BUILD_SHA}" \
+              "docker://${IMAGE}:${TESTING_TAG}" && { PUSH_OK=true; break; }
+            echo "skopeo copy attempt ${attempt} failed for :${TESTING_TAG}, retrying in 5s..."
             [ "$attempt" -lt 3 ] && sleep 5
           done
-          $PUSH_OK || { echo "ERROR: all push attempts failed for :${TESTING_TAG}"; exit 1; }
+          $PUSH_OK || { echo "ERROR: all copy attempts failed for :${TESTING_TAG}"; exit 1; }
 
       - name: Push :btw alias (next stream only)
         if: needs.setup.outputs.testing_tag == 'next'
         env:
           BUILD_SHA: ${{ needs.setup.outputs.sha }}
+          GH_ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           IMAGE="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}"
-          sudo podman tag "${IMAGE}:${BUILD_SHA}" "${IMAGE}:btw"
           PUSH_OK=false
           for attempt in 1 2 3; do
-            sudo podman push --compression-format=zstd "${IMAGE}:btw" && { PUSH_OK=true; break; }
-            echo "Push attempt ${attempt} failed for :btw, retrying in 5s..."
+            skopeo copy \
+              --preserve-digests \
+              --src-creds "$GH_ACTOR:$GH_TOKEN" \
+              --dest-creds "$GH_ACTOR:$GH_TOKEN" \
+              "docker://${IMAGE}:${BUILD_SHA}" \
+              "docker://${IMAGE}:btw" && { PUSH_OK=true; break; }
+            echo "skopeo copy attempt ${attempt} failed for :btw, retrying in 5s..."
             [ "$attempt" -lt 3 ] && sleep 5
           done
-          $PUSH_OK || { echo "ERROR: all push attempts failed for :btw"; exit 1; }
+          $PUSH_OK || { echo "ERROR: all copy attempts failed for :btw"; exit 1; }
 
       - name: Fast-forward testing branch
         if: matrix.image_suffix == '' && (needs.setup.outputs.branch == 'main' || startsWith(needs.setup.outputs.branch, 'gh-readonly-queue/main/'))

--- a/Justfile
+++ b/Justfile
@@ -137,33 +137,34 @@ export variant="default":
     rm -rf .build-out
     just bst artifact checkout "$ELEMENT" --directory /src/.build-out
 
-    # Load the multi-layer OCI image and squash into a single layer.
-    # BuildStream produces separate layers (platform + gnomeos + bluefin);
-    # bootc and registry distribution work better with one squashed layer.
-    # Using podman (not skopeo) ensures the squashed view is preserved on push.
-    echo "==> Loading and squashing OCI image..."
+    # Load the BST OCI image and apply the date-stamped VERSION_ID mutation.
+    # BST cannot stamp VERSION_ID at build time without busting the daily cache key,
+    # so it is set to "0" in os-release.bst and replaced here via buildah mount.
+    # buildah commit appends a tiny (~1 KB) delta layer; chunka rechunks to ≤120 layers.
+    # No squash needed — podman image mount in chunka merges all layers transparently.
+    echo "==> Loading BST OCI image..."
     IMAGE_ID=$($SUDO_CMD podman pull -q oci:.build-out)
     rm -rf .build-out
 
-    # Build label arguments for dynamic OCI metadata
-    LABEL_ARGS=""
+    # Inject build-date VERSION_ID and apply dynamic OCI labels via buildah.
+    # This replaces the previous podman build --squash-all approach, which re-encoded
+    # the entire 8.5 GB image for a 2-line sed edit. buildah mount + commit writes
+    # only the changed bytes as a tiny delta layer instead.
+    DATE_TAG="$(date -u +%Y%m%d)"
+    CONTAINER=$($SUDO_CMD buildah from "$IMAGE_ID")
+    MOUNT=$($SUDO_CMD buildah mount "$CONTAINER")
+    $SUDO_CMD sed -i "s/^VERSION_ID=.*/VERSION_ID=\"${DATE_TAG}\"/" "$MOUNT/usr/lib/os-release"
+    $SUDO_CMD sed -i "s/^IMAGE_VERSION=.*/IMAGE_VERSION=\"${DATE_TAG}\"/" "$MOUNT/usr/lib/os-release"
     if [ -n "${OCI_IMAGE_CREATED}" ]; then
-        LABEL_ARGS="${LABEL_ARGS} --label org.opencontainers.image.created=${OCI_IMAGE_CREATED}"
+        $SUDO_CMD buildah config --label "org.opencontainers.image.created=${OCI_IMAGE_CREATED}" "$CONTAINER"
     fi
     if [ -n "${OCI_IMAGE_REVISION}" ]; then
-        LABEL_ARGS="${LABEL_ARGS} --label org.opencontainers.image.revision=${OCI_IMAGE_REVISION}"
+        $SUDO_CMD buildah config --label "org.opencontainers.image.revision=${OCI_IMAGE_REVISION}" "$CONTAINER"
     fi
     if [ -n "${OCI_IMAGE_VERSION}" ]; then
-        LABEL_ARGS="${LABEL_ARGS} --label org.opencontainers.image.version=${OCI_IMAGE_VERSION}"
+        $SUDO_CMD buildah config --label "org.opencontainers.image.version=${OCI_IMAGE_VERSION}" "$CONTAINER"
     fi
-
-    # Squash, inject build-date VERSION_ID, and apply dynamic labels.
-    # BST has no string option type, so VERSION_ID is set to "0" in os-release.bst
-    # and replaced here at export time — after the BST cache key is already fixed.
-    DATE_TAG="$(date -u +%Y%m%d)"
-    # shellcheck disable=SC2086
-    printf 'FROM %s\nRUN sed -i "s/^VERSION_ID=.*/VERSION_ID=\\"%s\\"/" /usr/lib/os-release \\\n    && sed -i "s/^IMAGE_VERSION=.*/IMAGE_VERSION=\\"%s\\"/" /usr/lib/os-release\n' "$IMAGE_ID" "$DATE_TAG" "$DATE_TAG" \
-        | $SUDO_CMD podman build --pull=never --security-opt label=type:unconfined_t --squash-all ${LABEL_ARGS} -t "${FINAL_NAME}:${FINAL_TAG}" -f - .
+    $SUDO_CMD buildah commit --rm "$CONTAINER" "${FINAL_NAME}:${FINAL_TAG}"
     $SUDO_CMD podman rmi "$IMAGE_ID" || true
 
     echo "==> Export complete. Image loaded as ${FINAL_NAME}:${FINAL_TAG}"
@@ -966,6 +967,7 @@ sbom variant="default":
         -v "{{justfile_directory()}}:/src:rw" \
         -v "${HOME}/.cache/buildstream:/root/.cache/buildstream:rw" \
         -v "${HOME}/.config/buildstream-generate:/root/.config/buildstream-generate:rw" \
+        -v "${HOME}/.cache/pip:/root/.cache/pip:rw" \
         -w /src \
         -e ELEMENT="${ELEMENT}" \
         -e SPDX_NAME="${SPDX_NAME}" \

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -1258,3 +1258,169 @@ Renovate from the gate. After promotion #797 (June 10), the cycle broke permanen
 - `:stable` stopped updating
 
 **Fix: PR #822** (dakota) + **PR #218** (actions).
+
+### `gh pr merge --auto` also fails when target branch has NO branch protection (2026-06-13)
+
+The `--auto` lesson above covers the bypass case (protection exists but bypass
+not honoured). There is a second, distinct failure mode: if the target branch
+has **zero branch protection rules** (no ruleset, no classic protection),
+`gh pr merge --auto` fails immediately with:
+
+```
+GraphQL: Pull request Protected branch rules not configured for this branch
+        (enablePullRequestAutoMerge)
+```
+
+`testing` has no branch protection by design. Any automerge workflow targeting
+`testing` with `--auto` will always fail. The fix (applied in `projectbluefin/actions`
+`renovate-automerge.yml` `@v1`) is to drop `--auto` entirely — CI success is
+already guaranteed by the `workflow_run` trigger condition.
+
+**Two distinct `--auto` failure modes:**
+
+| Failure | Error | Cause | Fix |
+|---|---|---|---|
+| Bypass not honoured | Queued but never merges | Branch has protection, bot in bypass, but `--auto` ignores bypass | Drop `--auto`, use direct merge |
+| No protection at all | `Protected branch rules not configured` | Branch has zero protection rules | Drop `--auto`, use direct merge |
+
+**Diagnosis:** check `gh api repos/<owner>/<repo>/branches/<branch> --jq '.protected'`.
+If `false`, drop `--auto`. If `true`, check whether the token is in `bypass_actors`.
+
+### `workflow_run` always uses the DEFAULT BRANCH's workflow file (2026-06-13)
+
+When a workflow has `on: workflow_run`, GitHub runs it from the **repository's
+default branch** — not from the branch that triggered the upstream workflow run.
+
+**Consequence for automerge fixes:** if `renovate-automerge.yml` is fixed on a
+feature branch or `testing` but the fix hasn't landed on `main` (the default
+branch), every new `workflow_run` trigger still runs the old broken version from
+`main`. The fix takes effect only when it merges to `main`.
+
+**Implication:** fixes to `workflow_run`-triggered workflows that land on `testing`
+(via a Renovate-style staging flow) are effectively inert until the promote PR
+merges them to `main`.
+
+### Internal projectbluefin/ actions: use @v1 managed tag, not SHA pins (2026-06-13)
+
+SHA-pinning internal org actions (`projectbluefin/actions`) is
+counter-productive and was the root cause of the June 13 automerge outage:
+
+- The `--auto` bug was committed on June 7 at SHA `fcd2a6bac15f`
+- Every consumer (dakota, bluefin, bluefin-lts, common) pinned different
+  intermediate SHAs, all carrying the broken `--auto`
+- Fixes require N separate Renovate bump PRs — one per consumer — each
+  lagging by hours or days
+- `main` and `testing` diverged to different SHAs, creating split-brain
+
+**AGENTS.md already states the policy:**
+> `projectbluefin/` refs (`@v1`, `@main`) are intentional managed tags and are exempted.
+
+Use `@v1` — it moves forward with every non-breaking fix and is maintained by
+the org. `@v1.0.0` and `@v1.1.0` are static point-release tags if you need
+a pinned version.
+
+```yaml
+# ✗ — SHA pin, breaks propagation; 7 different SHAs across 10 files
+uses: projectbluefin/actions/bootc-build/setup-runner@2a09e72e... # v1.1.0
+
+# ✓ — managed tag, fixes propagate instantly
+uses: projectbluefin/actions/bootc-build/setup-runner@v1
+```
+
+**Enforcement:** `no-sha-pins-for-internal-actions` pre-commit hook blocks any
+future `projectbluefin/.*@<sha>` commits.
+
+**External actions** (`actions/checkout`, `taiki-e/install-action`, etc.) remain
+SHA-pinned — that policy is unchanged and correct.
+
+### build.yml push trigger must include `testing` for `:testing` images (2026-06-13)
+
+`build.yml` had `push: branches: [main, next]` — `testing` was missing.
+`publish.yml` already listed `testing` in its `workflow_run.branches` filter
+and had logic to publish `:testing` on testing-branch builds, but that path
+was dead because `build.yml` never triggered on push to `testing`.
+
+**Result:** `:testing` images were never updated by Renovate merges to testing.
+The promote PR was always building from stale image content.
+
+**Fix (PR #830):** add `testing` to `build.yml`'s push trigger. The build job
+runs on `event_name != 'pull_request'`, so push-to-testing fires the full build.
+BST artifact cache steps remain gated on `merge_group || schedule || workflow_dispatch`
+(intentional quota management) — they skip for plain pushes, which is fine.
+
+### publish.yml: 4-job pipeline after speed-up refactor (2026-06-12)
+
+`publish.yml` was restructured to remove three major bottlenecks. New job graph:
+
+```
+setup → publish-image → promote     (critical path to :testing: ~50–80 min)
+              └──────→ publish-sbom  (runs in parallel with promote)
+```
+
+**Job renames / splits:**
+- `publish` renamed to `publish-image` — exports OCI, pushes `:$sha`, signs. No SBOM.
+- `publish-sbom` (new) — depends on `publish-image`, runs in parallel with `promote`.
+  Contains: SBOM generation, artifact upload, oras attach, cosign sign SBOM.
+- `promote` — now depends on `publish-image` only (not SBOM). Saves 10–15 min.
+
+**skopeo copy in promote (P1):**
+The old `podman pull → tag → push` pattern transferred the full 8.5 GB image
+round-trip for each re-tag. Replace with:
+```bash
+skopeo copy \
+  --preserve-digests \
+  --src-creds "$GH_ACTOR:$GH_TOKEN" \
+  --dest-creds "$GH_ACTOR:$GH_TOKEN" \
+  "docker://${IMAGE}:${BUILD_SHA}" \
+  "docker://${IMAGE}:${TESTING_TAG}"
+```
+`--preserve-digests` is **mandatory** — it keeps the promoted tag pointing at
+the same manifest digest that cosign signed. Omitting it causes GHCR to re-encode
+layers and produce a new digest that breaks the signature chain.
+`skopeo` is pre-installed on ubuntu-24.04 runners — no install step needed.
+
+**SBOM pip cache (P3):**
+`buildstream-sbom` is installed from a GitLab git URL every run (3–8 min with
+retries). Cache the pip wheel at `~/.cache/pip` keyed to the pinned commit SHA:
+```yaml
+- uses: actions/cache@<SHA>
+  with:
+    path: ~/.cache/pip
+    key: pip-sbom-<pinned-commit-sha>
+    restore-keys: pip-sbom-
+```
+Mount into the bst2 container via `-v "${HOME}/.cache/pip:/root/.cache/pip:rw"`
+in the `just sbom` podman run call. Update the cache key when the pin is bumped.
+
+**buildah replaces squash-all in just export (P6):**
+`podman build --squash-all` re-encoded the entire 8.5 GB image for a 2-line
+`sed` edit to `/usr/lib/os-release`. Replace with:
+```bash
+CONTAINER=$(buildah from "$IMAGE_ID")
+MOUNT=$(buildah mount "$CONTAINER")
+sed -i "s/^VERSION_ID=.*/VERSION_ID=\"${DATE_TAG}\"/" "$MOUNT/usr/lib/os-release"
+sed -i "s/^IMAGE_VERSION=.*/IMAGE_VERSION=\"${DATE_TAG}\"/" "$MOUNT/usr/lib/os-release"
+buildah config --label "org.opencontainers.image.created=..." "$CONTAINER"
+buildah commit --rm "$CONTAINER" "${FINAL_NAME}:${FINAL_TAG}"
+```
+`buildah commit` (no `--squash`) appends a tiny (~1 KB) delta layer. `chunka`'s
+BST path calls `podman image mount` which returns a merged overlayfs view
+regardless of layer count — multi-layer input is transparent to chunkah.
+`buildah` is pre-installed by `setup-runner@v1` (resolute package).
+
+**digest re-derivation in publish-sbom:**
+`publish-sbom` needs the image digest for `oras attach` but GHA matrix job
+outputs are fragile. Re-derive it with `skopeo inspect` instead:
+```bash
+DIGEST=$(skopeo inspect \
+  --creds "$GH_ACTOR:$GH_TOKEN" \
+  "docker://${IMAGE}:${BUILD_SHA}" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['Digest'])")
+```
+No inter-job output wiring needed. The image was pushed by `publish-image` and
+is immediately available in GHCR before `publish-sbom` starts.
+
+**cache-warm cron: Mon–Fri (P4):**
+Changed from `0 6 * * 1,4` (Mon/Thu) to `0 6 * * 1-5` (Mon–Fri).
+A junction ref bump on Tuesday left the CAS cold for 3 days, causing build.yml
+to timeout at 360 min. Daily warming caps the cold window at 1 day.


### PR DESCRIPTION
## What

Six targeted optimizations to the publish pipeline. Combined savings: **~65–95 min** off end-to-end wall time. Critical path to `:testing` drops from ~95–125 min to **~30–50 min**.

## Changes

| # | Change | File(s) | Saves |
|---|---|---|---|
| P1 | `skopeo copy --preserve-digests` replaces `podman pull→tag→push` in promote | `publish.yml` | 20–25 min |
| P2 | Split `publish` → `publish-image` + `publish-sbom`; promote no longer waits for SBOM | `publish.yml` | 10–15 min off critical path |
| P3 | Pip wheel cache for `buildstream-sbom` (keyed to pinned commit SHA) | `publish.yml`, `Justfile` | 3–8 min |
| P4 | `cache-warm` cron Mon–Fri instead of Mon/Thu | `cache-warm.yml` | Prevents cold-build outages |
| P5 | Step reorder: login/push/sign before SBOM (implicit in P2 split) | `publish.yml` | — |
| P6 | `buildah from+mount+sed+commit` replaces `podman build --squash-all` | `Justfile` | 35–50 min |

## Key design decisions

**P1 — skopeo copy:** `--preserve-digests` is mandatory — it keeps the promoted tag pointing at the same manifest digest that cosign signed. Without it GHCR re-encodes layers and produces a new digest that breaks the signature chain. `skopeo` is pre-installed on ubuntu-24.04 runners.

**P2 — job split:** `publish-sbom` re-derives the image digest via `skopeo inspect` rather than wiring GHA matrix job outputs (which are fragile). The image is already in GHCR by the time `publish-sbom` starts.

**P3 — pip cache:** Cache key is the pinned GitLab commit SHA for `buildstream-sbom`. Auto-invalidates when the pin is bumped. The wheel is volume-mounted into the bst2 container (`-v ~/.cache/pip:/root/.cache/pip:rw`).

**P6 — buildah vs squash-all:** Research confirmed that chunka's BST code path calls `podman image mount` which returns a merged overlayfs view regardless of layer count — multi-layer input is transparent to chunkah. `buildah commit` (no `--squash`) appends only the ~1 KB os-release delta instead of re-encoding 8.5 GB. `buildah` is pre-installed by `setup-runner@v1` (resolute package).

## New pipeline graph

```
setup → publish-image → promote       ← critical path to :testing
               └──────→ publish-sbom  ← parallel, not on critical path
```

## Verification

- `actionlint` passes on both modified workflow files
- Skill file `docs/skills/ci.md` updated with all patterns and rationale

## Checklist

- [x] `actionlint` clean
- [x] Skill file updated in same PR
- [x] One logical change per PR
- [x] Conventional Commits
- [ ] I am using an agent and I take responsibility for this PR

Assisted-by: Claude Sonnet 4.5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced cache warm scheduling to run on weekdays (Mon–Fri) at 06:00 UTC for faster build initialization.
  * Refactored image publication pipeline to decouple software bill-of-materials generation from image publishing.
  * Optimized build export process with improved dependency handling.

* **Documentation**
  * Expanded CI troubleshooting guide with updated pipeline mechanics and best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->