### PR TITLE
fix(bootc): require xfs root filesystem in install config

### DIFF
--- a/files/bootc-install/00-defaults.toml
+++ b/files/bootc-install/00-defaults.toml
@@ -1,2 +1,8 @@
 [install]
 bootloader = "systemd"
+
+[install.filesystem.root]
+# Required since bootc no longer defaults the root filesystem type.
+# Without this, `bootc install to-disk` exits 1 with "No root filesystem
+# specified", leaving disk.raw unpartitioned and breaking the CI boot check.
+type = "xfs"


### PR DESCRIPTION
## What

The CI boot-check gate (`Boot check — gate` job in `publish.yml`) has been failing with exit code 1 since it was introduced in #849 (2026-06-13). It has never successfully run.

## Root cause

`bootc install to-disk --via-loopback disk.raw` exits 1 with:
```
error: Installing to disk: No root filesystem specified
```

The publish workflow treats any non-zero exit as a bootupd-expected failure and continues. But bootc never wrote a partition table to `disk.raw`, so `losetup -P` creates no partition nodes, and the subsequent `mount /dev/loop0p3 /mnt` fails with `special device does not exist`.

Newer bootc no longer defaults the root filesystem type — it must be explicitly declared in `/usr/lib/bootc/install/`. Without it, `bootc install to-disk` refuses to proceed.

## Fix

Add `[install.filesystem.root]` with `type = "xfs"` to `files/bootc-install/00-defaults.toml`.

Per [bootc install config docs](https://github.com/bootc-dev/bootc/blob/main/docs/src/bootc-install.md):
```toml
[install.filesystem.root]
type = "xfs"
```

## Impact

None for real-hardware users — xfs was always the implicit default. This makes it explicit and unambiguous.

The boot-check gate will pass after this merges and the image rebuilds.

Assisted-by: Claude Sonnet 4.5 via pi