### PR TITLE
fix(ci): pre-partition disk before bootc to avoid udev race on node creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -269,6 +269,18 @@ jobs:
           LOOP=$(sudo losetup -f --show -P disk.raw)
           echo "Host loop device: ${LOOP}"
           echo "BOOT_CHECK_LOOP=${LOOP}" >> "$GITHUB_ENV"
+          # Pre-create the GPT partition table and wait for udev to materialise
+          # /dev/loop0p1-p3 BEFORE running bootc. When nodes already exist,
+          # bootc's internal sfdisk performs an in-place UPDATE (synchronous)
+          # rather than a CREATE FROM SCRATCH (async udev event). Without this,
+          # bootc calls mkfs immediately after sfdisk and races udevd — losing
+          # with ENOENT on loop0p3. Layout matches bootc's default for x86-64:
+          #   2048  sectors (1 MiB)  — BIOS boot
+          #   1048576 sectors (512 MiB) — EFI System
+          #   rest                    — Linux root (x86-64)
+          printf 'label: gpt\n2048 2048 21686148-6449-6E6F-744E-656564454649\n4096 1048576 C12A7328-F81F-11D2-BA4B-00A0C93EC93B\n1052672 - 4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709\n' \
+            | sudo sfdisk "${LOOP}"
+          sudo udevadm settle --timeout=10 2>/dev/null || true
           # bootupd exits 1 in plain VMs (no EFI partition target) — expected.
           if sudo podman run --rm --quiet "${IMAGE}" bootc install to-disk --help 2>&1 | grep -q '\-\-bootloader'; then
             sudo podman run --rm --privileged \

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -1789,7 +1789,7 @@ image. The image always worked on real hardware.
 Even after pre-creating the loop device on the host (PR #864 fix above), bootc's
 internal `sfdisk` call fails to make partition nodes appear in time:
 
-```
+```text
 Re-reading the partition table failed.: Invalid argument
 The kernel still uses the old table. The new table will be used at the next reboot
 or after you run partprobe(8) or partx(8).
@@ -1829,3 +1829,22 @@ loop device for partition table changes and auto-creates device nodes via uevent
 processed by the host udevd. The container sees these via `-v /dev:/dev`. The
 `sfdisk` "Invalid argument" message is benign — PARTSCAN replaces the old
 `BLKRRPART` ioctl mechanism.
+
+**Second race — node creation from scratch is still async (PR #886):**
+Even with PARTSCAN, creating device nodes from scratch requires udevd to
+process the uevent, which is asynchronous. bootc's `mkfs.xfs` call immediately
+follows sfdisk and races udevd — resulting in `ENOENT` on `/dev/loop0p3`.
+
+Fix: pre-seed the loop device with the same GPT layout bootc will use, then
+`udevadm settle`, *before* starting the container. bootc's sfdisk then
+performs an **in-place UPDATE** of existing nodes (synchronous) rather than
+a **CREATE FROM SCRATCH** (async). Layout must match bootc's x86-64 default:
+
+```bash
+# Pre-create GPT so nodes exist before bootc runs
+# Layout: 1M BIOS | 512M EFI | rest Linux root (x86-64)
+printf 'label: gpt\n2048 2048 21686148-6449-6E6F-744E-656564454649\n4096 1048576 C12A7328-F81F-11D2-BA4B-00A0C93EC93B\n1052672 - 4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709\n' \
+  | sudo sfdisk "${LOOP}"
+sudo udevadm settle --timeout=10 2>/dev/null || true
+# now run bootc install — sfdisk UPDATE is synchronous, mkfs finds the node
+```


### PR DESCRIPTION
Follow-up to #883.

## Problem

PR #883 fixed `ioctl(BLKRRPART)` returning `EINVAL` via `losetup -P`. That gets bootc further, but now hits the next layer of the same race:

```text
Creating root filesystem (xfs) on device /dev/loop0p3 (size=31.7 GB)
> mkfs.xfs -m uuid=... -L root /dev/loop0p3
error: Installing to disk: Creating rootfs: No such file or directory (os error 2)
```

Device node creation from scratch is async — udevd processes the uevent after sfdisk returns. bootc's `mkfs.xfs` call immediately follows sfdisk and loses the race.

## Fix

Pre-seed the loop device with the same GPT layout bootc will use, then `udevadm settle`. bootc's sfdisk then performs an **in-place UPDATE** (synchronous) rather than a **CREATE FROM SCRATCH** (async). mkfs finds the node immediately.

## Checklist
- [x] `actionlint` passes
- [x] CodeRabbit feedback addressed (code fence tag, skill docs updated)
- [ ] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of disk installation during boot-check workflow by ensuring proper partition device initialization.

* **Documentation**
  * Added troubleshooting guidance for disk installation failures with recommended mitigation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->