### PR TITLE
fix(ci): unstick dakota publish pipeline

### DIFF
--- a/.github/workflows/pr-release-gate.yml
+++ b/.github/workflows/pr-release-gate.yml
@@ -5,17 +5,16 @@ on:
     branches:
       - main
 
-permissions: {}
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  packages: read
+  pull-requests: write
 
 jobs:
   gate:
     if: github.event.pull_request.head.ref == 'auto/promote-testing-to-main'
-    permissions:
-      actions: read
-      contents: read
-      issues: write
-      packages: read
-      pull-requests: write
     uses: projectbluefin/actions/.github/workflows/reusable-release-gate.yml@v1
     with:
       repo: ${{ github.repository }}

--- a/.github/workflows/publish-smoke.yml
+++ b/.github/workflows/publish-smoke.yml
@@ -1,0 +1,29 @@
+name: Publish Smoke
+
+# Observational smoke must live in a separate workflow. A reusable-workflow call
+# job cannot be marked continue-on-error, so keeping smoke inside publish.yml
+# turns flaky desktop assertions into a red publish pipeline.
+on:
+  workflow_run:
+    workflows: ["Publish Bluefin dakota"]
+    types: [completed]
+    branches:
+      - main
+      - 'gh-readonly-queue/main/**'
+      - next
+      - 'gh-readonly-queue/next/**'
+      - testing
+      - 'gh-readonly-queue/testing/**'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  smoke:
+    if: github.event.workflow_run.conclusion == 'success'
+    uses: ./.github/workflows/run-testsuite.yml
+    with:
+      image: ghcr.io/${{ github.repository_owner }}/dakota:${{ github.event.workflow_run.head_sha }}
+      suites: smoke
+    secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -258,21 +258,21 @@ jobs:
         run: |
           set -euo pipefail
           fallocate -l 30G disk.raw
-          # Use --via-loopback: pass the raw file path directly into the
-          # container. bootc manages the loop device lifecycle internally,
-          # avoiding the host-side loop/partition-node race entirely.
-          # After the container exits the raw file has a complete partition
-          # table; attach with -P to materialise loop0p1/p2/p3 on the host.
+          # Use the documented raw-image install path: bootc manages the loop
+          # device lifecycle internally, writes a generic VM image layout, and
+          # uses the same xfs root filesystem users get by default.
           # Source: https://github.com/bootc-dev/bootc/blob/main/docs/src/bootc-install.md
-          sudo podman run --rm --privileged --pid=host \
+          sudo podman run --rm --privileged --pid=host --ipc=host \
             --security-opt label=type:unconfined_t \
             -v /dev:/dev \
             -v /var/lib/containers:/var/lib/containers \
             -v "$(pwd):/data" \
             "${IMAGE}" bootc install to-disk \
+              --generic-image \
+              --filesystem xfs \
               --via-loopback /data/disk.raw \
               --wipe \
-            || echo "bootc install exited $? (bootupd expected — continuing)"
+            || { rc=$?; echo "bootc install exited ${rc} — checking whether the deployment was written"; }
           sudo podman rmi "${IMAGE}" 2>/dev/null || true
           # Attach with -P so the kernel scans the partition table and
           # creates loop0p1/p2/p3 nodes before the next step mounts them.
@@ -500,27 +500,9 @@ jobs:
           retention-days: 3
           if-no-files-found: ignore
 
-  # ── Testsuite smoke (observational) ───────────────────────────────────────
-  # Runs the full testsuite smoke suite for signal. Non-blocking — AT-SPI
-  # timing failures do not block :testing promotion. Results visible in the
-  # workflow timeline. The full suite gates :testing → :stable in the weekly
-  # promotion workflow. See: projectbluefin/dakota#850
-  smoke:
-    name: Smoke — observational
-    needs: [setup, publish-image]
-    if: needs.publish-image.result == 'success'
-    permissions:
-      contents: read
-      packages: write
-    uses: ./.github/workflows/run-testsuite.yml
-    with:
-      image: ghcr.io/${{ github.repository_owner }}/dakota:${{ needs.setup.outputs.sha }}
-      suites: smoke
-    secrets: inherit
-
   # ── Generate and attach SBOM ──────────────────────────────────────────────
-  # Runs in parallel with smoke — SBOM generation is not on the critical path
-  # to :testing. A fresh runner fetches BST metadata from remote CAS (no full
+  # Runs outside the critical path to :testing. A fresh runner fetches BST
+  # metadata from remote CAS (no full
   # artifact download needed; bst show reads element graph only).
   # P3: pip wheel cache keyed to the pinned buildstream-sbom commit SHA so
   # repeated runs skip the GitLab git fetch entirely.

--- a/Justfile
+++ b/Justfile
@@ -954,7 +954,9 @@ sbom variant="default":
         *) echo "ERROR: unknown variant '{{variant}}' (expected: default | nvidia)" >&2; exit 1 ;;
     esac
 
-    # Persist the snakeoil key cache so bst show runs silently (see bst recipe).
+    # Persist host-side caches before bind-mounting them into podman.
+    # actions/cache restores archives but does not create missing directories on a cold miss.
+    mkdir -p "${HOME}/.cache/buildstream"
     mkdir -p "${HOME}/.config/buildstream-generate"
     GIT_SHA="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
     # Prime the generated source plugin cache (snakeoil secureboot keys).

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -1,6 +1,10 @@
 ---
 name: ci
 description: Dakota CI pipeline reference. Covers workflow files, trigger behavior, remote cache architecture, common failures, and promotion flow. Load when debugging CI failures, understanding why a build was or wasn't triggered, or running a manual promotion.
+metadata:
+  context7-sources:
+    - /websites/github_en_actions
+    - /bootc-dev/bootc
 ---
 
 # CI Pipeline Operations
@@ -1563,22 +1567,25 @@ belongs in the action, not scattered across consumers.
 
 `actions/cache` only *restores* an existing archive; on a cache miss it does
 nothing and leaves the target path absent. If a subsequent `podman run` uses
-`-v "${HOME}/.cache/pip:/root/.cache/pip:rw"` and the host-side directory
-does not exist, podman exits **125** (container failed to start) before any
-command runs.
+bind mounts such as `-v "${HOME}/.cache/pip:/root/.cache/pip:rw"` or
+`-v "${HOME}/.cache/buildstream:/root/.cache/buildstream:rw"` and the host-side
+directory does not exist, podman exits **125** (container failed to start)
+before any command runs.
 
 ```
-Error: statfs /home/runner/.cache/pip: no such file or directory
+Error: statfs /home/runner/.cache/buildstream: no such file or directory
 error: recipe `sbom` failed with exit code 125
 ```
 
-**Fix:** `mkdir -p` the directory in the Justfile recipe immediately before
-the `podman run`, not in the workflow step. This makes the fix unconditional
-regardless of where `just sbom` is invoked:
+**Fix:** `mkdir -p` every host cache directory in the Justfile recipe
+immediately before the `podman run`, not in the workflow step. This makes the
+fix unconditional regardless of where `just sbom` is invoked:
 
 ```bash
-mkdir -p "${HOME}/.cache/pip"
-podman run --rm ... -v "${HOME}/.cache/pip:/root/.cache/pip:rw" ...
+mkdir -p "${HOME}/.cache/buildstream" "${HOME}/.cache/pip"
+podman run --rm ... \
+  -v "${HOME}/.cache/buildstream:/root/.cache/buildstream:rw" \
+  -v "${HOME}/.cache/pip:/root/.cache/pip:rw" ...
 ```
 
 **Rule:** Any `podman run -v HOST_PATH:...` where `HOST_PATH` is a cache
@@ -1611,6 +1618,26 @@ condition alone is insufficient; the job still waits if the dep is in `needs`).
 **Rule:** The per-merge gate should always be a deterministic boot
 check (SSH reachable + GDM active). The full AT-SPI suite belongs in
 the weekly pre-stable gate, not the per-merge pre-testing gate.
+
+### Observational reusable-workflow jobs must be split out of publish.yml (2026-06-16)
+
+`continue-on-error` is **not** supported on jobs that call a reusable workflow
+via `uses:`. That means an observational suite like `smoke` still makes the
+parent workflow red if it lives inside `publish.yml`, even when `promote` no
+longer depends on it.
+
+**Symptom:** publish pipeline lands `:testing` successfully, but
+`Publish Bluefin dakota` still ends red because the observational smoke job
+fails inside the same workflow run.
+
+**Fix:** move observational reusable-workflow jobs into a separate workflow
+triggered by `workflow_run` from the successful publish pipeline. Keep the
+hard gate (`boot-check`) in `publish.yml`; keep the flaky/slow signal in the
+follow-up workflow.
+
+**Rule:** If a GitHub Actions job is both (a) observational and
+(b) implemented as a reusable-workflow call, it does not belong in the
+critical publish workflow.
 
 ### OSTREE_PATH in boot-check kernel args must come from the BLS entry (2026-06-13)
 


### PR DESCRIPTION
## Summary
- stop starving the reusable PR release gate token by moving required permissions to workflow level
- create missing host cache directories before SBOM podman bind mounts
- move observational smoke into a separate workflow so flaky AT-SPI failures stop marking publish red
- align boot-check with the documented bootc raw-image install path
- record the new CI rules in `docs/skills/ci.md`

## Verification
- `actionlint .github/workflows/*.yml`
- `just --dry-run sbom default`

## Why
Recent dakota publish failures had three separate causes:
1. `PR Release Gate` could not start because the caller workflow used `permissions: {}` while calling a reusable workflow.
2. `publish-sbom` failed on cold runners because `~/.cache/buildstream` did not exist before podman bind-mounted it.
3. `smoke` was observational in intent, but because it lived inside `publish.yml` as a reusable-workflow call, its failures still painted the publish workflow red.

Assisted-by: OpenAI GPT-5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated smoke test workflow that triggers after successful publish operations.

* **Chores**
  * Refactored workflow permission declarations for improved clarity and maintainability.
  * Enhanced build cache directory initialization to ensure proper container mounting.

* **Documentation**
  * Updated CI guidance with best practices for cache handling and workflow patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->