### PR TITLE
feat(audio): add lsp-plugins-lv2 for PipeWire DSP filter-chain

### DIFF
--- a/docs/skills/add-package.md
+++ b/docs/skills/add-package.md
@@ -139,3 +139,22 @@ variables:
 ### BST variables cannot be used in source URL fields (2026-06-07)
 
 Unlike install commands where `%{version}` expands correctly, BuildStream does NOT expand variables inside `sources[].url:` fields. Use `include/aliases.yml` to define a URL alias, then reference the alias.
+
+### lsp-plugins 1.1.x is self-contained; 1.2.x requires network module fetching (2026-06-21)
+
+The `sadko4u/lsp-plugins` GitHub repo (redirects to `lsp-plugins/lsp-plugins`) switched to a modular
+build system in the 1.2.x series that runs `make fetch` to download ~12 submodules at build time.
+The 1.1.x series (latest: 1.1.26) is monolithic and BST-safe. Use 1.1.x for BST packaging.
+
+Build LV2 only (no UI, no JACK, no standalone):
+
+```yaml
+variables:
+  make-args: >-
+    BUILD_MODULES=lv2
+    LV2_UI=0
+    BUILD_R3D_BACKENDS=
+    PREFIX=%{prefix}
+```
+
+External dep: `freedesktop-sdk.bst:components/sndfile.bst`. No external LV2 headers needed — bundled.

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -40,6 +40,7 @@ depends:
   - bluefin/gnome-ponytail-daemon.bst
   - bluefin/network.bst
   - bluefin/countme.bst
+  - bluefin/lsp-plugins-lv2.bst
 
   # Include things missing from the gnomeos base image
   - gnome-build-meta.bst:core-deps/fwupd.bst

--- a/elements/bluefin/lsp-plugins-lv2.bst
+++ b/elements/bluefin/lsp-plugins-lv2.bst
@@ -1,0 +1,22 @@
+kind: make
+
+sources:
+- kind: git_repo
+  url: github:sadko4u/lsp-plugins.git
+  track: lsp-plugins-1.1.*
+  ref: lsp-plugins-1.1.26-0-gad2720345ce5dffb45f871146de1ae6d16f4c73d
+
+variables:
+  make-args: >-
+    BUILD_MODULES=lv2
+    LV2_UI=0
+    BUILD_R3D_BACKENDS=
+    PREFIX=%{prefix}
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-make.bst
+- freedesktop-sdk.bst:components/pkg-config.bst
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+- freedesktop-sdk.bst:components/sndfile.bst


### PR DESCRIPTION
Adds lsp-plugins 1.1.26 as a new BST element, building only the LV2 format (headless, no GUI) for use with PipeWire filter-chain configs.

lsp-plugins provides a full suite of DSP plugins including parametric EQ, compressor, limiter, gate, bass enhancer, and expander. These load natively via PipeWire filter-chain without Easy Effects or any Flatpak overhead.

The 1.1.x release series is self-contained (no network module fetching at build time). The element uses BUILD_MODULES=lv2 LV2_UI=0 BUILD_R3D_BACKENDS= to produce only the LV2 .so files (~2MB installed). External dependency: freedesktop-sdk libsndfile.

Closes #903

- [ ] I am using an agent and I take responsibility for this PR