### PR TITLE
feat(ci): nightly next branch build at 03:00 UTC

### DIFF
--- a/.github/workflows/nightly-next-build.yml
+++ b/.github/workflows/nightly-next-build.yml
@@ -1,0 +1,37 @@
+name: Nightly next build
+
+# Dispatches a build on the next branch every night at 03:00 UTC.
+#
+# Why a separate workflow instead of a schedule in build.yml:
+#   GitHub schedule events always run on the default branch. build.yml on
+#   main cannot directly trigger a build on next via schedule.
+#
+# Timing rationale:
+#   - gnome-build-meta nightly finishes  ~08:00 UTC
+#   - track-next-junctions opens PR       20:00 UTC  (artifacts confirmed in CAS)
+#   - junction PR auto-merges             ~21:00 UTC
+#   - this workflow fires                  03:00 UTC  (+6 h margin, US off-hours)
+#
+# The build triggered here runs through the normal build.yml → publish.yml
+# chain, so :next and :btw tags are updated automatically on success.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  dispatch:
+    name: Trigger next branch build
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch build.yml on next
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yml \
+            --repo "${{ github.repository }}" \
+            --ref next
+          echo "Build dispatched on next branch"


### PR DESCRIPTION
## Problem

Mergeraptor PR merges on `next` do not create push events, so `build.yml` never fires automatically after junction bumps. The `next` branch went 9 days without a build despite 5 junction updates landing.

## Fix

Add `nightly-next-build.yml` — a thin scheduler that dispatches `build.yml` on `next` every night at 03:00 UTC.

**Timing rationale:**
| Event | Time (UTC) |
|---|---|
| gnome-build-meta nightly finishes | ~08:00 |
| `track-next-junctions` opens junction-bump PR | 20:00 |
| Junction PR auto-merges | ~21:00 |
| **This workflow fires** | **03:00 (+1 day)** |

03:00 UTC is 6 hours after the junction lands (artifacts confirmed in CAS) and maps to 8pm PDT — outside US active development hours, so the BST remote executor isn't competing with `main` branch builds.

The build triggered here runs through the normal `build.yml` → `publish.yml` chain, so `:next` and `:btw` tags update automatically on success.

`workflow_dispatch` is also included so the nightly can be kicked off manually.

## Checklist

- [x] `actionlint` passes
- [x] I am using an agent and I take responsibility for this PR

Assisted-by: Claude Sonnet 4.5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated nightly build process for the development branch, running daily at 03:00 UTC with manual trigger capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->