### PR TITLE
fix(ci): exempt projectbluefin/testsuite from floating-tag hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: no-floating-action-tags
         name: Block floating GitHub Action tags (external)
         language: pygrep
-        entry: 'uses:(?!.*projectbluefin/(actions|bonedigger)/).*@(main|master|latest|v[0-9])'
+        entry: 'uses:(?!.*projectbluefin/(actions|bonedigger|testsuite)/).*@(main|master|latest|v[0-9])'
         types: [yaml]
         files: '(^\.github/workflows/.*\.yml$|action\.yml$)'
       - id: no-sha-pins-for-internal-actions


### PR DESCRIPTION
## Problem

The `no-floating-action-tags` pre-commit hook exempted only `actions|bonedigger` from the floating-tag check. `projectbluefin/testsuite` uses `@main` (managed floating tag, same as all internal `projectbluefin/` refs) but was not exempted, so any PR touching `run-testsuite.yml` fails `validate`.

## Fix

Add `testsuite` to the hook's negative lookahead exemption:
`actions|bonedigger` → `actions|bonedigger|testsuite`