### PR TITLE
docs(skills): split CI knowledge into focused skills

### DIFF
--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -1,57 +1,59 @@
 # Dakota Skill Router
 
-Agent entry point. Load only the skill for your current task — do not load everything.
+Load the smallest skill that answers the job. Do not read the whole repo memory bank unless the task is genuinely cross-cutting.
 
-If your first draft says "use dnf/RPM/COPR" or "edit the Containerfile to add a package", stop and reload `docs/skills/not-bluefin.md`. Dakota image changes happen in `.bst` elements and `elements/bluefin/deps.bst`, even though those paths still say `bluefin`.
+If your first draft says "use dnf", "edit the Containerfile", or "enable a COPR", stop and load `docs/skills/not-bluefin.md` first.
 
-## Docs-and-code-first — no guessing
+## Fast Path
 
-**This project and every tool it uses is well-documented. There is almost never a reason to guess.**
-
-Before writing any implementation:
-1. **Check the relevant skill file** in `docs/skills/` — known patterns and failure modes are documented there.
-2. **Read the actual file** you are about to change.
-3. **Check upstream docs** for any external tool via Context7 (`resolve-library-id` → `query-docs`): bootc, BuildStream, skopeo, cosign, GitHub Actions, GNOME, etc.
-4. **Check working reference implementations** in this org before writing from scratch — `projectbluefin/testsuite`, `projectbluefin/actions`, `projectbluefin/bluefin` often have solved the same problem.
-
-If you are about to try a flag, API call, or workflow pattern from memory: stop and verify it first. Guessing costs CI time and human attention that the project cannot afford.
+1. **Reset the mental model** → `docs/skills/not-bluefin.md`
+2. **Classify the task** → package / build / CI / issue lifecycle / review / installer
+3. **Load one focused skill** from the table below
+4. **Read the actual file** you will edit
+5. **Verify external tool behavior with Context7** before changing syntax or flags
 
 ## Task → Skill
 
 | I need to... | Load |
-| **Load the dakota build context first** | **⚠️ REQUIRED FIRST — `docs/skills/not-bluefin.md` before any other skill, especially if you have bluefin context. If your plan mentions dnf/RPM/Containerfile overlays, reload it and translate the task into BST terms first.** |
-| Review a pull request | `docs/workflow.md` + `docs/pr-checklist.md` |
-| Add a package to Dakota | `docs/skills/add-package.md` |
-| Remove a package | `docs/skills/remove-package.md` |
-| Update a package version | `docs/skills/update-refs.md` |
-| Understand BST element syntax | `docs/skills/buildstream.md` |
+|---|---|
+| Reset Dakota vs bluefin mental model | `docs/skills/not-bluefin.md` |
+| Start routine maintenance with little context | `docs/skills/quickstart.md` |
+| Add or remove a package | `docs/skills/add-package.md` / `docs/skills/remove-package.md` |
+| Update a package version or ref | `docs/skills/update-refs.md` |
+| Understand BST syntax or element kinds | `docs/skills/buildstream.md` |
 | Debug a build failure | `docs/skills/debugging.md` |
 | Understand OCI layer assembly | `docs/skills/oci-layers.md` |
-| Work with junction overrides | `docs/skills/bst-overrides.md` |
-| Add/rebase a patch | `docs/skills/patch-junctions.md` |
-| Package pre-built binaries | `docs/skills/packaging-binaries.md` |
-| Package a Go project | `docs/skills/packaging-go.md` |
-| Package a Rust project | `docs/skills/packaging-rust.md` |
-| Package a Zig project | `docs/skills/packaging-zig.md` |
-| Package a GNOME extension | `docs/skills/packaging-gnome-extensions.md` |
+| Work with junction overrides or patches | `docs/skills/bst-overrides.md` / `docs/skills/patch-junctions.md` |
+| Package a Go/Rust/Zig/binary/extension project | `docs/skills/packaging-*.md` |
 | Test OTA updates locally or on hardware | `docs/skills/local-ota.md` |
-| Debug CI failures | `docs/skills/ci.md` |
-| Understand what dakota/Bluefin is | `docs/skills/overview.md` |
+| Identify which CI workflow owns the problem | `docs/skills/workflow-map.md` |
+| Fix reusable workflow / token / cache / startup failures | `docs/skills/ci-tooling.md` |
+| Change boot-check, smoke, testsuite, or QEMU CI | `docs/skills/e2e-ci.md` |
+| Change promotion PR or stable release flow | `docs/skills/release-promotion.md` |
+| Need historical CI edge cases | `docs/skills/ci-reference.md` |
+| Clear stuck queue or conflicting chore PRs | `docs/skills/merge-queue.md` |
+| Work on issues, triage, or Actionadon | `docs/skills/actionadon.md` |
+| Understand what Dakota is | `docs/skills/overview.md` |
 | Write ujust recipes | `.github/skills/ujust-recipes.md` |
 | Work on the installer | `docs/skills/installer.md` |
-| Routine maintenance (add/remove/update) | `docs/skills/quickstart.md` |
+| Review a pull request | `docs/workflow.md` + `docs/pr-checklist.md` + `docs/skills/pr-review.md` |
 
 ## Reference Docs
 
 | Topic | File |
 |---|---|
-| Build workflow, repo layout, dev loop | [`build.md`](build.md) |
-| PR checklist by change type | [`pr-checklist.md`](pr-checklist.md) |
-| Patch lifecycle and junction bumps | [`patches.md`](patches.md) |
-| CI jobs, schedule, published images | [`ci.md`](ci.md) |
-| Community workflow, labels, Hive, Actionadon | [`workflow.md`](workflow.md) |
-| OCI assembly (ldconfig, dconf, build-oci) | [`oci-assembly.md`](oci-assembly.md) |
+| Build workflow, repo layout, dev loop | `docs/build.md` |
+| PR checklist by change type | `docs/pr-checklist.md` |
+| Patch lifecycle and junction bumps | `docs/patches.md` |
+| CI jobs, publish, and release | `docs/ci.md` |
+| Community workflow and labels | `docs/workflow.md` |
+| OCI assembly internals | `docs/oci-assembly.md` |
 
-## Full Skill Index
+## Routing Rule
 
-`docs/skills/README.md` — complete routing table with all 20 skills.
+If a skill starts turning into a dumping ground, split it. Dakota should optimize for:
+- fast agent loading
+- narrow task targeting
+- factory memory that compounds instead of sprawling
+
+Full index: `docs/skills/README.md`

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -1,87 +1,124 @@
-# docs/skills — In-Repo Knowledge Base
+---
+name: skills-index
+description: Routing table for Dakota's in-repo skills. Load this when you need to find the right skill fast instead of reading everything. Use when starting work, switching problem domains, or deciding which focused skill to load next.
+metadata:
+  context7-sources:
+    - /addyosmani/agent-skills
+---
 
-Accumulated lessons from real work on this repo. Every agent working here
-should read the relevant file before starting in that area.
+# docs/skills — In-Repo Skill Index
 
-If your first instinct is `dnf`, RPM/COPR, or a Containerfile package layer, you are in the wrong mental model. In this repo, historical `bluefin/` paths still contain Dakota's BuildStream elements; package changes happen there, not in Containerfile overlays.
+## Overview
 
-## Docs-and-code-first — no guessing
+This directory is Dakota's **working memory**.
+Read the smallest skill that answers the job. Do not load every file just because it exists.
 
-**This project is well-documented. Everything has a source of truth. Look it up.**
+The factory model depends on this discipline:
+- **Work** lands as code or docs
+- **Learning** lands as a focused skill update in the same PR
 
-Before implementing anything, in this order:
-1. **Check `docs/skills/`** — the relevant skill file likely already has the answer, including known failure modes and correct patterns.
-2. **Read the actual file or workflow** being changed — not just the file name.
-3. **Check upstream docs via Context7** for any external tool (bootc, BuildStream, skopeo, cosign, GitHub Actions). `resolve-library-id` → `query-docs`.
-4. **Check working reference implementations** in this org (e.g., `projectbluefin/testsuite`, `projectbluefin/actions`) before writing from scratch.
+## When to Use
 
-**If you are about to guess: stop.** Find the authoritative source. Guessing at CLI flags, API behavior, or workflow structure costs hours of CI time. The documented answer is almost always available and faster to find than to iterate toward.
+Use this file when:
+- starting a Dakota task
+- switching from one problem class to another
+- deciding which skill to load next
+- cleaning up or splitting an overgrown skill
 
-**Examples:**
-- `bootc install to-disk` → read `/bootc-dev/bootc` docs via Context7, or look at `testsuite/spike-uefi-boot.yml` for a working GHA reference
-- BuildStream element fields → `docs/skills/buildstream.md` + `/buildstream-project/buildstream` via Context7
-- cosign/skopeo/oras flags → Context7 before trying flags at random
-- GitHub Actions `needs:` vs `if:` behavior → `docs/skills/ci.md` first
+## When NOT to Use
 
-When you discover a new pattern or fix a recurring mistake, add it here in the
-same PR as your change. This is the Self-Improvement Loop: lessons land here and help
-every future agent and contributor — not just you, and not just on one machine.
+- You already know the exact focused skill you need
+- You are looking for raw project docs rather than agent workflow guidance
 
-Every agent session produces two outputs: **the work** (the PR) and **the learning** (the skill update). Output 1 without Output 2 leaves the system no smarter.
+## Core Process
 
-## Routing Table — load only what you need
+1. **Load `not-bluefin.md` first** if there is any chance you are drifting into dnf/RPM/Containerfile habits.
+2. **Pick the narrowest skill** that matches the task.
+3. **Read the actual file or workflow** before editing code.
+4. **Verify external tool behavior with Context7** before changing syntax, flags, or API usage.
+5. **Write back learnings** to the narrowest skill file, not the nearest giant dumping ground.
+
+## Fast Paths
+
+### Build / packaging
+- Add package → `add-package.md`
+- Remove package → `remove-package.md`
+- Update version or ref → `update-refs.md`
+- Need BST syntax or element kinds → `buildstream.md`
+- Need a language-specific packaging pattern → `packaging-*.md`
+
+### CI / release
+- Need to know which workflow owns the stage → `workflow-map.md`
+- Reusable workflow / token / cache weirdness → `ci-tooling.md`
+- boot-check, smoke, testsuite, QEMU → `e2e-ci.md`
+- promotion PRs and stable release flow → `release-promotion.md`
+- stale queue branches / conflicting bot PRs → `merge-queue.md`
+- historical deep cuts → `ci-reference.md`
+
+### Factory workflow
+- Issue lifecycle, data donation, slash commands → `actionadon.md`
+- Routine zero-context maintenance → `quickstart.md`
+- Review flow → `pr-review.md`
+- Repo/product context → `overview.md`
+
+## Routing Table
 
 | Task | Load |
-|------|------|
-| **Load the dakota build context first** | **⚠️ REQUIRED FIRST — [`not-bluefin.md`](not-bluefin.md) before any other skill, especially if you have bluefin context. If your plan mentions dnf/RPM/Containerfile overlays, reload it and translate the task into BST terms first.** |
-| Zero-context routine maintenance | [`quickstart.md`](quickstart.md) |
-| Adding a package | [`add-package.md`](add-package.md) |
-| Removing a package | [`remove-package.md`](remove-package.md) |
-| Updating a package version | [`update-refs.md`](update-refs.md) |
-| BST YAML reference, variables, kinds | [`buildstream.md`](buildstream.md) |
-| Debugging a build failure | [`debugging.md`](debugging.md) |
-| OCI image layer assembly | [`oci-layers.md`](oci-layers.md) |
-| Junction overrides (when to, when not to) | [`bst-overrides.md`](bst-overrides.md) |
-| Patching junction elements | [`patch-junctions.md`](patch-junctions.md) |
-| Pre-built binary packaging | [`packaging-binaries.md`](packaging-binaries.md) |
-| Go project packaging | [`packaging-go.md`](packaging-go.md) |
-| Rust/Cargo project packaging | [`packaging-rust.md`](packaging-rust.md) |
-| Zig project packaging | [`packaging-zig.md`](packaging-zig.md) |
-| GNOME Shell extension packaging | [`packaging-gnome-extensions.md`](packaging-gnome-extensions.md) |
-| Local OTA testing (QEMU or physical hardware) | [`local-ota.md`](local-ota.md) |
-| CI pipeline, remote cache, GHCR | [`ci.md`](ci.md) |
-| Manual promotion (testing → stable) and release | [`ci.md`](ci.md) — *Manual stable promotion flow* |
-| Reusable workflow `startup_failure` debugging | [`ci.md`](ci.md) — *`permissions: {}` at workflow level starves GITHUB_TOKEN*, *`pull_request: closed` trigger*, and *`sign-and-publish` cert identity regexp* |
-| CODEOWNERS: auto-managed file bypass | [`ci.md`](ci.md) — *CODEOWNERS: no-owner override for auto-managed files* |
-| Structured changelog / release notes (cliff.toml) | [`ci.md`](ci.md) — *`cliff.toml` required at repo root for structured release notes* |
-| `:next`/`:btw` rolling GNOME 51 stream | [`overview.md`](overview.md) — *Image Streams* + [`ci.md`](ci.md) |
-| Clearing stuck merge queue | [`merge-queue.md`](merge-queue.md) |
-| Actionadon lifecycle, issue queue, data donation | [`actionadon.md`](actionadon.md) |
-| Project overview and what Dakota is | [`overview.md`](overview.md) |
-| ujust recipes in `files/just-overrides/` | [`.github/skills/ujust-recipes.md`](../../.github/skills/ujust-recipes.md) |
-| VM stack (virt-manager + QEMU flatpaks) | [`vm-stack.md`](vm-stack.md) |
-| Installer (bootc-installer) | [`installer.md`](installer.md) |
-| Merging dep-update PRs into testing | [`merge-queue.md`](merge-queue.md) |
-| PR review workflow | [`pr-review.md`](pr-review.md) |
+|---|---|
+| **Reset the Dakota mental model first** | **`not-bluefin.md`** |
+| Routine maintenance with low context | `quickstart.md` |
+| Add a package | `add-package.md` |
+| Remove a package | `remove-package.md` |
+| Update a package version or source ref | `update-refs.md` |
+| BST YAML, kinds, variables, or structure | `buildstream.md` |
+| Debug an element build failure | `debugging.md` |
+| OCI image layer assembly | `oci-layers.md` |
+| Junction overrides | `bst-overrides.md` |
+| Patch junction elements | `patch-junctions.md` |
+| Package a pre-built binary | `packaging-binaries.md` |
+| Package a Go project | `packaging-go.md` |
+| Package a Rust project | `packaging-rust.md` |
+| Package a Zig project | `packaging-zig.md` |
+| Package a GNOME Shell extension | `packaging-gnome-extensions.md` |
+| Local OTA testing | `local-ota.md` |
+| Figure out which CI workflow owns the problem | `workflow-map.md` |
+| Reusable workflow / token / cache / startup failures | `ci-tooling.md` |
+| boot-check, smoke, testsuite wiring | `e2e-ci.md` |
+| Promotion PRs and stable release flow | `release-promotion.md` |
+| Historical CI edge cases | `ci-reference.md` |
+| Merge queue cleanup | `merge-queue.md` |
+| Issue lifecycle / Actionadon / data donation | `actionadon.md` |
+| Installer work | `installer.md` |
+| VM stack context | `vm-stack.md` |
+| Repo and product overview | `overview.md` |
+| PR review workflow | `pr-review.md` |
+| ujust recipes in `files/just-overrides/` | `.github/skills/ujust-recipes.md` |
 
-## Mandatory skill contribution
+## Common Rationalizations
 
-**All agents must improve skills.** If you discover a new pattern, fix a recurring
-mistake, or learn something that would help future contributors, update the
-relevant skill file in this directory — in the same PR as your change.
+| Rationalization | Reality |
+|---|---|
+| "I'll just read the biggest skill so I don't miss anything." | That's how agents waste context and still miss the relevant part. |
+| "This new lesson can go into the nearest large file." | Large files rot. Put the lesson in the narrowest skill or split a new one. |
+| "I know the tool well enough; I don't need docs." | The repo explicitly optimizes for source-driven work. Use Context7. |
+| "The router can hold one more giant subsection." | No. Route, then split. |
 
-- If no relevant skill file exists, create one and add it to the routing table above.
-- If your lesson applies to an existing skill, add it under `## Lessons Learned`.
-- Skills are living documents. Every agent and human contributor improves them.
+## Red Flags
 
-### How to add a lesson
+- A skill grows into a catch-all for multiple failure classes
+- New lessons land in a giant history dump instead of a focused skill
+- Agents load 500+ lines before they know which subsystem failed
+- The route table points to one file for three unrelated jobs
 
-1. Open the relevant skill file (or create a new one)
-2. Add a section under `## Lessons Learned`: `### <pattern name> (YYYY-MM-DD)`
-3. What failed → why → the fix → code example
-4. Commit it in the same PR as your change
+## Verification
+
+- [ ] The route table points to the narrowest useful skill
+- [ ] CI topics are split by workflow map, tooling, boot/e2e, and promotion
+- [ ] New skill growth reinforces the factory model instead of creating a second archive
+- [ ] External tool behavior is verified via Context7 before skills are updated
 
 ## Related
 
-- Role policies for Hive agents: [`../../files/hive/agent-policies/`](../../files/hive/agent-policies/)
-- Top-level agent rules: [`../../AGENTS.md`](../../AGENTS.md)
+- `../SKILL.md` — top-level skill router
+- `../../AGENTS.md` — repo rules and factory policy
+- `../../files/hive/agent-policies/` — Hive role policy files

--- a/docs/skills/actionadon.md
+++ b/docs/skills/actionadon.md
@@ -1,74 +1,96 @@
 ---
 name: actionadon
-description: Dakota issue lifecycle — Actionadon pipeline stages, data donation contract, pipeline widget sentinel rules, and slash commands. Load when working on any GitHub issue, triaging bugs, or processing the contribution queue.
+description: Dakota issue lifecycle and data-donation contract. Use when triaging issues, claiming work, reading the pipeline widget, or touching issue-lifecycle automation.
 ---
 
-# Actionadon Lifecycle and Data Donation
+# Actionadon
 
-Load when working on any GitHub issue in this repo, triaging bugs, processing the queue, or touching `.github/workflows/actionadon.yml`.
+## Overview
 
-## When to load this skill
+Dakota issues are not just tickets. They are **data donations**.
+The pipeline widget, labels, slash commands, and verification counts are how the factory turns user evidence into work the queue can trust.
 
-Load when: working on any GitHub issue in this repo, triaging bugs, processing the queue, or touching `.github/workflows/actionadon.yml`.
+## When to Use
 
-## The data donation contract
+Use when:
+- working from GitHub issues in this repo
+- triaging or claiming work
+- reading the Actionadon / pipeline widget state
+- touching issue lifecycle automation or slash-command behavior
 
-Dakota's bug reports are not bug reports. They are data donations. A user running `ujust report` deliberately captures and shares their system state. This is the ground truth that makes from-source OS development tractable. Agents working in this repo must understand this contract and never devalue it.
+## When NOT to Use
 
-**The automation ratio**: without `ujust report`, fixing one bug requires 5+ comment cycles: kernel version, hardware, logs, reproducible, always. With a gist-backed report, the maintainer has everything before the first reply. The pipeline widget makes this visible to the reporter so they know their donation landed and is moving.
+- Reviewing or fixing code after the issue is already fully understood
+- Debugging CI or release workflows unrelated to issue lifecycle
 
-## Pipeline stages and what each means for agents
+## Core Process
 
-```text
-<!-- actionadon-pipeline -->
-DAKOTA  ·  issue pipeline
-─────────────────────────────────────────────────
-  ✓  filed      report received
-  ✓  approved   cleared for the build queue
-  ▶  queued     open for contributors
-  ·  claimed    —
-  ·  done       —
-─────────────────────────────────────────────────
-  report:       attached    ·  confirms: 2
-  area:         hardware    ·  priority: high
-  verified:     0/3         ·  next action: comment /claim to take this
-```
+1. **Read the widget before acting.**
+2. **Treat `report: attached` as ground truth.** Read the report before asking questions.
+3. **Respect stage ownership.** Agents build from queued/claimed work; humans approve.
+4. **Use slash commands to interact with the queue.** Do not freestyle the lifecycle.
+5. **Do not duplicate widget state in comments.** The widget is already the status surface.
 
-| Stage | Widget line | Trigger | Agent action |
-|---|---|---|---|
-| `filed` | `✓ filed` or active `▶ filed` | Issue opened. `status/triage` applied. | Do not claim. Wait for human triage. If `report: missing`, do not interrogate the reporter. They may not have run `ujust report` yet. If the issue is vague, link them to `ujust report`. |
-| `approved` | `✓ approved` or active `▶ approved` | Maintainer adds `status/approved`. Actionadon also adds `status/queued`. | Human review is complete. Agent may `/claim` once the issue is actually in queue. |
-| `queued` | `▶ queued` | `status/queued` present. Issue is in the contributor pool. | Comment `/claim` to take it. Check `confirms:` first. Higher count means broader hardware impact. |
-| `claimed` | `▶ claimed` | `/claim` comment assigns the issue and adds `status/claimed`. | You own it. Build, test, open the PR. Comment `/unclaim` if blocked. Seven days of inactivity auto-releases it. |
-| `done` | `▶ done` or closed issue | Issue closed after the fix ships. | Do not reopen. Read `verified: N/3` as post-ship hardware confirmation. If below target, flag for human decision instead of acting unilaterally. |
+## Data Donation Contract
 
-## Widget sentinel rule
+A user who runs `ujust report` intentionally donates system state.
+That donation is what makes a from-source desktop factory workable.
 
-The sentinel `<!-- actionadon-pipeline -->` marks the managed block at the top of every issue body. Agents must never:
+Implications for agents:
+- if `report: attached`, read it before asking the reporter anything
+- if `confirms: N` is high, treat the issue as broader hardware impact
+- if `verified: N/3` is low after ship, do not close the loop casually
 
-- Remove or edit the sentinel block manually
-- Post a comment that duplicates the pipeline state. The widget is the state.
-- Close an issue without checking `verified:`. Target is `3/3`. Below that, flag for human decision.
+## Stage Map
 
-## Reading the metadata rows
+| Stage | Meaning | Agent action |
+|---|---|---|
+| `filed` | Issue exists, not yet queued for builders | do not claim; wait for human triage |
+| `approved` | Human review says it is real and should move forward | prepare to pick it up once queued |
+| `queued` | Ready for contributors/agents | `/claim` if you are taking it |
+| `claimed` | Someone owns it | if not you, leave it alone |
+| `done` | Fix shipped, awaiting verification | do not rewrite history; check `verified:` |
 
-| Row | What it tells you |
-|-----|-------------------|
-| `report: attached` | Full gist telemetry exists. Check it before asking any question. |
-| `report: missing` | No gist yet. The issue may be less actionable. |
-| `confirms: N` | `N` people hit this on distinct hardware. Use it as a blast-radius proxy. |
-| `verified: N/3` | `N` people confirmed the fix on real hardware after ship. |
-| `area:` | Subsystem from labels. Scope your fix accordingly. |
-| `priority:` | Urgency from labels. |
+## Widget Reading Guide
 
-## Slash commands
+| Row | Meaning |
+|---|---|
+| `report: attached` | gist-backed telemetry exists |
+| `report: missing` | less evidence; ask for `ujust report` rather than freeform logs |
+| `confirms: N` | blast radius proxy across real hardware |
+| `verified: N/3` | post-ship confirmation target |
+| `area:` | subsystem scope |
+| `priority:` | urgency from labels |
 
-| Command | Who | Effect |
-|---------|-----|--------|
-| `/claim` | anyone | Assigns you, adds `status/claimed`, advances the widget |
-| `/unclaim` | assignee or write+ | Returns the issue to the queue |
-| `/approve` or `/lgtm` | write+ | Adds `lgtm`, auto-queues |
+## Slash Commands
 
-## Hive exempt labels
+| Command | Effect |
+|---|---|
+| `/claim` | assign yourself and move to claimed |
+| `/unclaim` | return the issue to the queue |
+| `/approve` or `/lgtm` | maintainer approval / queue progression |
 
-Do not touch issues with: `hold`, `do-not-merge`, `status/discussing`, `status/claimed` (if you are not the assignee), `agent/blocked`, `needs-human/agent-oops`.
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I'll just ask the reporter for logs." | If `report: attached`, the logs are already there. Read them first. |
+| "I'll claim it even though it's not queued yet." | That bypasses the factory's human approval step. |
+| "I'll summarize widget state in a comment." | Noise. The widget already exists for that. |
+| "`verified: 0/3` is probably fine if CI passed." | This repo explicitly values hardware confirmation over wishful closure. |
+
+## Red Flags
+
+- Claiming non-queued work
+- Ignoring an attached report
+- Commenting status that is already visible in the widget
+- Reopening or closing issues without checking verification counts
+- Touching `hold`, `do-not-merge`, `status/discussing`, or someone else's `status/claimed` issue
+
+## Verification
+
+- [ ] Widget state was read before acting
+- [ ] Attached reports were read before asking questions
+- [ ] Only queued work was claimed
+- [ ] No comments duplicated existing widget state
+- [ ] Hardware confirmation state was considered before treating the loop as closed

--- a/docs/skills/add-package.md
+++ b/docs/skills/add-package.md
@@ -1,70 +1,76 @@
 ---
 name: add-package
-description: End-to-end workflow for adding a new software package to the Dakota image. Covers element creation, deps.bst wiring, systemd service installation, and common mistakes. Load for any "add package to Dakota" task.
+description: End-to-end workflow for adding a new package to Dakota. Use when a task adds software, services, config-only elements, or new image content via BuildStream elements.
+metadata:
+  context7-sources:
+    - /apache/buildstream
 ---
 
-# Adding a Package
+# Add a Package
 
-Entry-point workflow for adding any software package to the Dakota image.
+## Overview
+
+This skill is the **end-to-end path** for new Dakota packages.
+Use it after `not-bluefin.md` has reset the repo model.
+
+## When to Use
+
+Use when you need to:
+- add a new package to the image
+- add a new service or preset shipped by a package
+- add a config-only/import element
+- wire new software into `deps.bst`
 
 ## When NOT to Use
 
-- Removing a package → `remove-package.md`
-- Updating an existing package's version → `update-refs.md`
-- Debugging a build failure → `debugging.md`
-- BST variable/kind reference only → `buildstream.md`
+- Remove an existing package → `remove-package.md`
+- Update an existing package version → `update-refs.md`
+- Debug a failing build → `debugging.md`
+- Need only BST syntax or element-kind reference → `buildstream.md`
 
-## Agent Quick-Start
+## Core Process
+
+1. **Pick the right element kind.**
+2. **Copy a similar element as the starting point.** There is no scaffold generator.
+3. **Create the new element under `elements/bluefin/`.**
+4. **Wire it into the correct stack** (usually `elements/bluefin/deps.bst`).
+5. **Add a source alias if the download domain is new.**
+6. **Validate the graph before building.**
+7. **Build the element, then the full image if needed.**
+
+## Quick Start
 
 ```bash
-# Create element file manually at elements/bluefin/<name>.bst
-# Use an existing element as a template, e.g.:
 cp elements/bluefin/glow.bst elements/bluefin/<name>.bst
-# Edit to match the new package's source and install paths
+# edit the new element
+just bst show oci/bluefin.bst
+just bst build bluefin/<name>.bst
 ```
-
-There are no scaffold scripts. Copy an existing element of the appropriate kind as a starting point.
-
-**Historical path note:** new Dakota packages still live under
-`elements/bluefin/` and are added to `elements/bluefin/deps.bst`. That path
-name is historical only — do not translate package work into dnf, RPM, or
-Containerfile-overlay steps.
 
 ## Choose Element Kind
 
-| Source type | BuildStream kind | Sub-skill |
+| Source type | BuildStream kind | Next skill |
 |---|---|---|
 | Pre-built binary/tarball | `manual` + tar/remote source | `packaging-binaries.md` |
-| Source with Meson build | `meson` | — |
-| Source with Makefile | `make` | — |
-| Source with autotools | `autotools` | — |
-| Source with CMake | `cmake` | — |
+| Meson project | `meson` | — |
+| Makefile project | `make` | — |
+| Autotools project | `autotools` | — |
+| CMake project | `cmake` | — |
 | Rust/Cargo project | `make` + `cargo2` sources | `packaging-rust.md` |
-| Go project | `make` or `manual` + GOPATH/go_module | `packaging-go.md` |
+| Go project | `make` or `manual` + `go_module` | `packaging-go.md` |
 | Zig project | `manual` + offline cache | `packaging-zig.md` |
-| GNOME Shell extension | `import`/`meson`/`make` + extension layout | `packaging-gnome-extensions.md` |
+| GNOME Shell extension | extension-specific layout | `packaging-gnome-extensions.md` |
 | Config files only | `import` | — |
 
-## Workflow
+## Service Installation Rules
 
-1. **Create element** at `elements/bluefin/<name>.bst` (copy a similar existing element as a base)
-2. **Add to deps** — add `bluefin/<name>.bst` to `depends:` in `elements/bluefin/deps.bst`
-3. **Add source alias** — if the download domain is new, add an alias to `include/aliases.yml`
-4. **Validate graph** — `just validate` (full graph check)
-5. **Build element** — `just bst build bluefin/<name>.bst`
-6. **Full image test** — `just build` or `just show-me-the-future`
+Enable services with **preset files**, never `systemctl enable`.
 
-## Systemd Service Installation
-
-Services bundled with a package need three things:
-
-| What | Where | Notes |
+| What | Where | Rule |
 |---|---|---|
-| Service file | `%{indep-libdir}/systemd/system/` | Patch `/usr/sbin` to `/usr/bin`; remove `EnvironmentFile=/etc/default/*` lines |
-| Preset file | `%{indep-libdir}/systemd/system-preset/80-<name>.preset` | Content: `enable <service-name>.service` |
-| Binaries | `%{bindir}` | Never `/usr/sbin` — GNOME OS uses merged-usr |
-
-Enable services via preset files, never `systemctl enable`.
+| service unit | `%{indep-libdir}/systemd/system/` | patch `/usr/sbin` → `/usr/bin`; remove `/etc/default/*` usage |
+| preset file | `%{indep-libdir}/systemd/system-preset/80-<name>.preset` | `enable <service>.service` |
+| binaries | `%{bindir}` | merged-usr means `/usr/bin`, not `/usr/sbin` |
 
 ```yaml
 install-commands:
@@ -73,8 +79,6 @@ install-commands:
         -e '/^EnvironmentFile=/d' \
         upstream.service > upstream.service.patched
     install -Dm644 -t "%{install-root}%{indep-libdir}/systemd/system" upstream.service.patched
-    mv "%{install-root}%{indep-libdir}/systemd/system/upstream.service.patched" \
-       "%{install-root}%{indep-libdir}/systemd/system/upstream.service"
   - |
     install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/systemd/system-preset/80-name.preset" <<'PRESET'
     enable service-name.service
@@ -85,14 +89,37 @@ install-commands:
 
 | Mistake | Fix |
 |---|---|
-| Missing `strip-binaries: ""` | Required for non-ELF elements — build fails otherwise |
-| Using `/usr/sbin` | Always `/usr/bin` — GNOME OS merged-usr |
-| `EnvironmentFile=/etc/default/...` | GNOME OS doesn't use `/etc/default/`; remove from upstream service files |
-| Variables in source URLs | BuildStream doesn't support this; use literal URLs with aliases |
-| Missing `%{install-extra}` | Must be last install-command |
-| Trying to add the package in `Containerfile`/`Justfile` | Package and image-content changes belong in `.bst` elements plus `deps.bst` |
-| Forgot to add element to `deps.bst` | Element builds but won't be in the image |
-| Wrong dependency stack | Use `freedesktop-sdk.bst:public-stacks/runtime-minimal.bst` for runtime deps |
+| Forgot `strip-binaries: ""` for non-ELF payloads | disable stripping in `variables:` |
+| Used `/usr/sbin` or `/lib` | merged-usr means `/usr/bin` and `/usr/lib` |
+| Left `EnvironmentFile=/etc/default/...` in unit | remove it |
+| Used variables in `sources[].url` | use literal URLs plus aliases |
+| Forgot to add the element to `deps.bst` | package builds but never lands in the image |
+| Tried to solve it in `Containerfile` or `Justfile` | package/image-content changes belong in `.bst` + stack wiring |
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I'll just copy a package in through the Containerfile." | Wrong layer. The image graph is owned by BST. |
+| "The element builds, so I'm done." | Not if it never got wired into the stack. |
+| "Upstream service files are probably fine as-is." | Dakota repeatedly trips on `/usr/sbin` and `/etc/default` assumptions. |
+| "I can skip graph validation and let CI tell me." | Local graph checks are cheaper than burning CI time. |
+
+## Red Flags
+
+- New package file exists but `deps.bst` was not touched
+- Unit files install into old FHS paths
+- Source URLs use fake variable expansion
+- The plan mentions Containerfile or RPM steps
+
+## Verification
+
+- [ ] New element exists under `elements/bluefin/`
+- [ ] Correct stack file was updated
+- [ ] New source alias was added if needed
+- [ ] `just bst show oci/bluefin.bst` passes
+- [ ] The element builds successfully
+- [ ] Service/preset files follow merged-usr and preset rules
 
 ## Lessons Learned
 
@@ -111,30 +138,4 @@ variables:
 
 ### BST variables cannot be used in source URL fields (2026-06-07)
 
-Unlike install commands where `%{version}` expands correctly, BuildStream does NOT expand variables inside `sources[].url:` fields. Use `include/aliases.yml` to define a URL alias, then reference the alias:
-
-```yaml
-# ❌ WRONG — variable expansion does not work in source URLs
-sources:
-- kind: tar
-  url: https://github.com/owner/project/releases/v%{version}.tar.gz
-
-# ✅ CORRECT — use an alias
-sources:
-- kind: tar
-  url: alias:project-releases/v%{version}.tar.gz
-  # alias defined in include/aliases.yml as:
-  #   project-releases: https://github.com/owner/project/releases/
-```
-
-### Service preset files must use /usr/lib path, not /etc (2026-06-07)
-
-Dakota is a GNOME OS-model image. Service preset files installed at `/etc/systemd/system-preset/` are ignored at boot. Presets must be at the `%{indep-libdir}` path:
-
-```yaml
-# ✅ correct
-install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/systemd/system-preset/80-name.preset"
-
-# ❌ wrong — ignored at boot
-install -Dm644 /dev/stdin "%{install-root}%{sysconfdir}/systemd/system-preset/80-name.preset"
-```
+Unlike install commands where `%{version}` expands correctly, BuildStream does NOT expand variables inside `sources[].url:` fields. Use `include/aliases.yml` to define a URL alias, then reference the alias.

--- a/docs/skills/bst-overrides.md
+++ b/docs/skills/bst-overrides.md
@@ -1,11 +1,33 @@
 ---
+
 name: bst-overrides
 description: Governs when and how to create junction overrides in dakota. Upstream-first principle — local overrides are last resort. Covers patch_queue overrides, exit conditions, and how to evaluate whether an override is justified.
+metadata:
+  context7-sources:
+    - /apache/buildstream
 ---
 
 # BST Junction Overrides
 
 Load when creating, evaluating, or removing BuildStream junction element overrides in `projectbluefin/dakota`.
+
+## When to Use
+
+Use when you need to decide whether a local override is justified, add a temporary junction override, or remove one after upstream catches up.
+
+## When NOT to Use
+
+- End-to-end patch lifecycle work after deciding an override is required → `patch-junctions.md`
+- Routine package updates that stay inside Dakota-owned elements → `update-refs.md`
+- Generic BuildStream syntax reference → `buildstream.md`
+
+## Core Process
+
+1. Check whether upstream already fixed the problem.
+2. Prefer an upstreamable patch or junction bump.
+3. Use a local override only as a last resort.
+4. Record the exit condition so the override can die.
+5. Revisit overrides whenever junction refs move.
 
 ## Core Principle: Upstream-First
 
@@ -74,6 +96,28 @@ gh api repos/GNOME/gnome-build-meta/commits?sha=gnome-50 | jq '.[].commit.messag
 # Check if fdsdk has the fix in their latest tag:
 gh api repos/freedesktop-sdk/freedesktop-sdk/releases/latest | jq '.tag_name'
 ```
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I'll just override it locally for now." | Local overrides are maintenance debt unless they have a clear exit path. |
+| "Editing the junction file directly is faster." | Faster to create debt, yes. Use the override mechanisms the repo expects. |
+| "We'll remember to drop the override later." | You won't unless the exit condition is written down. |
+
+## Red Flags
+
+- Local override with no upstream issue/PR reference
+- No stated exit condition
+- Direct edits to junction files as a convenience move
+- Override surviving multiple junction bumps without re-evaluation
+
+## Verification
+
+- [ ] Upstream was checked before creating the override
+- [ ] The local override mechanism is the narrowest one that works
+- [ ] An exit condition is documented
+- [ ] The override is discoverable and revisitable at the next junction bump
 
 ## Lessons Learned
 

--- a/docs/skills/buildstream.md
+++ b/docs/skills/buildstream.md
@@ -1,109 +1,128 @@
 ---
-name: buildstream-reference
-description: Reference for BuildStream 2 element syntax, variables, kinds, source kinds, and command hooks. Load when writing or reviewing .bst element files, not for end-to-end packaging workflows (use add-package.md for that).
+name: buildstream
+description: BuildStream reference for Dakota element authors. Use when writing, reviewing, or validating `.bst` files and you need the correct kinds, variables, source types, hooks, or graph commands.
+metadata:
+  context7-sources:
+    - /apache/buildstream
 ---
 
-# BuildStream Element Reference
+# BuildStream Reference
 
-Load when writing, editing, or reviewing BuildStream `.bst` element files.
+## Overview
+
+This skill is the **syntax and mechanics reference** for Dakota's BuildStream work.
+It is not the end-to-end packaging workflow; it is the cheat sheet for getting `.bst` files right.
+
+## When to Use
+
+Use when you need:
+- element kinds and when they apply
+- standard variables and install paths
+- source kind guidance
+- command-hook syntax
+- graph validation or inspection commands
 
 ## When NOT to Use
 
-- End-to-end workflow for adding a new package → `add-package.md`
-- Diagnosing build failures → `debugging.md`
-- Understanding the CI pipeline → `ci.md`
-- Managing junction overrides → `bst-overrides.md`
+- End-to-end package addition → `add-package.md`
+- Diagnosing a failing build → `debugging.md`
+- CI workflow behavior → CI skills
+- Junction override strategy → `bst-overrides.md`
+
+## Core Process
+
+1. **Validate the graph before building.**
+2. **Choose the correct element kind for the source/build system.**
+3. **Use standard install variables and merged-usr paths.**
+4. **Prefer existing repo patterns over invention.**
+5. **Inspect single-element deps and artifacts before escalating to a full image build.**
 
 ## Quick Recipes
 
 | Goal | Command |
-|------|---------|
-| Validate full element graph (no build) | `just validate` |
+|---|---|
+| Validate full graph | `just bst show oci/bluefin.bst` |
 | Inspect single element deps | `just bst show bluefin/<name>.bst` |
 | Build one element | `just bst build bluefin/<name>.bst` |
 | Enter build sandbox | `just bst shell --build bluefin/<name>.bst` |
-| Track a git/tarball ref | `just bst source track bluefin/<name>.bst` |
-| List built element contents | `just bst artifact list-contents bluefin/<name>.bst` |
+| Track a source ref | `just bst source track bluefin/<name>.bst` |
+| List built contents | `just bst artifact list-contents bluefin/<name>.bst` |
 | View build log | `just bst artifact log bluefin/<name>.bst` |
 | Delete cached build | `just bst artifact delete bluefin/<name>.bst` |
-| Full image build | `just build` |
-| All available recipes | `just --list` |
 
-## Variables
+## Key Variables
 
-| Variable | Expands To | Notes |
-|----------|-----------|-------|
-| `%{install-root}` | Staging directory | Always prefix install paths with this |
-| `%{prefix}` | `/usr` | |
-| `%{bindir}` | `/usr/bin` | |
-| `%{indep-libdir}` | `/usr/lib` | For systemd units, presets, sysusers, tmpfiles |
-| `%{datadir}` | `/usr/share` | |
-| `%{sysconfdir}` | `/etc` | Rarely used in GNOME OS elements |
-| `%{install-extra}` | Empty hook | Convention: always end install-commands with this |
-| `%{go-arch}` | `amd64`/`arm64`/`riscv64` | Defined in project.conf per-arch |
-| `%{arch}` | `x86_64`/`aarch64`/`riscv64` | Raw architecture name |
-| `strip-binaries` | Set to `""` to disable | Required for non-ELF elements (fonts, configs, pre-built) |
-| `overlap-whitelist` | `public: bst: overlap-whitelist:` | List of paths allowed to overlap between elements |
+| Variable | Expands to | Notes |
+|---|---|---|
+| `%{install-root}` | staging dir | prefix install paths with this |
+| `%{prefix}` | `/usr` | Dakota is merged-usr |
+| `%{bindir}` | `/usr/bin` | binaries go here |
+| `%{indep-libdir}` | `/usr/lib` | systemd units, presets, tmpfiles, sysusers |
+| `%{datadir}` | `/usr/share` | data files |
+| `%{sysconfdir}` | `/etc` | use sparingly |
+| `%{install-extra}` | trailing hook | convention: end install-commands with it |
+| `strip-binaries` | set to `""` to disable | needed for non-ELF payloads |
 
 ## Element Kinds
 
-| Kind | Use Case |
-|------|----------|
-| `manual` | Custom build/install, pre-built binaries, config files |
-| `meson` | GNOME libraries/apps |
-| `make` | Makefile projects, Go with vendored deps |
-| `autotools` | Legacy C projects |
-| `make` + `cargo2` | Rust projects (see `packaging-rust.md`) |
+| Kind | Use case |
+|---|---|
+| `manual` | custom build/install, pre-built binaries |
+| `meson` | GNOME apps and libraries |
+| `make` | Makefile projects |
+| `autotools` | legacy C projects |
 | `cmake` | CMake projects |
-| `import` | Direct file placement (no build) |
-| `stack` | Dependency aggregation, arch dispatch — **produces zero filesystem output** |
-| `compose` | Layer filtering (exclude debug/devel) |
-| `script` | OCI image assembly |
-| `collect_initial_scripts` | Collect systemd preset/sysusers/tmpfiles from deps |
+| `import` | direct file placement, no build |
+| `stack` | dependency aggregation only; **produces no filesystem output** |
+| `compose` | filesystem-producing layer/filter step |
+| `script` | OCI/image assembly |
+| `junction` | upstream source tree / external project boundary |
 
 ## Source Kinds
 
-| Source Kind | Use Case |
-|-------------|----------|
-| `git_repo` | Most elements |
-| `tar` | Release tarballs. Add `base-dir: ""` if tarball has no wrapping directory. |
-| `remote` | Single file download (not extracted). Use `directory:` to place into a subdirectory. |
-| `local` | Files from repo's `files/` directory |
-| `cargo2` | Rust crate vendoring. Generate with `files/scripts/generate_cargo_sources.py`. |
-| `go_module` | Go module deps (one per dep) |
-| `git_module` | Git submodule checkout |
-| `patch_queue` | Apply patches directory |
-| `gen_cargo_lock` | Generate Cargo.lock from base64 |
+| Source kind | Use case |
+|---|---|
+| `git_repo` | most source trees |
+| `tar` | release tarballs |
+| `remote` | single-file download |
+| `local` | repo-local files |
+| `cargo2` | Rust crate vendoring |
+| `go_module` | Go module deps |
+| `patch_queue` | patch application |
 
-## Command Hooks
+## Command Hook Syntax
 
 | Syntax | Meaning |
-|--------|---------|
-| `(>):` | Append to inherited command list from element kind |
-| `(<):` | Prepend to inherited command list |
-| `(@):` | Include a YAML file |
-| `(?):` | Conditional block (evaluates options like `arch`) |
-
-Convention: always end `install-commands` with `%{install-extra}`.
-
-## BST Weak-Key Caching Bug
-
-**Symptom:** Adding a new package to `deps.bst` (`kind: stack`) does NOT trigger a rebuild of downstream OCI image layers (`kind: compose`). New package is missing from the final image even though `bst show` lists it.
-
-**Root cause:** In BST non-strict mode, the "weak key" for a `kind: stack` element is computed from its **direct dependency names only**, not their content hashes. Changing what a `compose` element transitively depends on via a stack does not change the compose element's weak key → BST considers it cache-hit → skips rebuild.
-
-**Workaround:** Force-invalidate the cache of a `kind: compose` element that directly depends on the stack by making any content change to one of its direct dependencies.
-
-**Real fix:** Use `bst build` in strict mode: `just bst --no-cache-buildtrees build oci/bluefin.bst`.
-
-## ECL / Common Lisp Packaging
-
-| Fact | Detail |
 |---|---|
-| Must use `-std=gnu99` | ECL's `fpe_x86.c` uses bare `asm()` — invalid under `-std=c99` |
-| Must use `--with-gmp=/usr` | Without this, ECL bundles its own GMP and propagates `-fasm` which breaks configure |
-| `ecl --load` spawns `gcc` | Any element calling `ecl --load` at build time needs `gcc` in `build-depends` |
-| `gitlab.common-lisp.net` sources | BST's dulwich cannot parse this git protocol — use `kind: tar` with GitLab archive URL |
+| `(>):` | append to inherited commands |
+| `(<):` | prepend to inherited commands |
+| `(@):` | include YAML |
+| `(?):` | conditional block |
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "`stack` and `compose` are basically the same." | No. `stack` aggregates deps only; `compose` produces filesystem output. |
+| "I'll validate by building; same difference." | `bst show` catches graph/YAML problems faster and cheaper. |
+| "Variables should expand in URLs too." | They do not. Use aliases. |
+| "This path probably goes in `/usr/sbin`." | Dakota is merged-usr. Default to `/usr/bin`. |
+
+## Red Flags
+
+- `kind: stack` where filesystem output is expected
+- source URLs using fake variable expansion
+- install paths outside `/usr`
+- no `%{install-root}` prefix in install commands
+- building before the graph even shows cleanly
+
+## Verification
+
+- [ ] The chosen element kind matches the real build/input model
+- [ ] The graph validates with `just bst show oci/bluefin.bst`
+- [ ] Install paths use standard variables and merged-usr locations
+- [ ] Any filesystem-producing layer uses `compose`, not `stack`
+- [ ] Source and hook syntax follow repo conventions
 
 ## Lessons Learned
 
@@ -111,22 +130,6 @@ Convention: always end `install-commands` with `%{install-extra}`.
 
 BST option names only allow alphanumeric characters and underscores. A name like `my-option` silently fails or causes a parse error. Use `my_option` instead. This trips up agents that copy option names from CLI flags (which typically use hyphens).
 
-```yaml
-# ❌ wrong
-options:
-  my-arch:
-    type: arch
+### Weak-key caching can hide new packages behind a clean build (2026-06-07)
 
-# ✅ correct
-options:
-  my_arch:
-    type: arch
-```
-
-### `(>):` append syntax replaces the entire command list if used incorrectly (2026-06-07)
-
-The `(>):` syntax appends to the inherited command list from the element kind. If you write it as a key at the wrong indent level, BST silently ignores it and uses only your commands, dropping the kind's built-in build steps. Always verify the final command list with `just bst show --format '%{name}: %{build-commands}' bluefin/<name>.bst` before building.
-
-### `kind: stack` elements produce no filesystem output — they are dep aggregators only (2026-06-07)
-
-`deps.bst` is intentionally `kind: stack`. That means it has zero filesystem output. Only `kind: compose` and `kind: script` elements produce filesystem artifacts. If a new layer element is accidentally typed as `kind: stack`, it will build successfully but the image layer will be empty. Always verify with `grep '^kind:' elements/oci/layers/bluefin.bst`.
+Changing a `kind: stack` dependency does not always invalidate downstream `compose` outputs in non-strict mode. If a package is present in the graph but missing from the final image, inspect cache behavior before assuming the package element is wrong.

--- a/docs/skills/ci-reference.md
+++ b/docs/skills/ci-reference.md
@@ -26,6 +26,12 @@ Route through `ci.md` first, then come here only when the focused skills do not 
 - Writing or modifying `.bst` element files → `buildstream.md`
 - Understanding what packages flow into the OCI image → `oci-layers.md`
 
+## Core Process
+
+1. Route through the focused CI skills first.
+2. Come here only when you need historical prior art or an exact failure signature.
+3. If a pattern keeps recurring, extract it into a focused skill and stop adding load to this archive.
+
 ## Quick Reference
 
 | What | Value |
@@ -188,6 +194,26 @@ At the start of every dakota session, check GNOME OS upstream status:
 gh pr list --repo gnome/gnome-build-meta --state open --limit 10
 gh run list --repo projectbluefin/dakota --limit 5
 ```
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I'll just add the new lesson to the big archive." | If it is reusable enough, it probably deserves a focused skill. |
+| "Loading the giant reference first is safer." | It is slower and usually less accurate for the active task. |
+| "Historical prior art is the same as current guidance." | The point of the focused skills is to keep current guidance small and sharp. |
+
+## Red Flags
+
+- New agents loading this before `ci.md`
+- Repeated patterns staying buried here instead of being split out
+- Fixes being applied from old lore without checking current workflow files
+
+## Verification
+
+- [ ] The focused CI skills were exhausted before using this archive
+- [ ] Any recurring pattern found here was considered for extraction into a focused skill
+- [ ] The archive is being used as prior art, not as the default CI entry point
 
 ## Cross-References
 

--- a/docs/skills/ci-reference.md
+++ b/docs/skills/ci-reference.md
@@ -1,65 +1,52 @@
 ---
-name: ci
-description: CI entry point for Dakota. Routes agents to the right CI skill fast: workflow map, GitHub Actions tooling failures, e2e/boot checks, release promotion, or merge-queue recovery. Use when the task mentions CI, Actions, publish, promote, release, smoke, boot-check, or startup_failure.
+name: ci-reference
+description: Historical Dakota CI deep cuts and accumulated failure patterns. Use only after the focused CI skills when you need long-tail prior art or exact past failure signatures.
 metadata:
   context7-sources:
     - /websites/github_en_actions
     - /bootc-dev/bootc
 ---
 
-# CI Router
+# CI Reference
 
 ## Overview
 
-This is the **load-first** CI skill. Do not dump the whole CI history into context up front.
-Load this file, identify the failure class, then load only the next skill you need.
+This is the **deep-cut archive**, not the load-first CI skill.
+Route through `ci.md` first, then come here only when the focused skills do not cover the edge case.
 
 ## When to Use
 
-Use this skill when the task mentions:
-- GitHub Actions failures
-- `startup_failure`, `action_required`, missing jobs, or flaky checks
-- `publish.yml`, `build.yml`, `promote-testing-to-main.yml`, `execute-release.yml`
-- boot-check, smoke, testsuite, SBOM, or GHCR publish problems
-- merge queue, promotion PRs, or stable release flow
+- You have already classified the CI failure and still need prior-art details
+- You need an older exact failure signature, workaround, or recovery sequence
+- You are extracting a long-tail lesson into a newer focused skill
 
 ## When NOT to Use
 
-- Element build or packaging failures inside BST → `debugging.md`
-- BST syntax, element kinds, or project layout → `buildstream.md`
-- OCI image contents or layer assembly → `oci-layers.md`
-- Normal PR review → `pr-review.md`
+- Diagnosing an individual element build failure → `debugging.md`
+- Writing or modifying `.bst` element files → `buildstream.md`
+- Understanding what packages flow into the OCI image → `oci-layers.md`
 
-## Core Process
+## Quick Reference
 
-1. **Classify the failure before reading logs.**
-   - *Which workflow?* `build`, `publish`, `promote`, `release`, `e2e`, `merge queue`
-   - *Which phase?* trigger, setup, reusable workflow call, build/export, boot, smoke, promotion
-2. **Load one next skill, not five.**
-   - Need workflow/trigger map → `workflow-map.md`
-   - Need reusable workflow / permissions / cache-dir weirdness → `ci-tooling.md`
-   - Need boot-check / smoke / testsuite behavior → `e2e-ci.md`
-   - Need `:testing` → `:stable` / release flow → `release-promotion.md`
-   - Need stale PR or queue cleanup → `merge-queue.md`
-3. **Read the actual workflow file before editing.**
-4. **Verify tool behavior via Context7** for GitHub Actions or bootc when changing syntax/flags.
-5. **Write back the lesson** to the narrowest skill file, not this router, unless the routing itself changed.
-
-## Skill Selection Table
-
-| If the problem is about... | Load next |
+| What | Value |
 |---|---|
-| Which workflow owns this stage? | `workflow-map.md` |
-| `startup_failure`, `jobs: []`, token scopes, reusable workflows | `ci-tooling.md` |
-| `actions/cache`, podman bind mounts, runner/runtime quirks | `ci-tooling.md` |
-| boot-check, QEMU, `bootc install to-disk`, smoke placement | `e2e-ci.md` |
-| promotion PRs, release gate, `action_required`, stable release | `release-promotion.md` |
-| conflicting chore PRs, stale queue branches | `merge-queue.md` |
-| historical edge cases and deep cuts | `ci-reference.md` |
+| Workflow file | `.github/workflows/build.yml` |
+| Runner | `ubuntu-24.04` (standard GitHub-hosted) |
+| Build target | `oci/bluefin.bst` |
+| Build timeout | 330 min (job: 360 min) |
+| Remote cache server | `cache.projectbluefin.io:11002` |
+| Cache auth | mTLS — `CASD_CLIENT_CERT` (repo variable) + `CASD_CLIENT_KEY` (secret) |
+| Published image | `ghcr.io/projectbluefin/dakota:{testing,latest,stable}` and `:$SHA` |
+| Build logs artifact | `buildstream-logs-x86_64-<variant>` (7-day retention) |
+| Trigger (validate) | `pull_request` — `bst show --deps all`, no CAS |
+| Trigger (build) | `merge_group`, `workflow_dispatch` (no daily schedule) |
+**Nightly schedule rationale** — no longer applicable; schedule trigger was removed in favour of continuous builds on every merge.
 
-## Common Rationalizations
+**Merge queue path:** `build` fires on `merge_group` — full OCI build, real CI gate before merge. On success, `publish.yml` immediately promotes the new image to `:testing`.
 
-| Rationalization | Reality |
+## Workflow Files
+
+| File | Role |
 |---|---|
 | `.github/workflows/build.yml` | BST build + push artifacts to remote CAS. Fires on `merge_group` and `workflow_dispatch` only (no schedule). Does NOT push to GHCR directly. |
 | `.github/workflows/publish.yml` | 3-stage pipeline: setup → publish → promote. Pulls artifact from CAS, exports OCI, pushes `:$sha`, signs, attests, then immediately promotes to `:testing` on every successful merge. No e2e gate — that lives only in the weekly promotion. |
@@ -1589,25 +1576,22 @@ belongs in the action, not scattered across consumers.
 
 `actions/cache` only *restores* an existing archive; on a cache miss it does
 nothing and leaves the target path absent. If a subsequent `podman run` uses
-bind mounts such as `-v "${HOME}/.cache/pip:/root/.cache/pip:rw"` or
-`-v "${HOME}/.cache/buildstream:/root/.cache/buildstream:rw"` and the host-side
-directory does not exist, podman exits **125** (container failed to start)
-before any command runs.
+`-v "${HOME}/.cache/pip:/root/.cache/pip:rw"` and the host-side directory
+does not exist, podman exits **125** (container failed to start) before any
+command runs.
 
 ```
-Error: statfs /home/runner/.cache/buildstream: no such file or directory
+Error: statfs /home/runner/.cache/pip: no such file or directory
 error: recipe `sbom` failed with exit code 125
 ```
 
-**Fix:** `mkdir -p` every host cache directory in the Justfile recipe
-immediately before the `podman run`, not in the workflow step. This makes the
-fix unconditional regardless of where `just sbom` is invoked:
+**Fix:** `mkdir -p` the directory in the Justfile recipe immediately before
+the `podman run`, not in the workflow step. This makes the fix unconditional
+regardless of where `just sbom` is invoked:
 
 ```bash
-mkdir -p "${HOME}/.cache/buildstream" "${HOME}/.cache/pip"
-podman run --rm ... \
-  -v "${HOME}/.cache/buildstream:/root/.cache/buildstream:rw" \
-  -v "${HOME}/.cache/pip:/root/.cache/pip:rw" ...
+mkdir -p "${HOME}/.cache/pip"
+podman run --rm ... -v "${HOME}/.cache/pip:/root/.cache/pip:rw" ...
 ```
 
 **Rule:** Any `podman run -v HOST_PATH:...` where `HOST_PATH` is a cache
@@ -1629,7 +1613,7 @@ not AT-SPI tests).
 
 | Job | Gate type | What it checks | Target time |
 |---|---|---|---|
-| `boot-check` | **Hard** — blocks promote | bootc install → boot → SSH → GDM not-failed | ~10 min |
+| `boot-check` | **Hard** — blocks promote | bootc install → boot → SSH → `gdm active` | ~10 min |
 | `smoke` | Observational | Full testsuite smoke suite (AT-SPI etc.) | ~80 min |
 
 The `promote` job gates on `boot-check.result == 'success'`. Smoke
@@ -1638,37 +1622,8 @@ removing it from `needs` is what makes it truly non-blocking (an `if:`
 condition alone is insufficient; the job still waits if the dep is in `needs`).
 
 **Rule:** The per-merge gate should always be a deterministic boot
-check (SSH reachable + GDM not-crashed). The full AT-SPI suite belongs
-in the weekly pre-stable gate, not the per-merge pre-testing gate.
-
-**GDM headless caveat:** QEMU runs with `-display none` (no display
-device). GDM will be `inactive` in this environment — that is expected
-behavior, not a regression. The health check uses
-`systemctl show gdm.service --property=ActiveState` and fails only if
-the state is `failed` (GDM crashed). `inactive` / `activating` are
-both acceptable. Using `systemctl is-active gdm.service` was wrong:
-it exits 3 on `inactive`, which triggers `set -e` and blocks every
-promote run regardless of image health.
-
-### Observational reusable-workflow jobs must be split out of publish.yml (2026-06-16)
-
-`continue-on-error` is **not** supported on jobs that call a reusable workflow
-via `uses:`. That means an observational suite like `smoke` still makes the
-parent workflow red if it lives inside `publish.yml`, even when `promote` no
-longer depends on it.
-
-**Symptom:** publish pipeline lands `:testing` successfully, but
-`Publish Bluefin dakota` still ends red because the observational smoke job
-fails inside the same workflow run.
-
-**Fix:** move observational reusable-workflow jobs into a separate workflow
-triggered by `workflow_run` from the successful publish pipeline. Keep the
-hard gate (`boot-check`) in `publish.yml`; keep the flaky/slow signal in the
-follow-up workflow.
-
-**Rule:** If a GitHub Actions job is both (a) observational and
-(b) implemented as a reusable-workflow call, it does not belong in the
-critical publish workflow.
+check (SSH reachable + GDM active). The full AT-SPI suite belongs in
+the weekly pre-stable gate, not the per-merge pre-testing gate.
 
 ### OSTREE_PATH in boot-check kernel args must come from the BLS entry (2026-06-13)
 
@@ -1800,13 +1755,13 @@ type = "xfs"
 
 No behaviour change for users — xfs was always the implicit default. This makes it explicit.
 
-### `bootc install to-disk` correct approach for CI loop devices (2026-06-17)
+### `bootc install to-disk` — correct approach for CI loop devices (2026-06-16)
 
-**Use `--via-loopback` with the raw file path, and let the image's own bootc
-install config provide the xfs rootfs + systemd bootloader defaults.**
+**Use `--via-loopback` with the raw file path.** This is the documented bootc
+pattern for disk images. bootc manages the loop device lifecycle internally,
+eliminating all host-side partition-node race conditions.
 
-Working reference: `projectbluefin/testsuite/.github/actions/gnome-e2e/action.yml`
-Source docs: https://github.com/bootc-dev/bootc/blob/main/docs/src/bootc-install.md
+Source: https://github.com/bootc-dev/bootc/blob/main/docs/src/bootc-install.md
 
 ```bash
 fallocate -l 30G disk.raw
@@ -1834,21 +1789,11 @@ if ! sudo blkid "${LOOP}p3" &>/dev/null; then
 fi
 ```
 
-Dakota already ships the real install defaults in `files/bootc-install/00-defaults.toml`:
-
-```toml
-[install]
-bootloader = "systemd"
-
-[install.filesystem.root]
-type = "xfs"
-```
-
-**Why this shape matters:** `--via-loopback` keeps bootc in control of the loop
-lifecycle, avoiding host-side partition-node races. But the workflow should not
-re-specify `--generic-image` or `--filesystem xfs` ad hoc — that drifted away
-from the working testsuite flow and reintroduced `Creating rootfs: No such file
-or directory (os error 2)` in Dakota publish boot-checks on 2026-06-17.
+**Why `--via-loopback` works:** bootc creates and manages the loop device
+inside the container where it controls the full lifecycle. Partition nodes
+appear correctly because bootc owns the device end-to-end. After the container
+exits, attaching with `-P` on a file that already has a partition table triggers
+a synchronous kernel scan — nodes are ready immediately.
 
 **Do NOT:**
 - Pre-create a host loop device and pass it as a block device path — bootc's
@@ -1857,105 +1802,7 @@ or directory (os error 2)` in Dakota publish boot-checks on 2026-06-17.
   removing the nodes you just created.
 - Pre-partition with `sfdisk` before running bootc — bootc refuses with
   "Detected existing partitions".
-- Add `--generic-image` or `--filesystem xfs` back into the CI boot-check
-  command; Dakota already gets xfs/systemd from image install config.
 
 **Note:** The boot-check gate never passed from PR #849 (2026-06-13) through
-PR #895 (2026-06-16) due to iterating on the wrong approach. The first stable
-shape was `--via-loopback`; the 2026-06-17 regression came from drifting away
-from the working testsuite invocation, not from a need to go back to host-side
-loop handling.
-
-### `multi-user.target` timing race in boot-check (2026-06-19)
-
-**Symptom:** boot-check fails immediately after SSH becomes reachable with
-`exit code 3` from `systemctl is-active multi-user.target`, even though the
-image boots and SSH works.
-
-**Cause:** `systemctl is-active` exits 3 for both `inactive` and `activating`.
-SSH becomes reachable (sshd started) while systemd is still processing the rest
-of `multi-user.target`'s dependency graph. The check fires before the target
-finishes activating.
-
-**Fix:** Replace the single `is-active` call with a retry loop:
-
-```bash
-for _i in $(seq 1 6); do
-  if "${SSH[@]}" sudo systemctl is-active multi-user.target 2>/dev/null; then
-    break
-  fi
-  [[ ${_i} -lt 6 ]] || { echo "ERROR: multi-user.target not active after 60s"; exit 1; }
-  echo "  not yet active (attempt ${_i}/6), retrying in 10s…"
-  sleep 10
-done
-```
-
-**Log trap:** The GHA log interleaves the step's script preview with its output.
-In a failed boot-check run, lines showing `is-active gdm.service` in the preview
-column appear alongside `inactive` + `exit code 3` in the output column — making
-it look like GDM failed. The actual failing line is always
-`systemctl is-active multi-user.target` immediately above. Verify by checking
-which `==>` echo precedes the `inactive` output, not which command appears in the
-script preview.
-
----
-
-### Mergeraptor merges on `next` do not fire `push` events (2026-06-19)
-
-**Symptom:** Junction-bump PRs merge into `next` but `build.yml` never triggers.
-The branch can go days without a build despite multiple commits landing.
-
-**Cause:** Mergeraptor uses the GitHub API to merge PRs. Those merges do not
-create a `push` event that triggers GitHub Actions workflows.
-
-**Fix:** Add a scheduled dispatcher workflow (`nightly-next-build.yml`) that
-calls `gh workflow run build.yml --ref next` once per night. Set it to 03:00 UTC
-— after the 20:00 UTC junction tracker and its auto-merge window, and before US
-daytime when `main` builds compete for the BST remote executor.
-
-```yaml
-on:
-  schedule:
-    - cron: '0 3 * * *'
-jobs:
-  dispatch:
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - run: gh workflow run build.yml --repo "${{ github.repository }}" --ref next
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
----
-
-### `sync-main-to-testing` does not need a GitHub App token (2026-06-19)
-
-`reusable-sync-branches.yml` declares `GH_TOKEN` as `required: false` and falls
-back to `github.token`. The `promote` job in `publish.yml` already fast-forwards
-the `testing` branch with `GITHUB_TOKEN` on every publish cycle — proof that no
-App token is needed. Remove the `generate-token` job and both `BLUEFINBOT_*`
-secret references entirely.
-
-| "I'll just load the giant CI file." | That's how agents waste context. Route first, then go narrow. |
-| "The workflow name tells me enough." | Wrong. Trigger type, branch filter, and reusable call semantics are usually the bug. |
-| "Smoke failed, publish is broken." | Not necessarily. First check whether the failure is in the hard gate or in observational signal. |
-| "I know GitHub Actions permissions from memory." | Good way to ship another `startup_failure`. Verify with Context7. |
-
-## Red Flags
-
-- Reading `ci-reference.md` before classifying the failure
-- Editing reusable-workflow callers without checking top-level `permissions:`
-- Treating AT-SPI smoke as the same class of signal as boot-check
-- Changing publish/promotion behavior without mapping the branch and trigger path first
-- Adding more prose to a router instead of splitting a focused skill
-
-## Verification
-
-After using this router, confirm:
-- [ ] You identified the exact CI failure class before deep reading
-- [ ] You loaded only the next relevant skill file
-- [ ] You read the actual workflow being changed
-- [ ] Any GitHub Actions or bootc syntax change was verified via Context7
-- [ ] The lesson landed in a focused skill, not as more sprawl in the router
+PR #895 (2026-06-16) due to iterating on the wrong approach. The fix was
+always to use `--via-loopback` as documented. The image works on real hardware.

--- a/docs/skills/ci-tooling.md
+++ b/docs/skills/ci-tooling.md
@@ -1,0 +1,127 @@
+---
+name: ci-tooling
+description: GitHub Actions failure patterns for Dakota: reusable workflow permissions, startup_failure, actions/cache bind-mount traps, token suppression, and ruleset interactions. Use when workflows do not start, show jobs: [], or fail before the real work begins.
+metadata:
+  context7-sources:
+    - /websites/github_en_actions
+---
+
+# CI Tooling Failures
+
+## Overview
+
+Most Dakota CI pain is not "the build failed". It is **GitHub Actions plumbing**:
+reusable workflow calls, token scopes, cache directories, rulesets, and trigger semantics.
+This skill is for failures that happen **before** the image logic.
+
+## When to Use
+
+Use when you see:
+- `startup_failure`
+- `jobs: []`
+- reusable workflow call jobs that never start
+- `actions/cache` + podman bind-mount weirdness
+- PRs created by automation that do not trigger checks
+- merge queue or ruleset behavior that makes a valid workflow look broken
+
+## When NOT to Use
+
+- Need to know which workflow should have run → `workflow-map.md`
+- boot-check or smoke failures after the workflow already started → `e2e-ci.md`
+- stable promotion flow, release gates, or action-required promotion PRs → `release-promotion.md`
+
+## Core Process
+
+1. **Check whether the workflow created jobs at all.**
+   - `gh run view <id> --json jobs,conclusion`
+   - If `jobs: []`, treat it as workflow syntax / permission / accessibility first.
+2. **For reusable workflow callers, inspect top-level `permissions:` first.**
+   - Caller permissions set the token ceiling.
+   - Nested workflows can only keep or reduce permissions, never elevate them.
+3. **Check job type before applying a fix.**
+   - `uses:` jobs behave differently from normal `runs-on:` jobs.
+4. **For podman bind mounts, ensure host cache dirs exist before the step.**
+5. **Only after the plumbing is sound, debug the actual build/test logic.**
+
+## High-Value Failure Patterns
+
+### 1) Reusable workflow token starvation
+
+If a thin caller uses `jobs.<id>.uses`, the caller's top-level `permissions:`
+cap the token for the entire reusable workflow chain.
+
+**Bad pattern:**
+```yaml
+permissions: {}
+
+jobs:
+  gate:
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: org/repo/.github/workflows/reusable.yml@v1
+```
+
+**Good pattern:**
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+  packages: read
+  issues: write
+
+jobs:
+  gate:
+    uses: org/repo/.github/workflows/reusable.yml@v1
+```
+
+Use this first when a reusable caller shows `startup_failure` and `jobs: []`.
+
+### 2) `actions/cache` restores content, not directories
+
+On a cold miss, `actions/cache` does not create the target path.
+If podman bind-mounts a missing host path, the container fails to start.
+
+```bash
+mkdir -p "${HOME}/.cache/buildstream" "${HOME}/.cache/pip"
+podman run --rm \
+  -v "${HOME}/.cache/buildstream:/root/.cache/buildstream:rw" \
+  -v "${HOME}/.cache/pip:/root/.cache/pip:rw" ...
+```
+
+### 3) Bot-created PRs with `GITHUB_TOKEN` suppress `pull_request`
+
+If a workflow creates a PR using `GITHUB_TOKEN`, GitHub suppresses recursive
+`pull_request` events. Use a GitHub App token for bot PR creation when checks
+must fire on the new PR.
+
+### 4) Required checks must exist on `pull_request`
+
+A check that only runs on `merge_group` cannot satisfy a PR ruleset. If the
+merge queue button is blocked, verify the required checks are PR-visible.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I set job-level permissions, so the reusable workflow can write." | Not if the caller's top-level permissions deny it. |
+| "actions/cache handles the path for me." | It handles archives, not directory creation. |
+| "The workflow is broken because it has no logs." | `jobs: []` usually means the workflow never got past validation. |
+| "I'll fix it by adding more permissions everywhere." | Wrong. Add the minimal top-level superset the reusable chain actually needs. |
+
+## Red Flags
+
+- `permissions: {}` on a reusable workflow caller
+- `startup_failure` with no jobs inspected
+- podman `statfs ... no such file or directory`
+- trying to use `continue-on-error` to tame a reusable-workflow call job
+- relying on `GITHUB_TOKEN` for bot PRs that need PR checks to fire
+
+## Verification
+
+- [ ] You checked whether the run had `jobs: []`
+- [ ] You inspected top-level caller permissions before editing nested jobs
+- [ ] Any podman bind-mounted cache dir is created explicitly
+- [ ] Required checks are aligned with `pull_request` visibility
+- [ ] The fix reduces CI ambiguity instead of adding more magic

--- a/docs/skills/debugging.md
+++ b/docs/skills/debugging.md
@@ -1,155 +1,147 @@
 ---
 name: debugging
-description: Diagnoses BST element build failures, YAML errors, source fetch failures, compile failures, and image build failures. Load when a `just bst build` fails or when reading CI build logs.
+description: Debug Dakota BuildStream build failures. Use when `just bst build` fails, `bst show` errors, source fetch breaks, or a package builds but does not land correctly in the image.
+metadata:
+  context7-sources:
+    - /apache/buildstream
 ---
 
 # Debugging Build Failures
 
-Load when a BST element build fails, or when diagnosing element errors from CI logs.
+## Overview
+
+This skill is for **element-level debugging**.
+Use it when the package/build graph is the problem, not when GitHub Actions plumbing is the problem.
+
+## When to Use
+
+Use when:
+- `just bst build ...` fails
+- `just bst show ...` errors
+- source fetch or ref tracking fails
+- compile/install/staging steps fail
+- the element builds but the final image is missing content
 
 ## When NOT to Use
 
-- Diagnosing CI pipeline failures (cache, GHCR, mTLS) → `ci.md`
-- Writing or modifying element files → `buildstream.md`
-- Debugging OCI layer content issues → `oci-layers.md`
+- CI trigger, token, cache, or workflow problems → CI skills
+- Writing a new element from scratch → `add-package.md` or `buildstream.md`
+- OCI layer design questions → `oci-layers.md`
+
+## Core Process
+
+1. **Classify the failure first.**
+   - graph/YAML
+   - fetch/ref
+   - compile
+   - install/staging
+   - image composition
+2. **Use the cheapest inspection command first.**
+   - `bst show` before `bst build`
+   - `artifact log` before guessing
+   - `artifact list-contents` before blaming compose layers
+3. **Reproduce in the sandbox if needed.**
+4. **Only escalate to full-image build after the element is clean.**
 
 ## Quick Reference
 
 | Action | Command |
-|--------|---------|
+|---|---|
 | Build one element | `just bst build bluefin/<name>.bst` |
 | Enter build sandbox | `just bst shell --build bluefin/<name>.bst` |
-| Inspect element sources | `just bst show bluefin/<name>.bst` |
-| Find what depends on an element | `grep -r "<name>" elements/` |
-| View last build log | `just bst artifact log bluefin/<name>.bst` |
-| List files in built element | `just bst artifact list-contents bluefin/<name>.bst` |
+| Inspect sources/graph | `just bst show bluefin/<name>.bst` |
+| View build log | `just bst artifact log bluefin/<name>.bst` |
+| List built files | `just bst artifact list-contents bluefin/<name>.bst` |
 | Delete cached failure | `just bst artifact delete bluefin/<name>.bst` |
-| Full image build (after fixing) | `just build` |
+| Full image build after fix | `just build` |
 
-## Debugging Workflow
+## Failure Classes
 
-1. **Read the build log** — The exact failure is in the last 20-50 lines. Look for `[FAILURE]` lines.
+### 1) Graph / YAML errors
 
-2. **Enter build sandbox** — Drop into the BST sandbox to reproduce manually:
-   ```bash
-   just bst shell --build bluefin/<name>.bst
-   ```
-   Inside the sandbox: run the failing configure/build command step-by-step.
+Symptom: `Error loading project` before any real build starts.
 
-3. **Check BST show output** — Verify all deps resolve and the element parses correctly:
-   ```bash
-   just bst show bluefin/<name>.bst
-   ```
-   A `Error loading project` here is a YAML/option error, not a build failure.
+Typical causes:
+- bad indentation
+- invalid option names or types
+- missing source alias
+- malformed element structure
 
-4. **List element content** — Verify installed files after a successful build:
-   ```bash
-   just bst artifact list-contents bluefin/<name>.bst
-   ```
+Start with:
+```bash
+just bst show bluefin/<name>.bst
+```
 
-## Common Failures
+### 2) Source fetch failures
 
-### YAML / Option Errors
+Typical causes:
+- stale `ref:`
+- moved upstream URL
+- tarball layout mismatch
 
-Symptom: `Error loading project` — element never starts building.
+Useful fixes:
+- `just bst source track bluefin/<name>.bst`
+- add/update alias in `include/aliases.yml`
+- use `base-dir: ""` for tarballs without a wrapping directory
 
-| Cause | Fix |
-|-------|-----|
-| Hyphenated option name | Options only allow alphanumeric + underscores (`my_option`, not `my-option`) |
-| Invalid type for `options:` | Valid types: `bool`, `enum`, `flags`, `element-mask`, `arch`, `os` (not `string`) |
-| Indentation error | Run `just bst show` to pinpoint the line |
-| Missing alias | Add to `include/aliases.yml` |
+### 3) Compile failures
 
-### Source Fetch Failures
+Typical causes:
+- missing build dependency
+- upstream path assumptions (`/usr/sbin`, `/lib`)
+- pkg-config visibility problems
 
-| Cause | Fix |
-|-------|-----|
-| Wrong `ref:` hash | Run `just bst source track bluefin/<name>.bst` to update |
-| URL changed upstream | Update URL + alias in `include/aliases.yml` |
-| Tarball has no wrapping directory | Add `base-dir: ""` to `kind: tar` source |
+### 4) Install / staging failures
 
-### Compile Failures
+Typical causes:
+- missing `strip-binaries: ""` for non-ELF payloads
+- forgot `mkdir -p` before symlink or install path creation
+- overlap conflict
+- files landing outside `/usr`
 
-| Cause | Fix |
-|-------|-----|
-| Missing build dep | Add to `build-depends:` in element YAML |
-| Wrong path assumption | GNOME OS is merged-usr; `/usr/sbin` → `/usr/bin`, `/lib` → `/usr/lib` |
-| `/usr/sbin` hardcoded in upstream | Patch the configure or Makefile |
-| Autotools can't find pkg | Check `PKG_CONFIG_PATH` and that the dep is in `build-depends:` |
+### 5) Image composition failures
 
-### Install / Staging Failures
+Typical causes:
+- element never wired into `deps.bst`
+- downstream compose cache did not invalidate
+- OCI layer is `stack` when it should be `compose`
 
-| Cause | Fix |
-|-------|-----|
-| Missing `strip-binaries: ""` | Required for non-ELF elements (fonts, pre-built binaries, configs) |
-| `mkdir` before `ln -sf` missing | Always `mkdir -p` before any symlink creation |
-| Overlap conflict | Add conflicting path to `overlap-whitelist:` |
-| File installed outside `/usr` | GNOME OS: everything must be under `/usr`. Patch install paths. |
-
-### Image Build Failures
-
-| Cause | Fix |
-|-------|-----|
-| New package not appearing in image | `deps.bst` cache invalidation bug — see BST Weak-Key Caching Bug in `buildstream.md` |
-| `ldconfig` error in OCI script | Run `ldconfig -r %{install-root}` after all installs, before `build-oci` |
-| Missing compose element content | OCI layer must be `kind: compose`, not `kind: stack` |
-
-## BST Shell Tips
+## Sandbox Workflow
 
 ```bash
-# Enter build sandbox for failing element
 just bst shell --build bluefin/<name>.bst
-
-# Inside the sandbox, run the failing step manually:
-./configure --prefix=/usr   # or whatever configure step is failing
-make -j$(nproc)
-make install DESTDIR=/path/to/staging
-
-# Check what's already installed in staging:
-find %{install-root} -type f | head -50
-
-# Check pkg-config sees expected deps:
-pkg-config --list-all | grep <libname>
+# inside the sandbox, rerun the failing configure/build/install step
 ```
+
+Use the sandbox when you know which phase failed and need to replay it interactively.
+Do not open the sandbox before you even know whether the graph parses.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "The build failed, so I need the sandbox immediately." | Not if `bst show` is already telling you it's YAML. |
+| "CI failed, so this must be a CI problem." | Many CI failures are just element failures surfacing remotely. Classify first. |
+| "The package is missing from the image, so the build must have failed." | It may have built fine and never been wired into the stack or compose step. |
+| "I'll skip straight to a full image build." | That's the slowest possible feedback loop. |
+
+## Red Flags
+
+- opening the sandbox before reading the log
+- debugging compile flags when the graph does not even parse
+- assuming missing image content means source fetch failure
+- rerunning full image builds for single-element syntax mistakes
+
+## Verification
+
+- [ ] The failure class is identified before deep debugging
+- [ ] `bst show` is clean before sandbox work begins
+- [ ] Logs or artifact contents were inspected before guessing
+- [ ] Single-element debugging was exhausted before full image rebuilds
+- [ ] The fix explains why the failure happened, not just how it was silenced
 
 ## Lessons Learned
 
 ### `Error loading project` before any build step = YAML error, not a build failure (2026-06-07)
 
 When BST exits with `Error loading project` before any `[build]` output appears, the element has a YAML/option error — it never even started building. Run `just bst show bluefin/<name>.bst` (no build) to pinpoint the exact line. Common causes: hyphenated option names, wrong option type, missing alias, bad indentation. Do not reach for `just bst shell` until `bst show` exits cleanly.
-
-### Delete the cached artifact before retrying a failed install step (2026-06-07)
-
-After fixing an `install-commands` error, BST may still report "cache hit" and skip the re-run. This is because the failed-build artifact is cached. Delete it before retrying:
-
-```bash
-just bst artifact delete bluefin/<name>.bst
-just bst build bluefin/<name>.bst
-```
-
-### Overlap conflicts block the final image build even when individual elements succeed (2026-06-07)
-
-When two elements install the same file path, `oci/bluefin.bst` fails with an overlap error even though each element builds fine individually. Fix by adding the conflicting path to `overlap-whitelist:` in `project.conf` or in the element's `public: bst:` section. Use `just bst show --format '%{name}: %{overlap-whitelist}' oci/bluefin.bst` to inspect current whitelist state.
-
-
-### meson `dependency("systemd")` fails with systemd-libs in build-depends (2026-06-07)
-
-If a meson element fails with:
-
-```
-meson.build:N: ERROR: Dependency "systemd" not found, tried pkgconfig
-```
-
-The element has `freedesktop-sdk.bst:components/systemd-libs.bst` in `build-depends`
-but the upstream `meson.build` calls `dependency('systemd')`, which needs `systemd.pc`
-— not `libsystemd.pc`. `systemd-libs.bst` only provides the library, not the pkgconfig
-descriptor for the systemd service itself.
-
-**Fix:** Replace `systemd-libs.bst` with `systemd.bst` in `build-depends`:
-
-```yaml
-build-depends:
-- freedesktop-sdk.bst:components/systemd.bst   # was systemd-libs.bst
-```
-
-`systemd.bst` ships `systemd.pc` and is a superset of `systemd-libs.bst`.

--- a/docs/skills/e2e-ci.md
+++ b/docs/skills/e2e-ci.md
@@ -1,0 +1,110 @@
+---
+name: e2e-ci
+description: Dakota boot and smoke gate patterns. Covers inline boot-check, testsuite usage, and where observational smoke belongs. Use when changing boot-check, QEMU, publish smoke, or testsuite wiring.
+metadata:
+  context7-sources:
+    - /bootc-dev/bootc
+    - /websites/github_en_actions
+---
+
+# E2E / Boot CI
+
+## Overview
+
+Dakota uses **two different signals** after publish:
+- **boot-check** — hard gate, fast, deterministic, blocks promotion
+- **smoke** — observational, slower, flaky in VMs, should not block publish
+
+Mixing them is how agents turn healthy publishes into red pipelines.
+
+## When to Use
+
+Use when working on:
+- `.github/workflows/publish.yml` boot-check logic
+- `.github/workflows/publish-smoke.yml`
+- `run-testsuite.yml`
+- inline QEMU boot flows
+- `bootc install to-disk` usage in CI
+- decisions about what should or should not block `:testing`
+
+## When NOT to Use
+
+- Generic workflow trigger/ownership questions → `workflow-map.md`
+- Reusable workflow token issues or cache-dir failures → `ci-tooling.md`
+- Stable promotion and release gating → `release-promotion.md`
+
+## Core Process
+
+1. **Choose the right gate class first.**
+   - Hard gate: boot/install/SSH/GDM sanity → inline boot-check
+   - Observational: AT-SPI, UX drift, slow desktop behavior → testsuite smoke
+2. **Keep the hard gate small and deterministic.**
+   - install image
+   - boot VM
+   - wait for SSH
+   - verify `multi-user.target` and `gdm.service`
+3. **Keep observational smoke outside the critical publish workflow.**
+4. **Use the documented bootc raw-image pattern.**
+5. **Use the testsuite wrapper workflow, not ad-hoc duplicate wiring.**
+
+## Hard Gate Pattern
+
+For raw disk images in CI, follow the documented bootc path:
+
+```bash
+fallocate -l 30G disk.raw
+sudo podman run --rm --privileged --pid=host --ipc=host \
+  --security-opt label=type:unconfined_t \
+  -v /dev:/dev \
+  -v /var/lib/containers:/var/lib/containers \
+  -v "$(pwd):/data" \
+  "${IMAGE}" bootc install to-disk \
+    --generic-image \
+    --filesystem xfs \
+    --via-loopback /data/disk.raw \
+    --wipe
+```
+
+Then attach the resulting raw file on the host and continue with QEMU boot checks.
+
+## Observational Smoke Rule
+
+A reusable-workflow call job cannot be made truly non-blocking with
+`continue-on-error`. If the smoke suite lives inside `publish.yml`, its failure
+still paints the publish workflow red.
+
+**Rule:** run smoke in a separate follow-up workflow triggered by successful
+publish, e.g. `publish-smoke.yml`.
+
+## Testsuite Rule
+
+Always call the local wrapper workflow:
+- `run-testsuite.yml`
+
+Do **not** wire `projectbluefin/testsuite` directly from every caller. Pin once
+in the wrapper, then inherit it everywhere.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "Smoke is green locally, so it can gate publish." | VM timing says otherwise. Keep publish gates deterministic. |
+| "I'll just make smoke optional with `continue-on-error`." | Not on a reusable-workflow call job. Split the workflow instead. |
+| "bootc already knows the defaults; I can skip the explicit flags." | CI has punished that repeatedly. Use the documented raw-image path. |
+| "The testsuite workflow is easy enough to copy here." | Duplicate wiring drifts. Use the wrapper. |
+
+## Red Flags
+
+- AT-SPI smoke in the hard publish path
+- host loop-device hand-rolling when bootc already supports `--via-loopback`
+- direct calls to upstream testsuite from multiple workflows
+- red publish runs caused by observational smoke
+- boot-check growing into a second full e2e suite
+
+## Verification
+
+- [ ] The hard gate only checks boot/install sanity
+- [ ] Smoke runs outside the critical publish workflow
+- [ ] `bootc install to-disk` uses the documented raw-image pattern
+- [ ] Testsuite calls go through `run-testsuite.yml`
+- [ ] The resulting pipeline is faster and more deterministic, not more ambitious

--- a/docs/skills/installer.md
+++ b/docs/skills/installer.md
@@ -1,11 +1,32 @@
 ---
+
 name: installer
 description: bootc-installer (GTK4/Adwaita Flatpak) for Dakota. Covers two-component architecture (Python GUI + Go fisherman backend), dev setup, demo mode, and the dakota/dakota-iso boundary. Load when working on installer UI, recipe, or firstboot installer-cleanup behavior.
+metadata:
+  context7-sources:
+    - /bootc-dev/bootc
 ---
 
 # Installer (bootc-installer)
 
 Load when working on the Bluefin Dakota installer or debugging ISO installer integration.
+
+## When to Use
+
+Use when working on `projectbluefin/bootc-installer`, the Dakota ISO installer path, firstboot cleanup, or the boundary between the desktop image and the installer experience.
+
+## When NOT to Use
+
+- General Dakota package/image work unrelated to install flows
+- CI-only release pipeline debugging → CI skills
+- BST element authoring unrelated to installer behavior
+
+## Core Process
+
+1. Confirm whether the change belongs in `bootc-installer`, `dakota`, or `dakota-iso`.
+2. Respect the two-component split: Python GTK frontend vs Go backend.
+3. Preserve the repo boundary; do not hide installer policy inside the wrong repo.
+4. Validate demo mode / firstboot cleanup / integration points explicitly.
 
 ## What It Is
 
@@ -98,6 +119,28 @@ git remote add upstream https://github.com/tuna-os/tuna-installer
 git fetch upstream
 git merge upstream/main  # or cherry-pick relevant commits
 ```
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "It's all installer behavior, so I can fix it in any repo." | Wrong boundary decisions are how installer bugs become factory bugs. |
+| "The GUI and backend are basically one thing." | They fail differently and must be debugged that way. |
+| "A firstboot cleanup tweak is harmless." | Those are exactly the changes that strand bad state on installed systems. |
+
+## Red Flags
+
+- Mixing Dakota image policy with installer UI concerns
+- Changing firstboot cleanup without tracing its full lifecycle
+- Debugging the GTK frontend when the bug is clearly in fisherman/backend behavior
+- Treating ISO integration as if it were normal desktop runtime behavior
+
+## Verification
+
+- [ ] The change was made in the correct repo/layer
+- [ ] Frontend/backend ownership is clear
+- [ ] Firstboot/install cleanup behavior was explicitly considered
+- [ ] The integration path with Dakota or dakota-iso is still clear to future agents
 
 ## Lessons Learned
 

--- a/docs/skills/local-ota.md
+++ b/docs/skills/local-ota.md
@@ -1,15 +1,31 @@
 ---
+
 name: local-ota
 description: Tests bootc upgrades via a local zot registry — QEMU VM or physical hardware. Covers registry setup, insecure registry configuration, and the build-push-upgrade loop. Load when validating image changes without pushing to GHCR.
+metadata:
+  context7-sources:
+    - /bootc-dev/bootc
 ---
 
 # Local & Hardware OTA Testing
 
 Load when testing bootc upgrades via a local registry — QEMU VM or physical hardware.
 
+## When to Use
+
+Use when you need to validate a Dakota image upgrade locally before GHCR publish, reproduce bootc upgrade behavior on hardware, or test a boot path with a local registry.
+
 ## When NOT to Use
 
 - CI pipeline questions → `ci.md`
+
+## Core Process
+
+1. Start a local registry.
+2. Build and push the image to that registry.
+3. Point a VM or hardware target at the registry.
+4. Run `bootc upgrade` and reboot.
+5. Verify the upgraded system actually reaches the expected graphical state.
 
 ## Overview
 
@@ -111,6 +127,28 @@ sudo podman start egg-registry
 ```
 
 ---
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "CI passed, so I don't need local OTA." | This repo explicitly values real upgrade evidence. |
+| "A local registry is too much setup for one test." | It's cheaper than shipping a broken upgrade path. |
+| "Booted once" means success. | Success is upgrade + reboot + expected runtime state. |
+
+## Red Flags
+
+- Testing image contents without exercising `bootc upgrade`
+- Declaring success without a reboot
+- Using local host state as proof instead of a VM/hardware target
+- Skipping registry wiring and testing a different path than users take
+
+## Verification
+
+- [ ] Image was pushed to the local registry actually used by the target
+- [ ] `bootc upgrade` ran against that registry
+- [ ] The target rebooted successfully
+- [ ] Post-upgrade runtime state was checked, not assumed
 
 ## Lessons Learned
 

--- a/docs/skills/merge-queue.md
+++ b/docs/skills/merge-queue.md
@@ -1,13 +1,25 @@
 ---
+
 name: merge-queue
 description: Clears stuck dependency-update PRs, rebases chore branches against main, and handles fork PRs. Covers rebase loops, merge command, e2e retrigger, and cross-repository PR handling. Load when PRs are stuck, conflicting, or blocked.
+metadata:
+  context7-sources:
+    - /websites/github_en_actions
 ---
 
 # Merge Queue Operations
 
-## When to Load
+## When to Use
 
-Load when clearing stuck dependency-update PRs, rebasing chore branches against `main`, or finishing a batch of bot PR merges.
+Use when clearing stuck dependency-update PRs, rebasing chore branches against `main`, or finishing a batch of bot PR merges.
+
+## Core Process
+
+1. Identify which PRs are actually stale or conflicting.
+2. Rebase the minimal set needed.
+3. Merge ready PRs in small waves.
+4. Re-list and do a cleanup pass, because earlier merges will stale later branches.
+5. Handle fork PRs differently from same-repo branches.
 
 ## When NOT to Use
 
@@ -158,6 +170,28 @@ Each agent should own one branch and run exactly this sequence:
 5. `git push upstream HEAD:<branch> --force-with-lease` (or push to fork for cross-repo)
 
 Why pairs: it speeds up queue recovery without turning every branch into a moving target at once. After the first wave lands, run one more cleanup pass for any PRs that became stale during the earlier merges.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I'll just rebase everything at once." | That's how you turn the queue into a moving target. |
+| "`--auto` merge will sort it out." | Dakota's queue and ruleset behavior often require explicit handling. |
+| "A fork PR is just another branch." | Not if you can't push to it. Treat fork ownership as a first-class constraint. |
+
+## Red Flags
+
+- Rebasing without checking `isCrossRepository`
+- Merging a batch without a final stale-branch pass
+- Force-pushing to the wrong remote
+- Treating empty-after-rebase PRs as if they still need merging
+
+## Verification
+
+- [ ] Stale/conflicting PRs were identified before rebasing
+- [ ] Same-repo and fork PRs were handled with the correct push path
+- [ ] The queue was processed in waves, not one giant churn pass
+- [ ] Empty or already-landed PRs were detected and not merged blindly
 
 ## Cross-References
 

--- a/docs/skills/not-bluefin.md
+++ b/docs/skills/not-bluefin.md
@@ -1,67 +1,82 @@
 ---
 name: not-bluefin
-description: Translates bluefin/RPM/dnf mental model to dakota BuildStream reality. Load FIRST on any dakota task if you have bluefin context, or if your plan mentions dnf, RPM, COPR, or Containerfile package layers.
+description: Reset the Dakota mental model before doing any package or image work. Use when your plan mentions dnf, RPM, COPR, spec files, or Containerfile package layers, or whenever bluefin habits are leaking into a Dakota task.
+metadata:
+  context7-sources:
+    - /apache/buildstream
 ---
 
-# NOT Bluefin — Dakota Build Context
+# Not Bluefin
 
-**Load this skill FIRST before any dakota task.** Dakota is fundamentally different from bluefin.
+## Overview
 
----
+Dakota is a **BuildStream-first** repo.
+It is not a Fedora/CentOS overlay repo, not an RPM repo, and not a Containerfile package-install repo.
 
-## Dakota uses BuildStream 2 (BST). Not dnf. Not RPM. Not Containerfile.
+This skill exists to kill the most expensive wrong turn early.
 
-| Bluefin Pattern | Dakota Reality | What to do instead |
-|---|---|---|
-| `dnf5 install <pkg>` | ❌ PROHIBITED | Write a `.bst` element file |
-| `dnf5 copr enable` | ❌ PROHIBITED | BST has no COPR concept |
-| `copr_install_isolated()` | ❌ PROHIBITED | Not applicable |
-| `copr-helpers.sh` | ❌ PROHIBITED | Does not exist in dakota |
-| Containerfile `RUN dnf5...` stage | ❌ PROHIBITED | Use BST elements for packages |
-| `.spec` files / RPM build | ❌ PROHIBITED | BST elements only |
-| Fedora package names (RPM) | ⚠️  May differ | Verify in BST element definitions |
+## When to Use
 
-## What dakota DOES use
+Use when:
+- your draft mentions `dnf`, RPM, COPR, `.spec`, or package repos
+- you are about to change image contents
+- you see `elements/bluefin/*` and start thinking "Bluefin workflow"
+- you are onboarding into Dakota from another Project Bluefin repo
 
-- **BuildStream 2** (`.bst` files) — the only way to add packages
-- **BST element kinds**: `autotools`, `cmake`, `meson`, `pip`, `manual`, `stack`, `junction`
-- **Upstream junctions**: `freedesktop-sdk.bst` and `gnome-build-meta.bst` provide most packages
-- **OCI assembly**: A `Containerfile` exists for final image assembly only — not for package installation
+## When NOT to Use
 
-## Historical name trap: `bluefin/` paths still mean Dakota
+- You already know you are editing the correct `.bst` element
+- You are debugging a CI trigger or GitHub workflow issue unrelated to packaging
 
-- `elements/bluefin/*.bst`, `elements/bluefin/deps.bst`, `elements/oci/bluefin.bst`, and `elements/oci/layers/bluefin.bst` are Dakota's main build paths.
-- Those names are historical carry-over from the broader Bluefin project. They do **not** mean "use the bluefin repo workflow" or "install packages with dnf in a Containerfile."
+## Core Process
 
-## Translate the request before acting
+1. **Translate the request into BST terms before doing anything else.**
+2. **Locate the actual Dakota path** (`elements/bluefin/*`, `elements/oci/*`, `Justfile`).
+3. **Choose the right next skill**:
+   - add/remove package → `add-package.md` / `remove-package.md`
+   - BST syntax → `buildstream.md`
+   - OCI assembly → `oci-layers.md`
+4. **Refuse the wrong mechanism** even if it feels faster.
 
-| If someone asks for... | In Dakota, do this |
+## Translation Table
+
+| If you are thinking... | In Dakota, do this instead |
 |---|---|
-| "Add/remove a package" | Add/remove a `.bst` element and wire/unwire it in `elements/bluefin/deps.bst` |
-| "Enable a service by default" | Ship the unit/preset from a `.bst` element |
-| "Change what ends up in the image" | Edit BST elements or `elements/oci/*`, not the repo `Containerfile` |
-| "Enable a COPR / add an RPM repo" | Stop — Dakota has no COPR/RPM repo layer; package the software in BST terms |
+| `dnf install <pkg>` | create or edit a `.bst` element |
+| enable a COPR / package repo | package it in BST terms |
+| edit Containerfile to add packages | edit BST elements or OCI assembly elements |
+| RPM package names are the source of truth | verify the actual BuildStream element or upstream source |
+| `bluefin/` path means bluefin workflow | treat it as Dakota history, not process |
 
-## Adding a package to dakota
+## Hard Facts
 
-See `docs/skills/add-package.md`. Never reach for `dnf5`.
+- `elements/bluefin/*` are **Dakota** paths.
+- `elements/bluefin/deps.bst` is the package manifest for Dakota's build graph.
+- `Containerfile` is for final OCI/image helper flows, **not** package installation.
+- BuildStream element kinds such as `manual`, `meson`, `cmake`, `autotools`, `pip`, `stack`, `junction`, and `compose` are the real building blocks here.
 
-## The Containerfile is NOT for packages
+## Common Rationalizations
 
-Dakota has a `Containerfile` for final OCI image assembly (copying BST artifacts into the image). It does NOT install packages. Do not add `RUN dnf5 install` to it.
+| Rationalization | Reality |
+|---|---|
+| "It's probably easier to add one `dnf install`." | That is the wrong repo model and creates factory debt. |
+| "The path says bluefin, so it must use bluefin's process." | The name is legacy; the mechanism is Dakota. |
+| "Containerfile is right there, I'll patch the image there." | Package/image-content changes belong in BST elements. |
+| "I can translate later after I inspect the files." | Translate first, or you'll inspect the wrong files. |
 
-## Common file traps
+## Red Flags
 
-| File / path | What it actually is | What it is **not** |
-|---|---|---|
-| `Containerfile` | Local bootc lint helper for an already-built Dakota image | A package overlay or install stage |
-| `Justfile` `build-containerfile` recipe | Convenience wrapper around that lint helper | The primary image build path |
-| `elements/bluefin/deps.bst` | Dakota's package manifest | An RPM package list |
-| `elements/oci/bluefin.bst` | Final BuildStream OCI assembly step | A signal to switch to bluefin repo habits |
+- Draft plan mentions dnf/RPM/COPR
+- Editing `Containerfile` to change package content
+- Treating `.spec` files or Fedora naming as the source of truth
+- Reaching for bluefin habits because of the `bluefin` directory name
 
-## The Justfile is NOT the same as bluefin's
+## Verification
 
-Dakota's `Justfile` has different semantics. `just lint` validates BST templates. There is no `just check` equivalent.
+- [ ] The task is expressed in BST terms before implementation starts
+- [ ] The next skill loaded is package/buildstream/OCI-specific, not an RPM workflow
+- [ ] No package or image-content change is routed through `Containerfile`
+- [ ] The final plan names the actual Dakota files being changed
 
 ## Lessons Learned
 

--- a/docs/skills/oci-layers.md
+++ b/docs/skills/oci-layers.md
@@ -1,17 +1,33 @@
 ---
+
 name: oci-layers
 description: Explains how packages flow from BST elements into the final OCI image layer. Covers compose vs stack kinds, BST weak-key caching bug, and layer verification. Load when packages go missing from the built image or when modifying layer assembly.
+metadata:
+  context7-sources:
+    - /apache/buildstream
 ---
 
 # OCI Layers and Image Assembly
 
 Load when understanding how packages flow into the final OCI image, modifying layer assembly, or debugging why files appear or are missing from the built image.
 
+## When to Use
+
+Use when a package builds but disappears from the image, when editing OCI layer assembly, or when you need to trace files from element to final image.
+
 ## When NOT to Use
 
 - Writing individual element files → `buildstream.md`
 - Debugging individual element build failures → `debugging.md`
 - Understanding the CI build pipeline → `ci.md`
+
+## Core Process
+
+1. Trace the package from element → stack → compose layer → OCI assembly.
+2. Confirm the producing element is wired into the correct dependency stack.
+3. Confirm the layer stage is `compose` when filesystem output is expected.
+4. Inspect built artifact contents before blaming later OCI assembly steps.
+5. Re-check cache behavior if the graph is right but the image is stale.
 
 ## Assembly Architecture
 
@@ -120,6 +136,28 @@ sudo podman images                          # find the image name
 sudo podman run --rm <image> which <binary> # check binary exists
 sudo podman run --rm <image> find /usr/lib/systemd -name "<service>.service"
 ```
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "The package built, so it must be in the image." | Not if it never made it through stack/compose wiring. |
+| "`stack` is fine; it depends on the right things." | `stack` produces no filesystem output. |
+| "Missing image content means the build failed." | It may be wiring or cache invalidation instead. |
+
+## Red Flags
+
+- `kind: stack` used where a layer must emit files
+- Debugging OCI assembly before inspecting element artifact contents
+- Assuming cache hits imply correct image contents
+- Editing final OCI script when the real bug is earlier compose wiring
+
+## Verification
+
+- [ ] The file path was traced through element, stack, compose, and OCI assembly
+- [ ] Filesystem-producing layers use `compose`
+- [ ] Artifact contents were inspected before changing OCI assembly logic
+- [ ] Cache behavior was considered when the graph looked correct but output was stale
 
 ## Lessons Learned
 

--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -1,17 +1,32 @@
 ---
+
 name: dakota-overview
 description: Provides context on what Dakota is, how it differs from bluefin/bluefin-lts, current package gaps, and build optimization notes. Load when planning new package additions or when someone asks what Dakota is.
+metadata:
+  context7-sources:
+    - /bootc-dev/bootc
+    - /apache/buildstream
 ---
 
 # Dakota Overview
 
 Load when you need context on what dakota is, how it differs from production Bluefin, what unique features it has, or when planning new package additions.
 
+## When to Use
+
+Use when you need product/repo context before planning work, when someone asks what Dakota is, or when deciding whether a package or feature fits Dakota's scope.
+
 ## When NOT to Use
 
 - Authoring `.bst` element files → use `buildstream.md` or `add-package.md`
 - Debugging CI pipeline failures → use `ci.md`
 - Looking up specific packaging patterns → use the relevant `packaging-*.md` skill
+
+## Core Process
+
+1. Confirm whether the question is about Dakota's identity, architecture, or scope.
+2. Use the hard facts here to avoid importing bluefin or OSTree assumptions.
+3. Route into a packaging or CI skill once the repo context is clear.
 
 ## Hard Facts — Violations Recorded 3+ Times
 
@@ -171,6 +186,26 @@ Heavy build contributors:
 2. **GRUB** — built in 3 variants (i386-pc, i386-efi, x86_64-efi). Required because upstream GNOME OS uses systemd-boot only; Bluefin needs GRUB for bootc compatibility.
 3. **Junction patches** — patches to freedesktop-sdk and gnome-build-meta modify junction identity hashes, which may affect upstream cache hit rates. Upstreaming patches would improve this.
 4. **Pre-built binary pattern** — used for Tailscale, Zig, Homebrew, Go CLI tools. New packages should follow this pattern where possible.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "Dakota is basically bluefin with different packaging." | No. The build and runtime model differ in important ways. |
+| "If it works in OSTree land, the advice carries over." | Dakota runtime is composefs/bootc-focused. |
+| "CI green is enough to say the image is fixed." | Hardware confirmation still matters here. |
+
+## Red Flags
+
+- Suggesting RPM, rpm-ostree, or OSTree-specific remediation for Dakota runtime problems
+- Treating `:next` as a stable-promotion stream
+- Describing Dakota as a 1:1 clone of production Bluefin
+
+## Verification
+
+- [ ] The answer reflects Dakota's actual runtime and build model
+- [ ] Bluefin/OSTree assumptions were explicitly filtered out
+- [ ] The scope advice matches Dakota's intended positioning
 
 ## Lessons Learned
 

--- a/docs/skills/packaging-binaries.md
+++ b/docs/skills/packaging-binaries.md
@@ -1,11 +1,33 @@
 ---
+
 name: packaging-binaries
 description: Packages a project using official pre-built static binaries (GitHub Releases). Use when upstream provides release binaries and building from source is unnecessary. Covers arch-conditional sources, kind:remote with filename, and strip-binaries placement.
+metadata:
+  context7-sources:
+    - /apache/buildstream
 ---
 
 # Packaging Pre-Built Binaries
 
 Load when packaging a project that provides official pre-built static binaries (GitHub Releases, official downloads), or when building from source is impractical.
+
+## When to Use
+
+Use when upstream ships trusted pre-built release binaries and a source build would add unnecessary complexity, bootstrap pain, or wasted CI time.
+
+## When NOT to Use
+
+- Source builds are straightforward and expected for this project
+- The binary provenance is unclear or unofficial
+- A language-specific source-packaging skill is the better fit
+
+## Core Process
+
+1. Confirm a pre-built binary is the right tradeoff.
+2. Fetch the official release artifact per architecture.
+3. Install into the correct merged-usr path.
+4. Disable stripping when the payload or layout needs it.
+5. Validate the installed files and runtime dependencies.
 
 ## When to Use Pre-Built Binaries
 
@@ -101,6 +123,28 @@ url: releases:owner/project/releases/download/v%{version}/binary.tar.gz
 - [ ] Element added to `elements/bluefin/deps.bst`
 - [ ] `just bst show bluefin/<name>.bst` passes
 - [ ] `just bst build bluefin/<name>.bst` passes
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "Source is available, but binaries are easier, so I'll always use binaries." | Use binaries when they reduce real complexity, not as a reflex. |
+| "One generic download URL is enough." | Multi-arch packaging fails fast if you do not model the real artifacts. |
+| "If the file lands in `/usr/bin`, we're done." | You still need to validate the final staged payload and execution model. |
+
+## Red Flags
+
+- Unofficial or mutable binary sources
+- Missing architecture split for release artifacts
+- Forgetting `strip-binaries: ""` when the payload needs it
+- Treating binary packaging as a way to dodge validation
+
+## Verification
+
+- [ ] Official binary source and per-arch artifacts are explicit
+- [ ] Install paths use merged-usr conventions
+- [ ] Stripping behavior is intentional
+- [ ] The packaged binary is actually runnable in the staged image model
 
 ## Lessons Learned
 

--- a/docs/skills/packaging-gnome-extensions.md
+++ b/docs/skills/packaging-gnome-extensions.md
@@ -1,11 +1,33 @@
 ---
+
 name: packaging-gnome-extensions
 description: Packages GNOME Shell extensions for BuildStream in dakota. Covers UUID discovery, install path, extension stack wiring, GSettings schema compilation, and dconf keyfile last-writer-wins behavior.
+metadata:
+  context7-sources:
+    - /apache/buildstream
 ---
 
 # Packaging GNOME Shell Extensions
 
 Load when packaging a GNOME Shell extension for BuildStream in dakota.
+
+## When to Use
+
+Use when adding, updating, or debugging a GNOME Shell extension package, schema wiring, or extension enablement behavior in Dakota.
+
+## When NOT to Use
+
+- Normal application packaging that is not a Shell extension
+- Generic BST syntax questions without extension-specific behavior
+- Desktop settings issues unrelated to extension packaging
+
+## Core Process
+
+1. Discover the extension UUID first.
+2. Create the element under the shell-extensions subtree.
+3. Install files into the UUID-based destination path.
+4. Wire the extension into the extension stack and any settings/defaults flow.
+5. Re-check schema compilation and dconf ordering behavior.
 
 ## Creating an Extension Element
 
@@ -135,6 +157,28 @@ install-commands:
 - [ ] Element added to `elements/bluefin/gnome-shell-extensions.bst`
 - [ ] `just validate` passes
 - [ ] `just bst build bluefin/shell-extensions/<name>.bst` passes
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "An extension is just another package." | UUID pathing, schemas, and settings wiring make it different. |
+| "I'll infer the UUID from the project name." | Wrong often enough to waste time; read metadata. |
+| "The files installed, so GNOME will see it." | Not if the path, schema, or enablement flow is wrong. |
+
+## Red Flags
+
+- UUID not verified from metadata
+- Extension installed into a guessed path
+- Settings/default behavior changed without considering last-writer-wins ordering
+- Treating schema compilation as optional
+
+## Verification
+
+- [ ] UUID was confirmed from the extension metadata
+- [ ] Files install to the correct Shell extension path
+- [ ] Schema/default wiring was considered explicitly
+- [ ] The extension is wired into the intended stack or enablement flow
 
 ## Lessons Learned
 

--- a/docs/skills/packaging-go.md
+++ b/docs/skills/packaging-go.md
@@ -1,17 +1,32 @@
 ---
+
 name: packaging-go
 description: Packages a Go project from source using BST go_module sources or a vendored GOPATH tarball. Note: all current Go tools in Dakota use pre-built binaries — load packaging-binaries.md first to confirm source build is truly needed.
+metadata:
+  context7-sources:
+    - /apache/buildstream
 ---
 
 # Packaging Go Projects
 
 Load when packaging a Go project for dakota/Bluefin BuildStream, or when setting up GOPATH vendoring in BuildStream.
 
+## When to Use
+
+Use when a Go project truly needs a source build in Dakota and pre-built binaries are not the better path.
+
 ## When NOT to Use
 
 - Rust project → `packaging-rust.md`
 - Zig project → `packaging-zig.md`
 - Pre-built binary → `packaging-binaries.md`
+
+## Core Process
+
+1. Confirm source packaging is actually needed.
+2. Pick the vendoring pattern (`go_module` vs embedded GOPATH tarball).
+3. Ensure the build is fully offline inside BST.
+4. Validate the produced binary layout and runtime behavior.
 
 ## Go Build Approach in BST
 
@@ -133,6 +148,28 @@ install-commands:
 - [ ] Element added to `elements/bluefin/deps.bst`
 - [ ] `just validate` passes
 - [ ] `just bst build bluefin/<name>.bst` passes
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "It's Go, so I can just let it download modules." | Not inside network-isolated BST builds. |
+| "Source build is more pure, so always do that." | Dakota already prefers pre-built binaries for many Go tools when that is the lazier correct path. |
+| "One vendoring strategy fits all Go projects." | Pick the smaller maintenance burden that actually matches the project. |
+
+## Red Flags
+
+- Network-dependent Go build steps
+- Choosing source packaging without checking `packaging-binaries.md` first
+- Missing vendored dependency material in the element sources
+- Treating GOPATH/module layout as an implementation detail you can hand-wave
+
+## Verification
+
+- [ ] Source build was justified over binary packaging
+- [ ] All Go deps are available offline in BST
+- [ ] The chosen vendoring pattern matches the project
+- [ ] The final staged binary layout is correct
 
 ## Lessons Learned
 

--- a/docs/skills/packaging-rust.md
+++ b/docs/skills/packaging-rust.md
@@ -1,17 +1,33 @@
 ---
+
 name: packaging-rust
 description: Packages a Rust/Cargo project from source using BST cargo2 sources. Covers cargo2 generation, overlap-whitelist for conflicting binaries, and tracking group assignment. Use sudo-rs.bst as the reference template.
+metadata:
+  context7-sources:
+    - /apache/buildstream
 ---
 
 # Packaging Rust Projects
 
 Load when packaging a Rust project with Cargo for dakota/Bluefin BuildStream.
 
+## When to Use
+
+Use when a Rust/Cargo project must be built from source in Dakota and you need the cargo2/offline-vendoring pattern.
+
 ## When NOT to Use
 
 - Go project → `packaging-go.md`
 - Zig project → `packaging-zig.md`
 - Pre-built binary → `packaging-binaries.md`
+
+## Core Process
+
+1. Copy an existing Rust element as the template.
+2. Update metadata, binary naming, and source refs.
+3. Regenerate the cargo2 source block from `Cargo.lock`.
+4. Validate offline dependency completeness before blaming Cargo.
+5. Check overlap and installed binary names explicitly.
 
 ## Overview
 
@@ -133,6 +149,28 @@ install-commands:
 - [ ] Element added to `elements/bluefin/deps.bst`
 - [ ] `just validate` passes
 - [ ] `just bst build bluefin/<name>.bst` passes
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I'll hand-edit the cargo2 block; it's only a few crates." | That's how you ship a broken vendor graph. Generate it. |
+| "Cargo can fetch the rest during build." | Not in BST. Offline means offline. |
+| "If the binary name collides, it's probably fine." | Overlap and replacement behavior must be deliberate. |
+
+## Red Flags
+
+- Hand-written or half-updated cargo2 blocks
+- Missing `Cargo.lock`-driven regeneration after ref bumps
+- Offline build assumptions violated
+- Binary overlap not examined when packaging CLI replacements
+
+## Verification
+
+- [ ] cargo2 sources were regenerated, not hand-maintained
+- [ ] The Rust build is fully offline in BST
+- [ ] Installed binary names and overlap behavior were checked
+- [ ] The element still matches repo Rust packaging conventions
 
 ## Lessons Learned
 

--- a/docs/skills/packaging-zig.md
+++ b/docs/skills/packaging-zig.md
@@ -1,17 +1,33 @@
 ---
+
 name: packaging-zig
 description: Packages a Zig build system project from source. Covers two-stage cache population (zig fetch for HTTP deps, manual placement for git deps), DESTDIR pattern, and -Dcpu=baseline requirement. ghostty.bst is the reference implementation.
+metadata:
+  context7-sources:
+    - /apache/buildstream
 ---
 
 # Packaging Zig Projects
 
 Load when packaging a project that uses the Zig build system for dakota/Bluefin BuildStream.
 
+## When to Use
+
+Use when a project is built with Zig and needs the Dakota offline-cache packaging pattern.
+
 ## When NOT to Use
 
 - Rust/Cargo project → `packaging-rust.md`
 - Go project → `packaging-go.md`
 - Pre-built binary → `packaging-binaries.md`
+
+## Core Process
+
+1. Read `build.zig.zon` and identify every dependency.
+2. Pre-stage all dependencies as sources.
+3. Populate the Zig cache in the expected offline layout.
+4. Build with the repo's known-good CPU/runtime flags.
+5. Validate the installed binary and cache assumptions.
 
 ## Overview
 
@@ -142,6 +158,28 @@ grep minimum_zig_version path/to/build.zig.zon
 - [ ] Element added to `elements/bluefin/deps.bst`
 - [ ] `just validate` passes
 - [ ] `just bst build bluefin/<name>.bst` passes
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "Zig will fetch dependencies for me during build." | Not inside BST. You must stage them. |
+| "If one cache trick worked once, it'll generalize." | Zig dependency shapes vary; read the project first. |
+| "The reference element is overkill." | The reference exists because ad-hoc Zig packaging breaks easily. |
+
+## Red Flags
+
+- Unstaged `build.zig.zon` dependencies
+- Guessing cache layout instead of matching the reference pattern
+- Skipping the repo's proven Zig flags
+- Treating network isolation as an afterthought
+
+## Verification
+
+- [ ] All Zig deps are staged as sources
+- [ ] Offline cache population is explicit and reproducible
+- [ ] Build flags follow the known-good Dakota pattern
+- [ ] Final binary layout was validated
 
 ## Lessons Learned
 

--- a/docs/skills/patch-junctions.md
+++ b/docs/skills/patch-junctions.md
@@ -1,16 +1,32 @@
 ---
+
 name: patch-junctions
 description: Lifecycle for patches applied to upstream junctions (freedesktop-sdk, gnome-build-meta). Covers adding patches, required Upstream-Status headers, rebasing after junction bumps, and dropping upstreamed patches.
+metadata:
+  context7-sources:
+    - /apache/buildstream
 ---
 
 # Patching Junction Elements
 
 Load when modifying upstream freedesktop-sdk or gnome-build-meta elements in dakota, or when fixing bugs in junction dependencies.
 
+## When to Use
+
+Use when an upstream junction dependency needs a local patch in Dakota or when maintaining/rebasing an existing junction patch queue.
+
 ## When NOT to Use
 
 - Understanding when to override vs. not → `bst-overrides.md`
 - Bumping a junction ref without patch changes → `update-refs.md`
+
+## Core Process
+
+1. Confirm a patch is really needed and not just a junction bump.
+2. Add the patch with the required metadata/header.
+3. Track the upstream status explicitly.
+4. Rebase or drop the patch as upstream moves.
+5. Keep the queue minimal and ordered.
 
 ## Overview
 
@@ -136,6 +152,28 @@ When the upstream junction ref includes the fix:
 | Patch file not found / wrong name | Filenames are alphabetical order; check numbering |
 | `patch_queue` source not in junction `.bst` | Must be declared as a source in the junction element |
 | Multiple patches conflict | Check filename ordering — earlier patches may change context for later ones |
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I'll add the patch now and upstream it later." | That is how patch queues become permanent. |
+| "One more local patch is cheap." | Every local junction patch compounds rebase debt. |
+| "Filename order probably won't matter here." | The queue is order-sensitive. Treat it that way. |
+
+## Red Flags
+
+- Patch with no upstream tracking reference
+- Missing or weak `Upstream-Status` metadata
+- Queue growth without drop/rebase discipline
+- Local patch solving something a junction bump already fixed
+
+## Verification
+
+- [ ] Patch was justified over a simple junction bump
+- [ ] Upstream tracking/status is explicit
+- [ ] Queue ordering and rebase implications were considered
+- [ ] There is a clear path to drop the patch later
 
 ## Lessons Learned
 

--- a/docs/skills/pr-review.md
+++ b/docs/skills/pr-review.md
@@ -1,11 +1,32 @@
 ---
+
 name: pr-review
 description: Consolidated review workflow for dakota pull requests. Covers review priorities, common rejection reasons, dep-update PR review, and ghost (agent-assisted PR) handling. Load when asked to review any PR in projectbluefin/dakota.
+metadata:
+  context7-sources:
+    - /websites/github_en_actions
 ---
 
 # PR Review
 
 Consolidated review workflow for dakota pull requests.
+
+## When to Use
+
+Use when asked to review any Dakota PR, including feature PRs, dep-update PRs, or agent-authored maintenance changes.
+
+## When NOT to Use
+
+- Queue cleanup or stale-branch repair without substantive review → `merge-queue.md`
+- General issue triage before any PR exists → `actionadon.md`
+
+## Core Process
+
+1. Read the workflow and checklist docs first.
+2. Check branch hygiene and diff scope.
+3. Verify the PR category-specific checklist items.
+4. Check required CI status and mergeability.
+5. Review correctness only after the workflow hygiene is sound.
 
 ## Before you review
 
@@ -64,6 +85,29 @@ Auto-generated dep-update PRs (`auto/track-*`, `renovate/*`) always target
    `:testing` issue, not a PR issue. Validate passing + correct diff is enough.
 
 See `merge-queue.md` for the full retarget/cherry-pick/merge flow.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "The code looks fine, so the workflow details can slide." | Dakota reviews start with branch hygiene and checklist compliance for a reason. |
+| "A giant diff is just a busy PR." | It often means the branch started from the wrong base. |
+| "CI hasn't run yet, but the change is obvious." | Required checks are part of correctness here. |
+
+## Red Flags
+
+- Reviewing code details before checking branch base and scope
+- Ignoring checklist category mismatches
+- Accepting junction bumps mixed with unrelated patch changes
+- Treating skipped/absent CI as equivalent without understanding why
+
+## Verification
+
+- [ ] Branch hygiene was checked first
+- [ ] Relevant checklist items were reviewed
+- [ ] Required CI/check state was examined
+- [ ] Scope is one logical change
+- [ ] Review comments align with Dakota workflow, not just generic code review taste
 
 ## Lessons Learned
 

--- a/docs/skills/quickstart.md
+++ b/docs/skills/quickstart.md
@@ -1,117 +1,120 @@
 ---
 name: quickstart
-description: Zero-context entry point for routine dakota maintenance. Provides 5 always-rules, 6 never-rules, task routing table, and the end-to-end PR workflow. Load first for add/remove/update tasks when you have no other context.
+description: Zero-context Dakota maintenance guide. Use when doing routine add/remove/update work and you need the shortest safe path through branch setup, validation, and the factory workflow.
+metadata:
+  context7-sources:
+    - /apache/buildstream
+    - /websites/github_en_actions
 ---
 
-# Agent Quickstart
+# Quickstart
 
-Zero-context entry point for routine dakota maintenance — add package, remove package, update refs.
+## Overview
 
-Historical path note: `elements/bluefin/*` is Dakota's package tree. The name
-is legacy. Do not use it as a cue to reach for dnf, RPM/COPR, or Containerfile
-overlay workflows.
+This is the **smallest safe default** for routine Dakota work.
+It is not the full reference manual. It is the path that prevents the most common factory mistakes.
 
-## 5 Always Rules
+## When to Use
 
-1. **Always run `just --list` first** — the Justfile is the ground truth for available recipes
-2. **Always run `just validate`, `just lint`, and `just boot-test` before opening a PR** — graph check, image lint, and automated boot smoke test
-3. **Always add new elements to `deps.bst`** (binary) or `gnome-shell-extensions.bst` (extensions)
-4. **Always grep for all references before removing** — `grep -r <name> elements/ .github/workflows/ files/`
-5. **Always use `just bst` not bare `bst`** — BST must run inside the pinned container
+Use when:
+- adding, removing, or updating a package
+- doing small maintenance with little repo context
+- you want the standard branch → edit → validate → PR flow
 
-## 6 Never Rules
+## When NOT to Use
 
-1. **Never edit** `elements/freedesktop-sdk.bst` or `elements/gnome-build-meta.bst` without human review
-2. **Never open a PR** to `projectbluefin/dakota` without running `just validate` first
-3. **Never add Renovate entries** for elements already in the `track-tarballs` CI job — causes racing PRs
-4. **Never call `bst` directly** — always `just bst ...`
-5. **Never skip `just validate`** even if `just bst build` "looks right"
-6. **Never solve package/image-content changes in `Containerfile`** — those belong in `.bst` elements and `elements/bluefin/deps.bst`
+- CI failure needs workflow-specific debugging → CI skills
+- complex packaging needs a language-specific skill → `packaging-*.md`
+- you are still leaking bluefin habits → `not-bluefin.md` first
+
+## Core Process
+
+1. **Load `not-bluefin.md` if needed.**
+2. **Branch from `upstream/main`.**
+3. **Pick the focused skill for the change.**
+4. **Use `just` recipes, not ad-hoc host commands.**
+5. **Run the lightest validation that proves the change.**
+6. **Commit with `Assisted-by:` and update the relevant skill in the same PR.**
+
+## Always Rules
+
+1. Run `just --list` first.
+2. Use `just bst ...`, not bare `bst`.
+3. Grep all references before removing a package or file.
+4. Add new package elements to the correct stack.
+5. Validate before opening the PR.
+6. Push to `upstream`, never the fork workflow by accident.
+
+## Never Rules
+
+1. Never solve package/image-content changes in `Containerfile`.
+2. Never open a Dakota PR without validation evidence.
+3. Never edit junctions casually; treat them as human-review territory.
+4. Never add duplicate automation when an existing recipe or workflow already owns it.
+5. Never skip the skill update if you discovered a reusable lesson.
 
 ## Task Routing
 
-| Task | Command | Skill |
-|------|---------|-------|
-| Add binary package | Create `elements/bluefin/<name>.bst` manually | `add-package.md` |
-| Add Rust package | Create element + run `generate_cargo_sources.py` | `add-package.md` + `packaging-rust.md` |
-| Add GNOME extension | Create `elements/bluefin/shell-extensions/<name>.bst` | `packaging-gnome-extensions.md` |
-| Remove package | `grep -r <name> elements/ .github/workflows/` then delete | `remove-package.md` |
-| Update tarball version | Edit version var, then `just bst source track bluefin/<name>.bst` | `update-refs.md` |
-| Update git ref | `just bst source track bluefin/<name>.bst` | `update-refs.md` |
-| Build failure | `just bst shell --build bluefin/<name>.bst` | `debugging.md` |
-| BST YAML reference | — | `buildstream.md` |
-| CI failure | — | `ci.md` |
+| Task | Load |
+|---|---|
+| Add package | `add-package.md` |
+| Remove package | `remove-package.md` |
+| Update source ref/version | `update-refs.md` |
+| Debug element build | `debugging.md` |
+| BST syntax/reference | `buildstream.md` |
+| CI failure | `ci.md` |
 
-## Tracking Groups
-
-| Group | When to use |
-|-------|-------------|
-| `auto-merge` | App packages, shell extensions — low-risk, squash-merged automatically |
-| `manual-merge` | Junctions, Rust elements — requires human review |
-
-## Fix an Issue — End-to-End
+## Default Workflow
 
 ```bash
-# 1. Claim the issue
-gh issue comment 635 --repo projectbluefin/dakota --body "/claim"
-
-# 2. Branch from upstream/main
+# branch
 git checkout upstream/main -b fix/short-description
 
-# 3. Make changes, validate
-just validate && just lint
+# inspect recipes
+just --list
 
-# 4. Commit with correct trailer
+# make the change
+
+# validate with the lightest checks that match the scope
+just bst show oci/bluefin.bst
+just lint
+
+# commit
 git commit -m "fix(bluefin): short description
 
-Closes #635
+Closes #NNN
 
-Assisted-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+Assisted-by: OpenAI GPT-5 via pi"
 
-# 5. Push to upstream (never castrojo fork)
+# push
 git push upstream fix/short-description
-
-# 6. Open PR with checklist checkbox checked
-gh pr create --repo projectbluefin/dakota ...
 ```
 
-If the issue is still `status/triage` (not yet `status/approved`), ask the user before claiming — agents don't self-approve issues.
+## Common Rationalizations
 
-## Commit Conventions
+| Rationalization | Reality |
+|---|---|
+| "I'll use bare bst just this once." | That's how environment drift sneaks in. |
+| "This is small; I don't need validation." | Small changes still waste CI if the graph is broken. |
+| "I learned something, but I'll document it later." | Later means never. The factory loop breaks immediately. |
+| "The fork is fine for this push." | Not for Dakota's normal upstream PR flow. |
 
-```text
-feat(bluefin): add <name>
-chore(deps): update <name>
-fix(bluefin): <description>
-chore: remove <name>
-```
+## Red Flags
 
-**Trailer:** Always `Assisted-by:` or `Signed-off-by:` — never `Co-authored-by:`. This is a hard rule from `docs/pr-checklist.md`.
+- Starting from local `main` instead of `upstream/main`
+- Using host-installed bst or random shell commands instead of `just`
+- No evidence attached to the PR
+- A skill-worthy lesson discovered but not written back
 
-## Key Paths
+## Verification
 
-```text
-elements/bluefin/                           All Bluefin-specific elements
-elements/bluefin/deps.bst                   Central dependency manifest
-elements/bluefin/shell-extensions/          GNOME Shell extensions
-elements/bluefin/gnome-shell-extensions.bst Extension stack
-include/aliases.yml                         URL aliases
-.github/workflows/track-bst-sources.yml    Tracking matrix
-.github/renovate.json5                      Renovate config
-```
-
-## Throughput Rule
-
-If working through a backlog of issues, do not stop after the first fix. Work from the issue backlog in this order:
-
-1. Issues labeled `status/queued`
-2. Issues labeled `kind:bug`
-3. Issues explicitly named by the user
+- [ ] Branch started from `upstream/main`
+- [ ] Correct focused skill was loaded for the task
+- [ ] Validation matched the scope of the change
+- [ ] Commit uses repo conventions including `Assisted-by:`
+- [ ] Skill update is included when a new pattern was learned
 
 ## Lessons Learned
-
-> Add entries here when you discover a new pattern or fix a recurring mistake.
-> Format: `### <pattern name> (YYYY-MM-DD)`
 
 ### Restarting the publish factory after a pause (2026-06-05)
 
@@ -119,7 +122,7 @@ When publishing has been intentionally paused (e.g., post-repo-refactor), the
 factory restart sequence is:
 
 1. Fix any `startup_failure` in `publish.yml` — check for invalid `permissions:` scopes
-   (e.g., `artifact-metadata: write` is not a valid GITHUB_TOKEN scope) and
+   (e.g. `artifact-metadata: write` is not a valid GITHUB_TOKEN scope) and
    job-level `permissions:` on reusable workflow call jobs.
 2. Dispatch `build.yml --ref main` to populate the remote CAS.
 3. Wait ~60–90 minutes for the build to complete.
@@ -128,4 +131,4 @@ factory restart sequence is:
    2 human approvals at https://github.com/projectbluefin/dakota/deployments
    to promote `:testing` → `:latest` + `:stable`.
 
-Full details: `docs/ci.md` → "Restarting the factory".
+Full details: `release-promotion.md` and `ci-tooling.md`.

--- a/docs/skills/release-promotion.md
+++ b/docs/skills/release-promotion.md
@@ -1,0 +1,109 @@
+---
+name: release-promotion
+description: Dakota publish and promotion flow from main to testing to stable, including promotion PRs, release gate behavior, and manual recovery. Use when working on promotion workflows, action_required gates, release execution, or stable-cut logic.
+metadata:
+  context7-sources:
+    - /websites/github_en_actions
+    - /bootc-dev/bootc
+---
+
+# Release Promotion
+
+## Overview
+
+Dakota has **two promotion layers**:
+1. `main` merge → publish → `:testing`
+2. `testing` → promotion PR → stable release execution
+
+Do not conflate "publish is healthy" with "stable promotion is healthy".
+
+## When to Use
+
+Use when the task mentions:
+- `promote-testing-to-main.yml`
+- `pr-release-gate.yml`
+- `execute-release.yml`
+- promotion PRs from `auto/promote-testing-to-main`
+- `action_required` release gates
+- stable release, `:latest`, `:stable`, or promotion PR flow
+
+## When NOT to Use
+
+- Need to know which workflow owns a stage → `workflow-map.md`
+- Workflow never starts because of caller permissions or cache plumbing → `ci-tooling.md`
+- Boot-check or smoke mechanics → `e2e-ci.md`
+
+## Core Process
+
+1. **Identify the stage.**
+   - publish to `:testing`
+   - open/update promotion PR
+   - gate the promotion PR
+   - execute stable release after merge
+2. **Check whether the gate is real or infrastructure.**
+   - `action_required` on a promotion PR often means the gate is waiting on policy or verification, not that the YAML crashed.
+3. **For promotion PR workflows, inspect reusable caller permissions first.**
+4. **Do not add e2e back into the promotion PR path.**
+   Dakota intentionally gates stable at the later human-approved release stage.
+5. **For manual recovery, re-run the failed publish/promote workflow that owns the stage, not some nearby check.**
+
+## Promotion Map
+
+```text
+main merge
+  → build.yml
+  → publish.yml
+  → :testing
+  → push testing / nightly / manual
+  → promote-testing-to-main.yml
+  → auto/promote-testing-to-main PR
+  → pr-release-gate.yml
+  → merge promotion PR
+  → execute-release.yml
+  → :latest / :stable + release notes
+```
+
+## Hard Rules
+
+- `promote-testing-to-main.yml` is a thin caller. Treat caller-level `permissions:` as critical.
+- `pr-release-gate.yml` must not starve the reusable gate token.
+- Promotion PRs do **not** run the full e2e quality gate; that belongs at the later stable promotion stage.
+- When a gate is `action_required`, inspect what policy condition it is waiting on before editing workflow code.
+
+## Manual Recovery Shortcuts
+
+```bash
+# open promotion PR status
+gh pr list --repo projectbluefin/dakota \
+  --search 'head:auto/promote-testing-to-main state:open'
+
+# recent gate runs
+gh run list --repo projectbluefin/dakota --workflow 'PR Release Gate' --limit 10
+
+# recent promote runs
+gh run list --repo projectbluefin/dakota --workflow 'Promote testing to main' --limit 10
+```
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "Release gate is red, so publish is broken." | Different layer. Publish may be healthy while promotion is blocked. |
+| "Let's just add more checks to the promotion PR." | That slows humans and duplicates the real stable gate. |
+| "`action_required` means rerun the same gate." | Usually it means read the gate condition first. |
+| "This reusable caller only needs job-level permissions." | Wrong often enough to deserve a scar. Check top-level caller permissions first. |
+
+## Red Flags
+
+- editing stable-promotion logic while the real failure is earlier publish plumbing
+- adding full e2e to the promotion PR path
+- rerunning arbitrary nearby workflows instead of the owning stage
+- ignoring `auto/promote-testing-to-main` PR state and debugging the wrong branch
+
+## Verification
+
+- [ ] You identified the exact promotion stage that is failing
+- [ ] You checked open promotion PR state before editing YAML
+- [ ] Reusable caller permissions were validated if the gate did not start
+- [ ] You did not collapse publish, promotion, and stable release into one mental model
+- [ ] Any change preserves the factory's intended human approval gates

--- a/docs/skills/remove-package.md
+++ b/docs/skills/remove-package.md
@@ -1,17 +1,33 @@
 ---
+
 name: remove-package
 description: Workflow for removing a software package from the Dakota image. Covers element deletion, deps.bst unwiring, dangling reference checks, and validation. Load for any "remove package from Dakota" task.
+metadata:
+  context7-sources:
+    - /apache/buildstream
 ---
 
 # Removing a Package
 
 Load when removing a software package from the Dakota image in `projectbluefin/dakota`.
 
+## When to Use
+
+Use when deleting software from Dakota, unwiring an obsolete element, or removing image content that should no longer ship.
+
 ## When NOT to Use
 
 - Adding a package → `add-package.md`
 - Only updating a version → `update-refs.md`
 - Debugging a broken element → `debugging.md`
+
+## Core Process
+
+1. Find every reference before deleting anything.
+2. Remove the element and unwind stack wiring.
+3. Check workflows, docs, presets, and ancillary references.
+4. Validate the graph after the removal.
+5. Confirm the image no longer carries the package.
 
 ## Quick Start
 
@@ -56,6 +72,28 @@ just validate
 # 6. Build image to confirm clean
 just build
 ```
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I'll just delete the element file and let CI find the rest." | Dakota removals usually leave dangling graph or workflow references. |
+| "The `bluefin/` path means there may be an RPM side to clean up too." | No. Clean up BST wiring, not imaginary RPM metadata. |
+| "If the build still works, the package is gone." | You still need to verify the image and references are actually clean. |
+
+## Red Flags
+
+- Element file deleted without touching `deps.bst` or other stacks
+- No repo-wide reference search before removal
+- Assuming package removal is local to one file
+- Containerfile/RPM cleanup steps showing up in the plan
+
+## Verification
+
+- [ ] All references to the package were searched before deletion
+- [ ] Stack wiring and ancillary references were removed
+- [ ] The graph validates after removal
+- [ ] The image/package output no longer includes the removed software
 
 ## Lessons Learned
 

--- a/docs/skills/update-refs.md
+++ b/docs/skills/update-refs.md
@@ -1,17 +1,33 @@
 ---
+
 name: update-refs
 description: Workflow for updating an existing package version in dakota. Covers tarball ref tracking, git ref tracking, and cargo2 regeneration for Rust elements. Load for any "update package version" task.
+metadata:
+  context7-sources:
+    - /apache/buildstream
 ---
 
 # Updating Package Refs
 
 Load when updating an existing package's version in `projectbluefin/dakota`.
 
+## When to Use
+
+Use when bumping a package version, refreshing a tracked source ref, or regenerating lock/vendor data after an upstream release.
+
 ## When NOT to Use
 
 - Adding a new package → `add-package.md`
 - Bumping junction refs (gnome-build-meta, freedesktop-sdk) → `patch-junctions.md`
 - Debugging a post-update build failure → `debugging.md`
+
+## Core Process
+
+1. Identify the source type and update path.
+2. Change the version metadata or track the source.
+3. Regenerate any derived vendor/lock blocks.
+4. Validate the graph and rebuild the affected element.
+5. Confirm the update changed what you intended, and nothing more.
 
 ## Quick Reference
 
@@ -92,6 +108,28 @@ just build                               # full image build (when unsure)
 ## Junction Bumps
 
 For `elements/gnome-build-meta.bst` or `elements/freedesktop-sdk.bst` ref updates, see `patch-junctions.md`. Junction bumps require patch verification and are a separate workflow.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "`source track` did the ref bump, so the job is finished." | Not for Rust and other ecosystems with generated dependency material. |
+| "I'll bump the version and skip the targeted rebuild." | That's how bad ref bumps survive until CI. |
+| "A junction bump is basically the same thing." | It is not; junctions have their own review and maintenance rules. |
+
+## Red Flags
+
+- Ref updated without rebuilding the affected element
+- Generated dependency blocks left stale after the version bump
+- Treating all source types as if they update the same way
+- Using this skill for junction maintenance
+
+## Verification
+
+- [ ] Correct update path was chosen for the source type
+- [ ] Any generated vendor/lock material was refreshed
+- [ ] The affected element graph validates and rebuilds cleanly
+- [ ] The diff reflects the intended update and no unrelated drift
 
 ## Lessons Learned
 

--- a/docs/skills/vm-stack.md
+++ b/docs/skills/vm-stack.md
@@ -1,4 +1,29 @@
+---
+name: vm-stack
+description: VM capability reference for Dakota's Flatpak-delivered virt-manager/QEMU stack. Use when deciding whether virtualization support belongs in the image, in Flatpaks, or outside the supported user-session model.
+metadata:
+  context7-sources:
+    - /bootc-dev/bootc
+---
+
 # VM Stack (virt-manager + QEMU flatpaks)
+
+## When to Use
+
+Use when answering VM capability questions, planning local virtualization support, or deciding whether a VM feature belongs in Dakota's image or in the Flatpak-delivered VM stack.
+
+## When NOT to Use
+
+- CI boot-check or testsuite VM wiring → `e2e-ci.md`
+- Image package additions unrelated to the user VM stack
+- Hardware/driver troubleshooting outside the VM capability model
+
+## Core Process
+
+1. Decide whether the capability belongs in the Flatpak VM stack or in Dakota itself.
+2. Check the user-session capability matrix.
+3. Distinguish user-session features from root/libvirt-only features.
+4. Avoid image changes when the Flatpak stack already owns the functionality.
 
 ## Overview
 
@@ -65,6 +90,26 @@ The canonical image-level mechanism is `brew bundle --file=...Brewfile` with `fl
 `flatpak install --system` works as a normal user — polkit handles privilege escalation internally. No `pkexec` wrapper needed.
 
 `flatpak override --system` requires root. We avoid it entirely here — the virt-manager manifest already declares `xdg-run/libvirt` and `devices=all`, so no override is needed.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "If users want VM support, we should add packages to the image." | This stack is intentionally Flatpak-delivered. |
+| "QEMU support means all virtualization features work." | User-session virtualization has real boundaries. |
+| "A missing root-only feature is a packaging bug." | It may simply be out of scope for the user-session model. |
+
+## Red Flags
+
+- Proposing BST/image changes for functionality already delivered by Flatpaks
+- Confusing user-session VM support with root/libvirt capabilities
+- Treating the VM stack as if it were part of Dakota's base image
+
+## Verification
+
+- [ ] The capability question was answered using the VM stack model, not guesswork
+- [ ] Flatpak-owned behavior was kept separate from image-owned behavior
+- [ ] User-session vs root-only boundaries were made explicit
 
 ## Lessons Learned
 

--- a/docs/skills/workflow-map.md
+++ b/docs/skills/workflow-map.md
@@ -1,0 +1,114 @@
+---
+name: workflow-map
+description: Maps Dakota's CI workflows, triggers, and branch flow so agents can identify the owning workflow before debugging. Use when you need to know which workflow should have run, why it did or did not run, or where a publish/promotion stage lives.
+metadata:
+  context7-sources:
+    - /websites/github_en_actions
+---
+
+# Workflow Map
+
+## Overview
+
+This skill answers one question fast: **which workflow owns this failure path?**
+Use it before log-diving or editing YAML.
+
+## When to Use
+
+Use when you need to answer:
+- Which workflow should have run?
+- Why did nothing trigger?
+- Is this a PR check, merge-queue build, publish, or promotion problem?
+- Which branch owns `:testing`, `:stable`, or `:next` behavior?
+
+## When NOT to Use
+
+- Reusable workflow `startup_failure`, token scopes, or cache bind-mount bugs → `ci-tooling.md`
+- boot-check, smoke, or testsuite behavior → `e2e-ci.md`
+- release gate, promotion PR, or stable promotion flow → `release-promotion.md`
+
+## Core Process
+
+1. **Identify the branch and event.**
+   - `pull_request`
+   - `merge_group`
+   - `workflow_run`
+   - `push: testing`
+   - `push: main`
+   - `workflow_dispatch`
+2. **Map the event to the owning workflow.**
+3. **Only then inspect logs or edit config.**
+
+## Pipeline Map
+
+```text
+PR touching image paths
+  ├─ validate (PR syntax / graph checks)
+  └─ e2e (testsuite wrapper; change-detected)
+
+Merge queue → main or next
+  └─ build.yml
+       └─ publish.yml (workflow_run from build)
+            ├─ publish-image
+            ├─ boot-check   [hard gate]
+            ├─ publish-sbom [parallel]
+            └─ promote to :testing / :next / :btw
+
+Successful publish.yml
+  └─ publish-smoke.yml
+       └─ smoke suite [observational only]
+
+push: testing / nightly / manual
+  └─ promote-testing-to-main.yml
+       └─ opens or updates promotion PR
+            └─ pr-release-gate.yml on that PR
+
+merge promotion PR to main
+  └─ execute-release.yml
+       └─ stable tag copy + release notes
+```
+
+## Workflow Ownership Table
+
+| Workflow | Owns | Normal trigger |
+|---|---|---|
+| `.github/workflows/build.yml` | BST build into remote CAS | `merge_group`, `workflow_dispatch` |
+| `.github/workflows/publish.yml` | export, sign, boot-check, promote tags | `workflow_run` from build |
+| `.github/workflows/publish-smoke.yml` | observational smoke only | `workflow_run` from publish |
+| `.github/workflows/e2e.yml` | PR-facing testsuite check | `pull_request` |
+| `.github/workflows/promote-testing-to-main.yml` | open/update promotion PR | `push: testing`, schedule, manual |
+| `.github/workflows/pr-release-gate.yml` | promotion PR gate | `pull_request` to `main` |
+| `.github/workflows/execute-release.yml` | stable release execution | `push: main`, manual |
+| `.github/workflows/cache-warm.yml` | warm CAS for later queue builds | schedule, manual |
+
+## Branch / Tag Map
+
+| Branch | Result |
+|---|---|
+| `main` | merged changes build, publish `:$sha`, then promote to `:testing` |
+| `testing` | source branch for promotion PRs into `main` |
+| `next` | rolling GNOME master stream; publish to `:next` and `:btw`, never stable |
+| `gh-readonly-queue/main/*` | merge-queue build path for `main` |
+| `gh-readonly-queue/next/*` | merge-queue build path for `next` |
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "Publish failed, so build must be broken." | Often false. Build, publish, boot, smoke, and promotion are separate stages. |
+| "Nothing ran, so GitHub is flaky." | Usually the trigger or branch filter is wrong. |
+| "The schedule still owns :testing." | Not anymore. Every successful merge publishes immediately. |
+
+## Red Flags
+
+- Debugging `publish.yml` when the branch only ever hits `e2e.yml`
+- Treating `testing` as the branch that publishes stable directly
+- Editing a workflow before checking whether a different workflow actually owns the stage
+- Assuming `workflow_dispatch` behaves like `workflow_run`
+
+## Verification
+
+- [ ] You can name the owning workflow for the failing stage
+- [ ] You can state the trigger event and branch filter
+- [ ] You know whether the signal is PR-time, merge-time, publish-time, or promotion-time
+- [ ] You loaded a narrower follow-up skill before touching YAML


### PR DESCRIPTION
## Summary
- turn `docs/skills/ci.md` into a load-first router instead of a giant catch-all
- preserve long-tail CI prior art in `docs/skills/ci-reference.md`
- add focused CI skills for workflow mapping, tooling failures, boot/e2e, and release promotion
- rewrite key entry skills (`README`, `not-bluefin`, `quickstart`, `actionadon`, `add-package`, `buildstream`, `debugging`) around the canonical agent-skills structure
- add Context7 source metadata where the skill content depends on GitHub Actions, bootc, BuildStream, or the canonical agent-skills spec

## Why
The skill set had drifted toward a few oversized documents, especially CI. That hurts agent efficiency in two ways:
1. agents load far more context than they need before they even classify the task
2. new lessons land in giant files instead of reinforcing the factory model with focused, reusable guidance

This refactor keeps the memory but changes the loading shape: route first, then read the narrowest skill.

## Verification
- audited the changed skills for canonical sections: `When to Use`, `When NOT to Use`, `Core Process`, `Common Rationalizations`, `Red Flags`, `Verification`
- verified all route targets referenced by `docs/SKILL.md` and `docs/skills/README.md` exist
- used Context7 for the agent-skills structure and for the GitHub Actions / bootc / BuildStream-backed skills

Assisted-by: OpenAI GPT-5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized the skill documentation into a clearer router, with task-to-skill guidance, a new “Fast Path” workflow, and a narrower routing approach to reduce distraction and keep edits focused.
  * Added multiple CI-focused guides (CI router, tooling/plumbing troubleshooting, workflow mapping, E2E/boot CI, and release promotion).
  * Updated many existing skills with consistent “When to Use/When NOT to Use,” “Core Process,” plus stronger troubleshooting, red flags, and verification checklists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->