### PR TITLE
fix(ci): align execute-release trigger with actual promotion commit format

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             echo "is-promotion=true" >> "$GITHUB_OUTPUT"
-          elif echo "$COMMIT_MSG" | grep -q "^ci: promote testing images to stable"; then
+          elif echo "$COMMIT_MSG" | grep -qE "^ci\(promote\): dakota testing|^chore: promote testing to main"; then
             echo "is-promotion=true" >> "$GITHUB_OUTPUT"
           else
             echo "is-promotion=false" >> "$GITHUB_OUTPUT"

--- a/docs/skills/release-promotion.md
+++ b/docs/skills/release-promotion.md
@@ -110,48 +110,59 @@ gh run list --repo projectbluefin/dakota --workflow 'Promote testing to main' --
 
 ---
 
-## How to cut a stable release
+## How stable releases work
 
-```bash
-gh workflow run execute-release.yml --repo projectbluefin/dakota
-```
+The stable release is **driven entirely by the promotion PR**. The flow is:
 
-That is the entire release command. `execute-release.yml` is always triggered
-via `workflow_dispatch` by a human. It is NOT automatically triggered by a
-promotion PR merging.
+1. `promote-testing-to-main.yml` runs (on push to `testing`, nightly, or manual dispatch)
+   and opens/updates the `auto/promote-testing-to-main` PR.
+2. A maintainer reviews the PR and approves it **at their discretion**.
+3. Approval triggers auto-merge → the squash commit lands on `main`.
+4. `execute-release.yml` detects the promotion commit and runs `reusable-execute-release.yml`
+   → `:stable` and `:latest` OCI tags are updated and a GitHub Release is created.
 
-The `check-trigger` job in `execute-release.yml` also accepts commit messages
-starting with `^ci: promote testing images to stable`, but in practice every
-stable release since the pipeline was built has been a manual dispatch.
+**There is no separate "cut a release" command.** The maintainer's approval on
+the promotion PR IS the release action.
+
+The `workflow_dispatch` path on `execute-release.yml` exists as a break-glass
+fallback only. Do not use it routinely — use it only when the promotion PR
+pipeline is broken and a release cannot wait.
 
 ---
 
 ## Lessons Learned
 
-### The promotion PR is git housekeeping, not the release trigger (2026-06-19)
+### execute-release.yml trigger pattern was wrong — automated promotion was broken (2026-06-19)
 
-**Mistake:** Closing the open promotion PR (#901) because its squash branch was
-deleted, then concluding "nothing to promote" and telling the maintainer the
-factory was healthy — while they had been trying to cut a stable release all day.
+`execute-release.yml` checked for `^ci: promote testing images to stable` but
+the squash commit that lands on `main` from the promotion PR has title
+`chore: promote testing to main` (set by `reusable-promote-squash.yml`).
 
-**Reality:**
-- The promotion PR (`auto/promote-testing-to-main`) squash-merges the `testing`
-  git branch into `main`. This is a git bookkeeping operation.
-- It does **not** cut a stable release. The stable release is always a separate
-  manual `workflow_dispatch` on `execute-release.yml`.
-- `testing` git branch == `main` tree does NOT mean "nothing to release". It
-  means the git trees are in sync. A new `:stable` OCI image can still be cut
-  from whatever `:testing` currently points to.
+This mismatch meant `execute-release.yml` NEVER fired automatically from a
+promotion PR merge. Every stable release required a manual `workflow_dispatch`.
 
-**Rule:** Never close a promotion PR that has maintainer approval. If the squash
-branch is deleted, rebuild it by re-running `promote-testing-to-main.yml` — do
-not close the PR and re-run, because re-running after the trees are in sync will
-say "nothing to promote" and leave no path to the release.
+**Fix:** Updated `execute-release.yml` check-trigger to match the actual commit
+patterns:
+```
+^ci\(promote\): dakota testing
+^chore: promote testing to main
+```
 
-**Recovery when promotion PR was incorrectly closed:**
+---
+
+### Never close a promotion PR with maintainer approval (2026-06-19)
+
+**Mistake:** Closing PR #901 (promotion PR with ahmed's approval) because its
+squash branch was deleted, then re-running promote which found testing=main and
+opened no new PR, leaving no path to the release.
+
+**Rule:** If the squash branch is deleted with an open promotion PR, rebuild the
+branch — do not close the PR. Re-run `promote-testing-to-main.yml`: if the
+branch content is unchanged it will skip the force-push and preserve the approval.
+
+**Recovery if promotion PR was incorrectly closed:**
 ```bash
-# Re-run promote — if testing != main tree it opens a fresh PR
 gh workflow run promote-testing-to-main.yml --repo projectbluefin/dakota
-# If testing == main tree (promote says "nothing to promote"), cut stable directly:
+# If testing == main tree and promote says "nothing to promote", use break-glass:
 gh workflow run execute-release.yml --repo projectbluefin/dakota
 ```


### PR DESCRIPTION
## Problem

`execute-release.yml` checked for `^ci: promote testing images to stable` but the squash commit that lands on `main` from the promotion PR is titled `chore: promote testing to main` (set by `reusable-promote-squash.yml` in `projectbluefin/actions`).

This mismatch meant `execute-release.yml` **never** fired automatically from a promotion PR merge. Every stable release required a manual `workflow_dispatch` workaround.

## Fix

Match both the branch commit title and the PR title format:

```
^ci\(promote\): dakota testing
^chore: promote testing to main
```

Also corrects `docs/skills/release-promotion.md` which incorrectly documented the release as always-manual. The maintainer's approval on the promotion PR is the release trigger.

## Checklist

- [x] `actionlint` passes
- [x] I am using an agent and I take responsibility for this PR

Assisted-by: Claude Sonnet 4.5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected stable release automation to properly recognize promotion commits with updated commit message patterns.

* **Documentation**
  * Updated release promotion documentation with clarified workflow processes, lessons learned, and recovery instructions for promotion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->