### PR TITLE
fix(sbom): mkdir -p pip cache dir before podman bind-mount

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -961,6 +961,10 @@ sbom variant="default":
         2>/dev/null || true
 
     echo "==> Generating BST-native SBOM with buildstream-sbom (${ELEMENT} → ${OUTFILE})..."
+    # Ensure pip cache directory exists before podman bind-mount.
+    # actions/cache does not create the path on a cold cache miss; podman
+    # refuses to start (exit 125) if the host-side directory is absent.
+    mkdir -p "${HOME}/.cache/pip"
     # Pinned to commit 0706fec3 (2026-04-01) — latest main, includes element
     # names in SPDX output (issue #9 fix). Switch to a versioned PyPI release
     # once the project publishes one.


### PR DESCRIPTION
## Problem

`publish-sbom` was failing on every cold runner (exit 125) with:

```
Error: statfs /home/runner/.cache/pip: no such file or directory
error: recipe `sbom` failed with exit code 125
```

Root cause: `just sbom` mounts `-v "${HOME}/.cache/pip:/root/.cache/pip:rw"` into the BST podman container. On a cold `actions/cache` miss, `~/.cache/pip` is never created on the runner — podman refuses to bind-mount a non-existent host path and exits 125 before the container starts.

## Fix

Add `mkdir -p "${HOME}/.cache/pip"` in the `sbom` recipe, immediately before the podman run, so the directory always exists regardless of cache state.

## Notes

The smoke failure in run [#27474257226](https://github.com/projectbluefin/dakota/actions/runs/27474257226) is **unrelated** — it tested the `d9bd43f` build which had the broken `buildah mount+commit` export (already fixed in `d7ba90f` / #846).

- [ ] I am using an agent and I take responsibility for this PR

Assisted-by: Claude Sonnet 4.5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build process reliability by ensuring necessary cache directories are properly initialized before builds commence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->