### PR TITLE
fix(ci): switch bonedigger caller to @main — eliminate SHA drift

### DIFF
--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   lifecycle:
-    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@30a240ea9163790fe9c1f24b2c6ce65af4a71798 # main
+    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@main
     with:
       brand_name: "Dakota"
     secrets: inherit


### PR DESCRIPTION
## Problem

`bonedigger.yml` was pinned to `30a240ea` (June 11, 4 days stale). SHA pins on internal `projectbluefin/` workflow refs silently break when they drift — GitHub returns "workflow file issue" startup_failure with no actionable error.

## Fix

Switch `@30a240ea...` → `@main`. Internal org refs don't need SHA pinning — any breakage in the called workflow fails CI immediately and is caught. Renovate SHA-pinning for `projectbluefin/` is already disabled.

Part of factory-wide cleanup: bonedigger#27.