### PR TITLE
fix(ci): check gdm not-failed instead of is-active in headless QEMU

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -480,7 +480,23 @@ jobs:
           "${SSH[@]}" sudo systemctl is-active multi-user.target
 
           echo "==> gdm.service"
-          "${SSH[@]}" sudo systemctl is-active gdm.service
+          # In headless QEMU (-display none) GDM is 'inactive' — no display device,
+          # so the display-manager never starts. That is expected and OK.
+          # Fail only if GDM is in 'failed' state, which means it crashed — a real
+          # image regression. 'inactive' / 'activating' are both acceptable here.
+          if ! GDM_STATE=$("${SSH[@]}" sudo systemctl show gdm.service --property=ActiveState --value 2>/dev/null); then
+            echo "ERROR: unable to query gdm.service ActiveState"
+            exit 1
+          fi
+          if [[ -z "${GDM_STATE}" ]]; then
+            echo "ERROR: empty gdm.service ActiveState — unit may not exist"
+            exit 1
+          fi
+          echo "GDM state: ${GDM_STATE}"
+          if [[ "${GDM_STATE}" == "failed" ]]; then
+            echo "ERROR: gdm.service is in failed state — image regression"
+            exit 1
+          fi
 
           echo "==> no failed critical units"
           FAILED=$("${SSH[@]}" sudo systemctl list-units --state=failed --no-legend \

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -1607,7 +1607,7 @@ not AT-SPI tests).
 
 | Job | Gate type | What it checks | Target time |
 |---|---|---|---|
-| `boot-check` | **Hard** — blocks promote | bootc install → boot → SSH → `gdm active` | ~10 min |
+| `boot-check` | **Hard** — blocks promote | bootc install → boot → SSH → GDM not-failed | ~10 min |
 | `smoke` | Observational | Full testsuite smoke suite (AT-SPI etc.) | ~80 min |
 
 The `promote` job gates on `boot-check.result == 'success'`. Smoke
@@ -1616,8 +1616,17 @@ removing it from `needs` is what makes it truly non-blocking (an `if:`
 condition alone is insufficient; the job still waits if the dep is in `needs`).
 
 **Rule:** The per-merge gate should always be a deterministic boot
-check (SSH reachable + GDM active). The full AT-SPI suite belongs in
-the weekly pre-stable gate, not the per-merge pre-testing gate.
+check (SSH reachable + GDM not-crashed). The full AT-SPI suite belongs
+in the weekly pre-stable gate, not the per-merge pre-testing gate.
+
+**GDM headless caveat:** QEMU runs with `-display none` (no display
+device). GDM will be `inactive` in this environment — that is expected
+behavior, not a regression. The health check uses
+`systemctl show gdm.service --property=ActiveState` and fails only if
+the state is `failed` (GDM crashed). `inactive` / `activating` are
+both acceptable. Using `systemctl is-active gdm.service` was wrong:
+it exits 3 on `inactive`, which triggers `set -e` and blocks every
+promote run regardless of image health.
 
 ### Observational reusable-workflow jobs must be split out of publish.yml (2026-06-16)
 


### PR DESCRIPTION
## Summary

`:testing` has not been promoted since June 12 (6 days). Every `publish.yml` run since the boot-check was introduced in #849 ends with the boot-check job failing, which causes the `promote` job to be skipped.

## Root cause

The health-check step asserts GDM is running:

```bash
"${SSH[@]}" sudo systemctl is-active gdm.service
```

The boot-check QEMU VM starts with `-display none`. No display device is presented to the guest, so `gdm.service` is always `inactive` — the display-manager has nothing to bind to. `systemctl is-active` exits 3 on `inactive`; combined with `set -euo pipefail`, the step fails on every run regardless of actual image health.

This is a CI configuration issue, not an image regression.

## Fix

Replace `systemctl is-active` with a query against `ActiveState` that only fails when GDM has crashed:

```bash
GDM_STATE=$("${SSH[@]}" sudo systemctl show gdm.service --property=ActiveState --value 2>/dev/null || true)
echo "GDM state: ${GDM_STATE:-unknown}"
if [[ "${GDM_STATE}" == "failed" ]]; then
  echo "ERROR: gdm.service is in failed state — image regression"
  exit 1
fi
```

`inactive` and `activating` are both accepted in a headless environment. `failed` (GDM crashed) still blocks promotion.

## Effect

- `boot-check` passes → `promote` runs → `:testing` is re-tagged on every successful build from `main`
- Actual GDM regressions (package errors, unit crashes) continue to be caught via the `failed` state check

## Checklist

- [x] `actionlint` passes (no output)
- [x] `docs/skills/ci.md` updated with GDM headless behaviour note
- [x] I am using an agent and I take responsibility for this PR

Assisted-by: Claude Sonnet 4.5 via pi