### PR TITLE
fix(ci): find OSTREE_PATH from boot.1 tree instead of BLS entries

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -263,6 +263,9 @@ jobs:
           # defaults, and only pass the raw file path via --via-loopback.
           # Dakota ships those defaults in files/bootc-install/00-defaults.toml.
           # Source: projectbluefin/testsuite/.github/actions/gnome-e2e/action.yml
+          # --ipc=host: bootc's loopback install uses IPC for udevd/mount
+          # coordination inside the privileged container; without it the
+          # loopback attach races and partitions may not be visible.
           sudo podman run --rm --privileged --pid=host --ipc=host \
             --security-opt label=type:unconfined_t \
             -v /dev:/dev \
@@ -292,10 +295,10 @@ jobs:
         run: |
           set -euo pipefail
           # Reuse the loop device attached by the install step.
-          # Disk layout from bootc (systemd-boot, x86-64):
-          #   p1 = BIOS boot (1 MiB, grub fallback)
-          #   p2 = EFI System / xbootldr (512 MiB, holds BLS entries)
-          #   p3 = Linux root — xfs, ostree deployments live here
+          # Disk layout from bootc (--bootloader none, x86-64):
+          #   p1 = BIOS boot (1 MiB)
+          #   p2 = EFI System (512 MiB, not populated — bootloader skipped)
+          #   p3 = Linux root — ext4, ostree deployments live here
           LOOP="${BOOT_CHECK_LOOP}"
           if [ -z "${LOOP}" ] || ! sudo losetup "${LOOP}" &>/dev/null; then
             # Fallback: re-attach if the install step detached it
@@ -304,7 +307,6 @@ jobs:
           fi
           echo "Loop: ${LOOP}"
           ROOT_PART="${LOOP}p3"
-          BOOT_PART="${LOOP}p2"
           sudo mount "${ROOT_PART}" /mnt
           ROOT_UUID=$(sudo blkid -s UUID -o value "${ROOT_PART}")
           echo "root=${ROOT_PART}  uuid=${ROOT_UUID}"
@@ -316,15 +318,14 @@ jobs:
           VAR="/mnt/ostree/deploy/default/var"
           echo "deploy=${DEPLOY}"
 
-          # Read the exact OSTREE_PATH from the BLS boot entry.
-          # bootc writes /ostree/boot.1/default/TREEHASH/N — a different hash
-          # from the deploy directory name; must be read from the entry.
-          sudo mkdir -p /mnt_boot
-          sudo mount "${BOOT_PART}" /mnt_boot
-          OSTREE_PATH=$(sudo grep -rh '^options' /mnt_boot/loader/entries/*.conf 2>/dev/null \
-            | grep -o 'ostree=[^ ]*' | head -1 | sed 's/ostree=//')
-          sudo umount /mnt_boot
-          [[ -z "${OSTREE_PATH}" ]] && { echo "ERROR: could not read OSTREE_PATH from BLS entries"; exit 1; }
+          # --bootloader none skips writing BLS entries to the ESP, so we
+          # find OSTREE_PATH directly from the ostree boot.1 tree on the root
+          # filesystem. bootc writes /ostree/boot.1/default/TREEHASH/N
+          # regardless of bootloader mode. Fresh install always has exactly
+          # one deployment so sort | head -1 is deterministic.
+          OSTREE_PATH=$(sudo find /mnt/ostree/boot.1/default -mindepth 2 -maxdepth 2 \
+            -type d 2>/dev/null | sort | head -1 | sed 's|^/mnt||')
+          [[ -z "${OSTREE_PATH}" ]] && { echo "ERROR: could not find OSTREE_PATH in /ostree/boot.1"; exit 1; }
           echo "ostree_path=${OSTREE_PATH}"
 
           # Pick kernel version that has vmlinuz


### PR DESCRIPTION
Replaces #914 (conflicted).

## Problem

`--bootloader none` (#912) fixed the `bootupd is required` error, but introduced a new failure: the **Extract** step tries to mount `${LOOP}p2` and read `ostree=` from `loader/entries/*.conf` (BLS boot entries). With `--bootloader none`, systemd-boot never writes those entries, so `sudo mount` fails instantly and the job exits (set -e):

```
deploy=9f4c36b9...
##[error]Process completed with exit code 1.
```

`vm-serial.log` is never uploaded (QEMU never ran), and `promote-to-testing` is blocked because it requires `boot-check.result == 'success'`.

## Fix

Remove the `BOOT_PART` mount entirely. Instead, scan the ostree `boot.1` tree on the root filesystem — `bootc` writes `/ostree/boot.1/default/TREEHASH/N` as part of the ostree deployment, regardless of bootloader mode:

```bash
OSTREE_PATH=$(sudo find /mnt/ostree/boot.1/default -mindepth 2 -maxdepth 2 \
  -type d 2>/dev/null | sort | head -1 | sed 's|^/mnt||')
```

Also documents why `--ipc=host` is required for the loopback install.

## History

Boot-check has never passed since it was added in #849 (2026-06-13). Each fix exposed the next layer:
1. No root filesystem → fixed by xfs TOML
2. mkfs.xfs not found → fixed by `--filesystem ext4` (#909)
3. bootupd required → fixed by `--bootloader none` (#912)
4. **BLS entries missing → fixed here**

## Testing

- [ ] I am using an agent and I take responsibility for this PR

Assisted-by: Claude Sonnet 4.5 via pi