### PR TITLE
fix(ci): unblock dakota publish pipeline

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,3 +53,6 @@ jobs:
 
       - name: Run actionlint
         run: ./actionlint -color .github/workflows/*.yml
+
+      - name: Check publish workflow policy
+        run: python3 scripts/check_publish_workflow.py

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,6 +53,3 @@ jobs:
 
       - name: Run actionlint
         run: ./actionlint -color .github/workflows/*.yml
-
-      - name: Check publish workflow policy
-        run: python3 scripts/check_publish_workflow.py

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -258,18 +258,17 @@ jobs:
         run: |
           set -euo pipefail
           fallocate -l 30G disk.raw
-          # Use the documented raw-image install path: bootc manages the loop
-          # device lifecycle internally, writes a generic VM image layout, and
-          # uses the same xfs root filesystem users get by default.
-          # Source: https://github.com/bootc-dev/bootc/blob/main/docs/src/bootc-install.md
-          sudo podman run --rm --privileged --pid=host --ipc=host \
+          # Match the working testsuite raw-image flow: let the image's own
+          # bootc install config provide the xfs rootfs + systemd bootloader
+          # defaults, and only pass the raw file path via --via-loopback.
+          # Dakota ships those defaults in files/bootc-install/00-defaults.toml.
+          # Source: projectbluefin/testsuite/.github/actions/gnome-e2e/action.yml
+          sudo podman run --rm --privileged --pid=host \
             --security-opt label=type:unconfined_t \
             -v /dev:/dev \
             -v /var/lib/containers:/var/lib/containers \
             -v "$(pwd):/data" \
             "${IMAGE}" bootc install to-disk \
-              --generic-image \
-              --filesystem xfs \
               --via-loopback /data/disk.raw \
               --wipe \
             || { rc=$?; echo "bootc install exited ${rc} — checking whether the deployment was written"; }
@@ -501,9 +500,10 @@ jobs:
           if-no-files-found: ignore
 
   # ── Generate and attach SBOM ──────────────────────────────────────────────
-  # Runs outside the critical path to :testing. A fresh runner fetches BST
-  # metadata from remote CAS (no full
-  # artifact download needed; bst show reads element graph only).
+  # Runs outside the critical path to :testing. Failures here must not block
+  # publish/promotion; stable release notes already regenerate SBOM inline in
+  # execute-release.yml. A fresh runner fetches BST metadata from remote CAS
+  # (no full artifact download needed; bst show reads element graph only).
   # P3: pip wheel cache keyed to the pinned buildstream-sbom commit SHA so
   # repeated runs skip the GitLab git fetch entirely.
   publish-sbom:
@@ -518,7 +518,7 @@ jobs:
             element: oci/bluefin.bst
             image_suffix: ''
             sbom_filename: dakota.spdx.json
-            continue: false
+            continue: true
           - variant: nvidia
             element: oci/bluefin-nvidia.bst
             image_suffix: '-nvidia'

--- a/Justfile
+++ b/Justfile
@@ -62,7 +62,12 @@ bst *ARGS:
 
 # Validate BST element graph — mirrors CI validate job.
 [group('dev')]
+check-publish-workflow:
+    python3 scripts/check_publish_workflow.py
+
+[group('dev')]
 validate:
+    just check-publish-workflow
     just bst show --deps all oci/bluefin.bst
     just bst show --deps all oci/bluefin-nvidia.bst
 

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -1769,13 +1769,13 @@ type = "xfs"
 
 No behaviour change for users — xfs was always the implicit default. This makes it explicit.
 
-### `bootc install to-disk` — correct approach for CI loop devices (2026-06-16)
+### `bootc install to-disk` — correct approach for CI loop devices (2026-06-16, updated 2026-06-17)
 
-**Use `--via-loopback` with the raw file path.** This is the documented bootc
-pattern for disk images. bootc manages the loop device lifecycle internally,
-eliminating all host-side partition-node race conditions.
+**Use `--via-loopback` with the raw file path, and let the image's own bootc
+install config provide the xfs rootfs + systemd bootloader defaults.**
 
-Source: https://github.com/bootc-dev/bootc/blob/main/docs/src/bootc-install.md
+Working reference: `projectbluefin/testsuite/.github/actions/gnome-e2e/action.yml`
+Source docs: https://github.com/bootc-dev/bootc/blob/main/docs/src/bootc-install.md
 
 ```bash
 fallocate -l 30G disk.raw
@@ -1803,11 +1803,21 @@ if ! sudo blkid "${LOOP}p3" &>/dev/null; then
 fi
 ```
 
-**Why `--via-loopback` works:** bootc creates and manages the loop device
-inside the container where it controls the full lifecycle. Partition nodes
-appear correctly because bootc owns the device end-to-end. After the container
-exits, attaching with `-P` on a file that already has a partition table triggers
-a synchronous kernel scan — nodes are ready immediately.
+Dakota already ships the real install defaults in `files/bootc-install/00-defaults.toml`:
+
+```toml
+[install]
+bootloader = "systemd"
+
+[install.filesystem.root]
+type = "xfs"
+```
+
+**Why this shape matters:** `--via-loopback` keeps bootc in control of the loop
+lifecycle, avoiding host-side partition-node races. But the workflow should not
+re-specify `--generic-image` or `--filesystem xfs` ad hoc — that drifted away
+from the working testsuite flow and reintroduced `Creating rootfs: No such file
+or directory (os error 2)` in Dakota publish boot-checks on 2026-06-17.
 
 **Do NOT:**
 - Pre-create a host loop device and pass it as a block device path — bootc's
@@ -1816,7 +1826,11 @@ a synchronous kernel scan — nodes are ready immediately.
   removing the nodes you just created.
 - Pre-partition with `sfdisk` before running bootc — bootc refuses with
   "Detected existing partitions".
+- Add `--generic-image` or `--filesystem xfs` back into the CI boot-check
+  command; Dakota already gets xfs/systemd from image install config.
 
 **Note:** The boot-check gate never passed from PR #849 (2026-06-13) through
-PR #895 (2026-06-16) due to iterating on the wrong approach. The fix was
-always to use `--via-loopback` as documented. The image works on real hardware.
+PR #895 (2026-06-16) due to iterating on the wrong approach. The first stable
+shape was `--via-loopback`; the 2026-06-17 regression came from drifting away
+from the working testsuite invocation, not from a need to go back to host-side
+loop handling.

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -1769,7 +1769,7 @@ type = "xfs"
 
 No behaviour change for users — xfs was always the implicit default. This makes it explicit.
 
-### `bootc install to-disk` — correct approach for CI loop devices (2026-06-16, updated 2026-06-17)
+### `bootc install to-disk` correct approach for CI loop devices (2026-06-17)
 
 **Use `--via-loopback` with the raw file path, and let the image's own bootc
 install config provide the xfs rootfs + systemd bootloader defaults.**

--- a/scripts/check_publish_workflow.py
+++ b/scripts/check_publish_workflow.py
@@ -54,6 +54,8 @@ else:
     )
     if not default_continue:
         errors.append('publish-sbom default variant must stay continue-on-error via continue: true')
+    if 'continue-on-error: ${{ matrix.continue }}' not in sbom_body:
+        errors.append('publish-sbom job must wire continue-on-error: ${{ matrix.continue }}')
 
 if errors:
     for err in errors:

--- a/scripts/check_publish_workflow.py
+++ b/scripts/check_publish_workflow.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import re
+import sys
+
+publish = Path('.github/workflows/publish.yml').read_text()
+install_defaults = Path('files/bootc-install/00-defaults.toml').read_text()
+
+match = re.search(
+    r'- name: Install image to disk via bootc\n(?P<body>.*?)(?:\n\s*- name: |\n\s*# ──)',
+    publish,
+    re.S,
+)
+if not match:
+    print('could not find boot-check install step in .github/workflows/publish.yml', file=sys.stderr)
+    sys.exit(1)
+
+body = match.group('body')
+errors = []
+
+required = [
+    '--via-loopback /data/disk.raw',
+    '--wipe',
+]
+for token in required:
+    if token not in body:
+        errors.append(f'missing {token!r} in boot-check install step')
+
+forbidden = [
+    '--generic-image',
+    '--filesystem xfs',
+]
+for token in forbidden:
+    if token in body:
+        errors.append(f'unexpected {token!r} in boot-check install step')
+
+if 'bootloader = "systemd"' not in install_defaults:
+    errors.append('files/bootc-install/00-defaults.toml must set bootloader = "systemd"')
+if 'type = "xfs"' not in install_defaults:
+    errors.append('files/bootc-install/00-defaults.toml must set root filesystem type = "xfs"')
+
+sbom_match = re.search(
+    r'publish-sbom:\n(?P<body>.*?)(?:\n\S|\Z)',
+    publish,
+    re.S,
+)
+if not sbom_match:
+    errors.append('could not find publish-sbom job in .github/workflows/publish.yml')
+else:
+    sbom_body = sbom_match.group('body')
+    default_continue = re.search(
+        r'- variant: default\n\s+element: oci/bluefin\.bst\n\s+image_suffix: \'\'\n\s+sbom_filename: dakota\.spdx\.json\n\s+continue: true',
+        sbom_body,
+    )
+    if not default_continue:
+        errors.append('publish-sbom default variant must stay continue-on-error via continue: true')
+
+if errors:
+    for err in errors:
+        print(err, file=sys.stderr)
+    sys.exit(1)
+
+print('publish workflow boot-check install path looks sane')


### PR DESCRIPTION
## What

- Drop `--generic-image` and `--filesystem xfs` from the boot-check `bootc install to-disk` step; rely on `files/bootc-install/00-defaults.toml` for xfs+systemd defaults (matching the working `projectbluefin/testsuite` raw-image flow)
- Set `publish-sbom` default variant `continue: true` so a flaky BuildStream FUSE-stager fetch does not block `:testing` promotion
- Add `scripts/check_publish_workflow.py` so future workflow drift is caught by `just validate`

## Why

Publish has been red since at least 2026-06-13. The rerun of run [27658617120](https://github.com/projectbluefin/dakota/actions/runs/27658617120) showed `publish-image` is fine; the two blockers were:
1. `boot-check` — `bootc install to-disk --generic-image --filesystem xfs` hit `Creating rootfs: No such file or directory`; removing the ad-hoc flags and using the image's install config fixes it
2. `publish-sbom` — flaky BuildStream FUSE-stager; `execute-release` already regenerates SBOM inline, so this should never block publish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD publish workflow validation to align bootc “install to-disk” usage with configured defaults, avoiding configuration drift.
  * Added an automated policy check for the publish workflow and ensured SBOM generation for the default variant won’t fail the overall matrix run.
* **Documentation**
  * Updated CI documentation for the bootc install-to-disk boot-check loop-device workflow, clarifying what to include/exclude to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->