### PR TITLE
ci(pr): enable auto-merge after approval; add pr-autoupdate workflow

### DIFF
--- a/.github/workflows/pr-autoupdate.yml
+++ b/.github/workflows/pr-autoupdate.yml
@@ -1,0 +1,67 @@
+# Auto-update open PRs targeting main when main advances.
+# Prevents the BEHIND state that blocks auto-merge from triggering.
+# Runs after every push to main (including merge-queue squash commits).
+# Non-destructive: gh pr update-branch merges main in; conflicts stay open.
+name: PR Auto-update
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: pr-autoupdate
+  cancel-in-progress: true
+
+jobs:
+  update-stale-prs:
+    name: Update stale PRs targeting main
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Find and update stale PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Find all open PRs targeting main that are BEHIND and not from bots.
+          # Renovate PRs target testing, not main — skip them.
+          # Mergeraptor manages its own branches — skip those too.
+          STALE_PRS=$(gh pr list \
+            --repo "$REPO" \
+            --base main \
+            --state open \
+            --json number,headRefName,mergeStateStatus,author \
+            --jq '
+              .[] |
+              select(.mergeStateStatus == "BEHIND") |
+              select(.author.login != "renovate[bot]") |
+              select(.author.login != "app/mergeraptor") |
+              .number
+            ')
+
+          if [ -z "$STALE_PRS" ]; then
+            echo "No stale PRs found — nothing to do"
+            exit 0
+          fi
+
+          echo "Stale PRs to update: $(echo "$STALE_PRS" | tr '\n' ' ')"
+
+          UPDATED=0
+          SKIPPED=0
+          for PR_NUM in $STALE_PRS; do
+            if gh pr update-branch "$PR_NUM" --repo "$REPO" 2>/dev/null; then
+              echo "  ✅ PR #${PR_NUM} updated"
+              UPDATED=$((UPDATED + 1))
+            else
+              echo "  ⚠️  PR #${PR_NUM} skipped (already up-to-date or merge conflict)"
+              SKIPPED=$((SKIPPED + 1))
+            fi
+          done
+
+          echo "Done — updated: ${UPDATED}, skipped: ${SKIPPED}"

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -130,7 +130,7 @@ jobs:
             *) echo "is_maintainer=false" >> "$GITHUB_OUTPUT" ;;
           esac
 
-      - name: Approved — clear label
+      - name: Approved — clear label, enable auto-merge, update branch
         if: >-
           steps.perm.outputs.is_maintainer == 'true' &&
           github.event.review.state == 'approved'
@@ -139,8 +139,21 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           gh pr edit "$PR_URL" --remove-label "pr/needs-review" 2>/dev/null || true
+
+          # Enable auto-merge — squash-merges once required checks pass.
+          # Requires 'validate' in branch protection required_status_checks.
+          gh pr merge "$PR_URL" --auto --squash 2>/dev/null \
+            && echo "✅ Auto-merge enabled" \
+            || echo "::warning::Auto-merge unavailable — PR will need manual merge"
+
+          # Bring the branch current with main so CI runs on the latest state.
+          # Non-fatal — pr-autoupdate.yml retries on the next push to main.
+          gh pr update-branch "$PR_URL" 2>/dev/null \
+            && echo "✅ Branch updated" \
+            || echo "Branch already up-to-date or conflict — pr-autoupdate will handle it"
+
           cat << 'EOF' > /tmp/comment.md
-          Approved. Auto-merge is now eligible — the PR will enter the merge queue once all required checks pass.
+          Approved. Auto-merge enabled — the PR will squash-merge once `validate` passes.
 
           After it ships in nightly, users can confirm the fix with:
           ```bash


### PR DESCRIPTION
## What

Closes the automation gap between 'maintainer approves' and 'PR merges'.

## Root causes

### Gap 1: pr-triage never enables auto-merge
`on-pr-review` removed `pr/needs-review` on approval and posted _"Auto-merge is now eligible"_ — but never called `gh pr merge --auto`. PRs #763, #834, #837 were all stuck in this limbo: approved in spirit, never queued.

### Gap 2: No branch auto-update on push to main
When `main` advances, open PRs become `BEHIND`. No workflow updated them. Auto-merge (once it exists) would be blocked by the stale state because `validate` won't run against the current `main`.

## Fix

**`pr-triage.yml`** — `Approved` step now:
1. Removes `pr/needs-review` (existing)
2. Calls `gh pr merge --auto --squash` (new)
3. Calls `gh pr update-branch` (new)

**`pr-autoupdate.yml`** (new) — fires on every push to `main`:
- Finds open PRs targeting `main` with `mergeStateStatus == BEHIND`
- Calls `gh pr update-branch` on each
- Skips Renovate/Mergeraptor bots (they target `testing`, handled by renovate-automerge)

## Required companion change

Add `validate` to `main` branch protection required status checks so `--auto` waits for CI before merging. Without this, auto-merge fires immediately on approval. That change is a branch protection API update (no workflow file needed).

## Testing

- Approve a PR as maintainer → verify auto-merge is enabled on it + branch is updated
- Push a commit to `main` → verify BEHIND PRs are updated within ~1 min

Assisted-by: Claude Sonnet 4.5 via pi