### PR TITLE
fix(ci): pre-partition disk before bootc to avoid udev race on node creation

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -37,4 +37,8 @@ jobs:
       cosign_identity_regexp: >-
         ^https://github\.com/projectbluefin/(dakota|actions)/\.github/workflows/
       run_e2e: false
+      # run_e2e is intentionally false for dakota. The e2e quality gate lives
+      # at the weekly-testing-promotion.yml level with a GitHub 'production'
+      # Environment requiring 2 explicit human approvals — not at the PR gate
+      # level. The promotion PR here gets cosign verification only.
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -269,6 +269,18 @@ jobs:
           LOOP=$(sudo losetup -f --show -P disk.raw)
           echo "Host loop device: ${LOOP}"
           echo "BOOT_CHECK_LOOP=${LOOP}" >> "$GITHUB_ENV"
+          # Pre-create the GPT partition table and wait for udev to materialise
+          # /dev/loop0p1-p3 BEFORE running bootc. When nodes already exist,
+          # bootc's internal sfdisk performs an in-place UPDATE (synchronous)
+          # rather than a CREATE FROM SCRATCH (async udev event). Without this,
+          # bootc calls mkfs immediately after sfdisk and races udevd — losing
+          # with ENOENT on loop0p3. Layout matches bootc's default for x86-64:
+          #   2048  sectors (1 MiB)  — BIOS boot
+          #   1048576 sectors (512 MiB) — EFI System
+          #   rest                    — Linux root (x86-64)
+          printf 'label: gpt\n2048 2048 21686148-6449-6E6F-744E-656564454649\n4096 1048576 C12A7328-F81F-11D2-BA4B-00A0C93EC93B\n1052672 - 4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709\n' \
+            | sudo sfdisk "${LOOP}"
+          sudo udevadm settle --timeout=10 2>/dev/null || true
           # bootupd exits 1 in plain VMs (no EFI partition target) — expected.
           if sudo podman run --rm --quiet "${IMAGE}" bootc install to-disk --help 2>&1 | grep -q '\-\-bootloader'; then
             sudo podman run --rm --privileged \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -258,13 +258,15 @@ jobs:
         run: |
           set -euo pipefail
           fallocate -l 30G disk.raw
-          # Pre-create the loopback device on the HOST before starting the container.
-          # --via-loopback creates the loop device inside the container; the host
-          # kernel doesn't create partition device nodes (loop0p2, loop0p3, etc.)
-          # visible inside the container, causing mkfs to fail with ENOENT.
-          # Passing the pre-created host loop device directly means the host kernel
-          # creates the partition nodes, which appear in the container via -v /dev:/dev.
-          LOOP=$(sudo losetup -f --show disk.raw)
+          # Pre-create the loopback device on the HOST (with -P / PARTSCAN) before
+          # starting the container. Two requirements:
+          # 1. Host device: --via-loopback creates the loop inside the container where
+          #    the host kernel never exposes partition nodes via -v /dev:/dev.
+          # 2. PARTSCAN (-P): without it, when sfdisk inside the container writes the
+          #    partition table, ioctl(BLKRRPART) returns EINVAL and the kernel never
+          #    creates loop0p2/loop0p3 nodes → bootc fails "Device has no children".
+          #    With -P (LO_FLAGS_PARTSCAN) the kernel auto-creates nodes via uevents.
+          LOOP=$(sudo losetup -f --show -P disk.raw)
           echo "Host loop device: ${LOOP}"
           echo "BOOT_CHECK_LOOP=${LOOP}" >> "$GITHUB_ENV"
           # bootupd exits 1 in plain VMs (no EFI partition target) — expected.
@@ -287,6 +289,13 @@ jobs:
           # the next step tries to mount them.
           sudo partprobe "${LOOP}" 2>/dev/null || true
           sudo udevadm settle --timeout=30 2>/dev/null || true
+          # Verify root filesystem was created — fail fast with a clear error
+          # rather than the confusing "wrong fs type" message in the Extract step.
+          if ! sudo blkid "${LOOP}p3" &>/dev/null; then
+            echo "ERROR: bootc install did not create a filesystem on ${LOOP}p3"
+            sudo fdisk -l "${LOOP}" 2>&1 || true
+            exit 1
+          fi
 
       - name: Extract kernel, initramfs, root UUID and ostree path
         id: disk

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: no-floating-action-tags
         name: Block floating GitHub Action tags (external)
         language: pygrep
-        entry: 'uses:(?!.*projectbluefin/actions/).*@(main|master|latest|v[0-9])'
+        entry: 'uses:(?!.*projectbluefin/(actions|bonedigger)/).*@(main|master|latest|v[0-9])'
         types: [yaml]
         files: '(^\.github/workflows/.*\.yml$|action\.yml$)'
       - id: no-sha-pins-for-internal-actions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,12 @@ repos:
       - id: no-floating-action-tags
         name: Block floating GitHub Action tags (external)
         language: pygrep
-        entry: 'uses:(?!.*projectbluefin/).*@(main|master|latest|v[0-9])'
+        entry: 'uses:(?!.*projectbluefin/actions/).*@(main|master|latest|v[0-9])'
         types: [yaml]
         files: '(^\.github/workflows/.*\.yml$|action\.yml$)'
       - id: no-sha-pins-for-internal-actions
-        name: Block SHA pins for projectbluefin/ actions (use @v1)
+        name: Block SHA pins for projectbluefin/actions refs (use @v1)
         language: pygrep
-        entry: 'uses:.*projectbluefin/.*@[0-9a-f]{40}'
+        entry: 'uses:.*projectbluefin/actions.*@[0-9a-f]{40}'
         types: [yaml]
         files: '(^\.github/workflows/.*\.yml$|action\.yml$)'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ Non-compliance = automatic rejection.
 
 **Verification:** Every PR must confirm `just lint` passed and the image booted. Use `just boot-test` for automated pass/fail. No WIP PRs.
 
-**Pre-commit guard:** `no-floating-action-tags` blocks third-party `@main`/`@v*` floating action tags at commit time. `projectbluefin/` refs (`@v1`, `@main`) are intentional managed tags and are exempted.
+**Pre-commit guard:** `no-floating-action-tags` blocks third-party `@main`/`@v*` floating action tags at commit time. `projectbluefin/actions/` refs (`@v1`) are intentional managed tags and are exempted.
 
 **Justfile integrity:** All maintenance tasks must be `just` recipes. No loose shell commands. If a task isn't covered by an existing recipe, add one alongside your change.
 
@@ -184,6 +184,8 @@ Do not request review without evidence. Before opening a PR for review:
 
 **Production promotion** (`weekly-testing-promotion.yml`) requires 2 distinct human approvals in the GitHub `production` Environment. No agent may trigger, approve, or bypass this gate. Admin bypasses are permanently logged in Environment deployment history.
 
+**Dakota promotion PR has no e2e gate by design.** `promote-testing-to-main.yml` passes `run_e2e: false` to `reusable-promote-squash.yml` — the promotion PR gets cosign verification only. The e2e quality gate is at the weekly-testing-promotion level (2 human approvals in the `production` Environment). Do not add `run_e2e: true` to the promote caller.
+
 **Promotion pipeline — cosign verify pattern:** When adding cosign verification to a promotion workflow, anchor the `--certificate-identity-regexp` with `^...$` and restrict it to the specific publishing workflow file and allowed ref patterns (e.g. `^https://github.com/<repo>/.github/workflows/publish\.yml@refs/heads/(main|gh-readonly-queue/main/.+)$`). An unanchored wildcard accepts signatures from any workflow in the repo.
 
 **cosign install on GHA runners:** Never write directly to `/usr/local/bin` without `sudo`. Use `curl -fsSL ... -o "$RUNNER_TEMP/cosign"` then `sudo install -m 0755 "$RUNNER_TEMP/cosign" /usr/local/bin/cosign`. The runner user cannot write to `/usr/local/bin` on GitHub-hosted runners.
@@ -243,4 +245,4 @@ Per `docs/pr-checklist.md`: always `Assisted-by:` — **never `Co-authored-by:`*
 
 ### SHA pinning (actions only)
 
-All `uses:` references to external actions must be pinned to a full commit SHA with a version comment. Never use floating tags. `projectbluefin/` refs (`@v1`, `@main`) are intentional managed tags and are exempted.
+All `uses:` references to external actions must be pinned to a full commit SHA with a version comment. Never use floating tags. `projectbluefin/actions` refs (`@v1`) are intentional managed tags and are exempted.

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -1789,7 +1789,7 @@ image. The image always worked on real hardware.
 Even after pre-creating the loop device on the host (PR #864 fix above), bootc's
 internal `sfdisk` call fails to make partition nodes appear in time:
 
-```
+```text
 Re-reading the partition table failed.: Invalid argument
 The kernel still uses the old table. The new table will be used at the next reboot
 or after you run partprobe(8) or partx(8).
@@ -1829,3 +1829,22 @@ loop device for partition table changes and auto-creates device nodes via uevent
 processed by the host udevd. The container sees these via `-v /dev:/dev`. The
 `sfdisk` "Invalid argument" message is benign — PARTSCAN replaces the old
 `BLKRRPART` ioctl mechanism.
+
+**Second race — node creation from scratch is still async (PR #886):**
+Even with PARTSCAN, creating device nodes from scratch requires udevd to
+process the uevent, which is asynchronous. bootc's `mkfs.xfs` call immediately
+follows sfdisk and races udevd — resulting in `ENOENT` on `/dev/loop0p3`.
+
+Fix: pre-seed the loop device with the same GPT layout bootc will use, then
+`udevadm settle`, *before* starting the container. bootc's sfdisk then
+performs an **in-place UPDATE** of existing nodes (synchronous) rather than
+a **CREATE FROM SCRATCH** (async). Layout must match bootc's x86-64 default:
+
+```bash
+# Pre-create GPT so nodes exist before bootc runs
+# Layout: 1M BIOS | 512M EFI | rest Linux root (x86-64)
+printf 'label: gpt\n2048 2048 21686148-6449-6E6F-744E-656564454649\n4096 1048576 C12A7328-F81F-11D2-BA4B-00A0C93EC93B\n1052672 - 4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709\n' \
+  | sudo sfdisk "${LOOP}"
+sudo udevadm settle --timeout=10 2>/dev/null || true
+# now run bootc install — sfdisk UPDATE is synchronous, mkfs finds the node
+```

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -1783,3 +1783,49 @@ appear in the host's `/dev`, which is bind-mounted into the container via
 **Note:** The boot-check gate (introduced PR #849, 2026-06-13) **never passed
 once** due to these two compounding bugs. Both were in the CI script, not the
 image. The image always worked on real hardware.
+
+### `bootc install to-disk` fails with "Device has no children" even with host-side loop device (2026-06-15)
+
+Even after pre-creating the loop device on the host (PR #864 fix above), bootc's
+internal `sfdisk` call fails to make partition nodes appear in time:
+
+```
+Re-reading the partition table failed.: Invalid argument
+The kernel still uses the old table. The new table will be used at the next reboot
+or after you run partprobe(8) or partx(8).
+error: Installing to disk: Creating rootfs: Device has no children
+bootc install exited 1 (bootupd expected — continuing)
+```
+
+Root cause: `losetup -f --show disk.raw` creates the loop device WITHOUT the
+`LO_FLAGS_PARTSCAN` kernel flag. Without it, `ioctl(BLKRRPART)` returns `EINVAL`
+on modern kernels, and the kernel does **not** auto-create `/dev/loop0p3` when
+sfdisk writes the partition table inside the container. bootc immediately tries
+`mkfs.xfs /dev/loop0p3` → node doesn't exist → "Device has no children".
+
+**Fix:** Use `-P` (PARTSCAN) in the initial `losetup` call:
+
+```bash
+# -P tells the kernel to auto-create partition nodes via uevents when
+# the partition table is written — even inside the container.
+LOOP=$(sudo losetup -f --show -P disk.raw)
+```
+
+Also add a fast-fail check after the install to catch the failure clearly
+rather than getting "wrong fs type" in the Extract step:
+
+```bash
+sudo partprobe "${LOOP}" 2>/dev/null || true
+sudo udevadm settle --timeout=30 2>/dev/null || true
+if ! sudo blkid "${LOOP}p3" &>/dev/null; then
+  echo "ERROR: bootc install did not create a filesystem on ${LOOP}p3"
+  sudo fdisk -l "${LOOP}" 2>&1 || true
+  exit 1
+fi
+```
+
+**Why PARTSCAN works:** with `LO_FLAGS_PARTSCAN` set, the kernel monitors the
+loop device for partition table changes and auto-creates device nodes via uevents
+processed by the host udevd. The container sees these via `-v /dev:/dev`. The
+`sfdisk` "Invalid argument" message is benign — PARTSCAN replaces the old
+`BLKRRPART` ioctl mechanism.


### PR DESCRIPTION
## Problem

PR #883 fixed `ioctl(BLKRRPART)` returning `EINVAL` by adding `-P` (PARTSCAN) to `losetup`. That got bootc further, but it now hits the next layer of the same race:

```
Creating root filesystem (xfs) on device /dev/loop0p3 (size=31.7 GB)
> mkfs.xfs -m uuid=... -L root /dev/loop0p3
error: Installing to disk: Creating rootfs: No such file or directory (os error 2)
```

**Root cause:** Device node creation from scratch is async. udevd processes the uevent `after` sfdisk returns. bootc's `mkfs.xfs` call immediately follows sfdisk and loses the race — `/dev/loop0p3` doesn't exist yet.

## Fix

Pre-create the GPT partition table with the exact same layout bootc will use, then `udevadm settle`. When nodes already exist, bootc's internal sfdisk performs an **in-place UPDATE** (synchronous) rather than a **CREATE FROM SCRATCH** (async udev event). mkfs finds the node immediately.

Partition type GUIDs and sector layout match bootc's observed x86-64 default.

## Checklist
- [x] `actionlint` passes
- [x] Builds on #883 (PARTSCAN foundation)
- [ ] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of boot image installation by pre-priming loopback partitions and adding a fail-fast check to verify the root filesystem is created, with clearer failure diagnostics.

* **Documentation**
  * Expanded troubleshooting guidance for loopback-based install issues, including race-condition mitigation steps and validation checks.
  * Clarified CI promotion workflow quality-gate behavior and action-tag pinning policy.

* **Chores**
  * Tightened repository checks for GitHub Action `uses:` references to better enforce tag and SHA pinning rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->