### PR TITLE
docs(ci): document run_e2e=false design, narrow hook exemptions to actions only

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -37,4 +37,8 @@ jobs:
       cosign_identity_regexp: >-
         ^https://github\.com/projectbluefin/(dakota|actions)/\.github/workflows/
       run_e2e: false
+      # run_e2e is intentionally false for dakota. The e2e quality gate lives
+      # at the weekly-testing-promotion.yml level with a GitHub 'production'
+      # Environment requiring 2 explicit human approvals — not at the PR gate
+      # level. The promotion PR here gets cosign verification only.
     secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,12 @@ repos:
       - id: no-floating-action-tags
         name: Block floating GitHub Action tags (external)
         language: pygrep
-        entry: 'uses:(?!.*projectbluefin/).*@(main|master|latest|v[0-9])'
+        entry: 'uses:(?!.*projectbluefin/actions/).*@(main|master|latest|v[0-9])'
         types: [yaml]
         files: '(^\.github/workflows/.*\.yml$|action\.yml$)'
       - id: no-sha-pins-for-internal-actions
-        name: Block SHA pins for projectbluefin/ actions (use @v1)
+        name: Block SHA pins for projectbluefin/actions refs (use @v1)
         language: pygrep
-        entry: 'uses:.*projectbluefin/.*@[0-9a-f]{40}'
+        entry: 'uses:.*projectbluefin/actions.*@[0-9a-f]{40}'
         types: [yaml]
         files: '(^\.github/workflows/.*\.yml$|action\.yml$)'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ Non-compliance = automatic rejection.
 
 **Verification:** Every PR must confirm `just lint` passed and the image booted. Use `just boot-test` for automated pass/fail. No WIP PRs.
 
-**Pre-commit guard:** `no-floating-action-tags` blocks third-party `@main`/`@v*` floating action tags at commit time. `projectbluefin/` refs (`@v1`, `@main`) are intentional managed tags and are exempted.
+**Pre-commit guard:** `no-floating-action-tags` blocks third-party `@main`/`@v*` floating action tags at commit time. `projectbluefin/actions/` refs (`@v1`) are intentional managed tags and are exempted.
 
 **Justfile integrity:** All maintenance tasks must be `just` recipes. No loose shell commands. If a task isn't covered by an existing recipe, add one alongside your change.
 
@@ -184,6 +184,8 @@ Do not request review without evidence. Before opening a PR for review:
 
 **Production promotion** (`weekly-testing-promotion.yml`) requires 2 distinct human approvals in the GitHub `production` Environment. No agent may trigger, approve, or bypass this gate. Admin bypasses are permanently logged in Environment deployment history.
 
+**Dakota promotion PR has no e2e gate by design.** `promote-testing-to-main.yml` passes `run_e2e: false` to `reusable-promote-squash.yml` — the promotion PR gets cosign verification only. The e2e quality gate is at the weekly-testing-promotion level (2 human approvals in the `production` Environment). Do not add `run_e2e: true` to the promote caller.
+
 **Promotion pipeline — cosign verify pattern:** When adding cosign verification to a promotion workflow, anchor the `--certificate-identity-regexp` with `^...$` and restrict it to the specific publishing workflow file and allowed ref patterns (e.g. `^https://github.com/<repo>/.github/workflows/publish\.yml@refs/heads/(main|gh-readonly-queue/main/.+)$`). An unanchored wildcard accepts signatures from any workflow in the repo.
 
 **cosign install on GHA runners:** Never write directly to `/usr/local/bin` without `sudo`. Use `curl -fsSL ... -o "$RUNNER_TEMP/cosign"` then `sudo install -m 0755 "$RUNNER_TEMP/cosign" /usr/local/bin/cosign`. The runner user cannot write to `/usr/local/bin` on GitHub-hosted runners.
@@ -243,4 +245,4 @@ Per `docs/pr-checklist.md`: always `Assisted-by:` — **never `Co-authored-by:`*
 
 ### SHA pinning (actions only)
 
-All `uses:` references to external actions must be pinned to a full commit SHA with a version comment. Never use floating tags. `projectbluefin/` refs (`@v1`, `@main`) are intentional managed tags and are exempted.
+All `uses:` references to external actions must be pinned to a full commit SHA with a version comment. Never use floating tags. `projectbluefin/actions` refs (`@v1`) are intentional managed tags and are exempted.


### PR DESCRIPTION
## Summary

Fixes items 5 and 8 from the promotion pipeline diagnostic report.

### Changes

**`.github/workflows/promote-testing-to-main.yml`**
- Add inline comment explaining that `run_e2e: false` is intentional: the e2e gate lives at the `weekly-testing-promotion.yml` level (2 human approvals in the `production` Environment), not at the PR gate level. Without this comment, agents seeing `run_e2e: false` have no context and may "fix" it incorrectly.

**`AGENTS.md`**
- Add explicit *Dakota promotion PR has no e2e gate by design* note adjacent to the production promotion rule.
- Narrow pre-commit guard note and SHA pinning section to `projectbluefin/actions`.

**`.pre-commit-config.yaml`**
- Narrow `no-floating-action-tags` and `no-sha-pins-for-internal-actions` to `projectbluefin/actions/` only.

### Verification
- No logic changes — comment and docs only in workflow file
- `pre-commit run --all-files` passes on this branch

Assisted-by: Claude Sonnet 4.5 via pi
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>