### PR TITLE
fix(ci): guard squash branch deletion when promotion PR is open

### DIFF
--- a/.github/workflows/sync-main-to-testing.yml
+++ b/.github/workflows/sync-main-to-testing.yml
@@ -37,6 +37,20 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Guard: do not delete the squash branch while a promotion PR is open.
+          # Every push to main triggers this workflow — including normal PR merges.
+          # Deleting the branch with an open PR leaves the PR pointing at a ghost
+          # ref, causing permanent UNKNOWN mergeability that requires manual recovery.
+          OPEN=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head auto/promote-testing-to-main \
+            --state open \
+            --json number \
+            --jq 'length')
+          if [[ "$OPEN" -gt 0 ]]; then
+            echo "Open promotion PR exists — skipping branch deletion"
+            exit 0
+          fi
           gh api repos/${{ github.repository }}/git/refs/heads/auto/promote-testing-to-main \
             -X DELETE 2>/dev/null \
             && echo "✅ Deleted squash promotion branch" \


### PR DESCRIPTION
## Problem

`sync-main-to-testing` fires on every push to `main`, including normal PR merges. The `cleanup-squash-branch` job unconditionally deleted `auto/promote-testing-to-main` on every run, even when a promotion PR was open and pointing at that branch.

Result: every PR merged to `main` while a promotion PR was open would silently delete the squash branch, leaving the promotion PR pointing at a ghost ref. GitHub then computes `UNKNOWN` mergeability permanently. Recovery requires manually closing the PR and re-running the promote workflow.

## Fix

Check for open PRs targeting `auto/promote-testing-to-main` before deleting. Skip deletion if any exist.

## Checklist

- [x] `actionlint` passes
- [x] I am using an agent and I take responsibility for this PR

Assisted-by: Claude Sonnet 4.5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved promotion workflow reliability by preventing branch deletion when open promotion pull requests exist for that branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->