### PR TITLE
fix(ci): add --bootloader none and --ipc=host to boot-check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -263,7 +263,7 @@ jobs:
           # defaults, and only pass the raw file path via --via-loopback.
           # Dakota ships those defaults in files/bootc-install/00-defaults.toml.
           # Source: projectbluefin/testsuite/.github/actions/gnome-e2e/action.yml
-          sudo podman run --rm --privileged --pid=host \
+          sudo podman run --rm --privileged --pid=host --ipc=host \
             --security-opt label=type:unconfined_t \
             -v /dev:/dev \
             -v /var/lib/containers:/var/lib/containers \
@@ -271,6 +271,7 @@ jobs:
             "${IMAGE}" bootc install to-disk \
               --via-loopback /data/disk.raw \
               --filesystem ext4 \
+              --bootloader none \
               --wipe \
             || { rc=$?; echo "bootc install exited ${rc} — checking whether the deployment was written"; }
           sudo podman rmi "${IMAGE}" 2>/dev/null || true


### PR DESCRIPTION
## Problem

bootc v1.16.x fails hard when bootupd cannot run in the CI container environment:

```
Initializing ostree layout
error: Installing to disk: bootupd is required for ostree-based installs
```

This exits before the ostree deployment is written, so the Extract step finds an empty disk and fails.

## Fix

- `--bootloader none` — skips bootupd entirely. For CI we only need the ostree deployment on disk; QEMU boots via direct kernel/initramfs extraction so the bootloader is irrelevant. Documented in bootc [bootloaders.md](https://github.com/bootc-dev/bootc/blob/main/docs/src/bootloaders.md): *"Users can opt out of bootloader installation entirely by specifying '--bootloader=none'"* (supported for ostree backend + `--generic-image`).
- `--ipc=host` — matches the canonical loopback install invocation from bootc install docs.

## History

The boot-check has never passed since PR #849 added it on 2026-06-13. Each attempt fixed one error and exposed the next:
1. No root filesystem specified → fixed by xfs TOML (#1a865c6)
2. mkfs.xfs not found → fixed by --filesystem ext4 (#909)
3. bootupd required → fixed here with --bootloader none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment workflow configuration to refine container execution and installation settings during the automated publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->