### PR TITLE
docs(skills): onboard factory self-improvement infrastructure

### DIFF
--- a/.github/workflows/skill-drift.yml
+++ b/.github/workflows/skill-drift.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   skill-drift:
-    uses: projectbluefin/actions/.github/workflows/skill-drift-check.yml@99d867d662ab64a1f82b4f5f24f73b4051dbff01 # v1
+    uses: projectbluefin/actions/.github/workflows/skill-drift-check.yml@v1
     with:
       code-paths: '[".github/workflows/**", "build_files/**", "Justfile", "elements/**"]'
       skill-paths: '["docs/skills/**", "docs/*.md", "AGENTS.md"]'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,14 @@ Agent works on task
 - Obvious things any developer would know
 - Ephemeral state ("currently broken, fix pending")
 
+### What is banned
+
+These patterns actively harm the factory. **Delete them on sight.**
+
+- **Changelog files** (`IMPROVEMENTS.md`, `CHANGELOG.md`, `CHANGES.md`, `SESSION.md`, agent-authored progress logs) — agents append to them instead of updating skill files. The result: a stale changelog, skill files that never get updated.
+- **"Append here" instructions** — any doc saying "append when you ship something" is a hallucination magnet. Route to `docs/skills/<file>.md` instead.
+- **Session notes committed to the repo** (`NOTES.md`, `PLAN.md`, `TODO.md`) — these become stale context that misleads every future agent. Session state lives in `~/.copilot/session-state/` only, never committed.
+
 ### Where learnings live
 
 | You are working in... | Write to |

--- a/docs/skills/INDEX.md
+++ b/docs/skills/INDEX.md
@@ -1,0 +1,46 @@
+---
+name: skills-index-factory
+description: Factory-standard index for Dakota's docs/skills/. Points to the full routing table in README.md. Load when onboarding to this repo or auditing factory compliance.
+metadata:
+  type: index
+---
+
+# docs/skills — Factory Index
+
+> **Full routing table and fast paths:** [`README.md`](README.md)
+
+This repo's skill directory follows the `projectbluefin/common` factory standard.
+
+## Factory Compliance Checklist
+
+- [x] `skill-improvement.md` — two-output mandate, banned anti-patterns
+- [x] `README.md` — full routing table with fast paths per task class
+- [x] `skill-drift.yml` — CI warns when code changes without a skill update
+- [x] AGENTS.md — self-improvement loop, banned list, hard rules
+
+## What Belongs Here
+
+Workflow knowledge, architectural patterns, and operational runbooks that any agent needs to work effectively in this repo.
+
+**Not here:** agent-specific instruction files (`.github/copilot-instructions.md`, `AGENTS.md`) — those are loaded separately by their respective tools.
+
+## Cross-Repo Skill Home
+
+| Repo | Skill home |
+|---|---|
+| `projectbluefin/dakota` | This directory |
+| `projectbluefin/common` | [`common/docs/skills/`](https://github.com/projectbluefin/common/tree/main/docs/skills) |
+| Cross-cutting patterns | Open issue in `projectbluefin/common` with `kind/improvement` + `area/agent` |
+
+## Self-Improvement Standard
+
+Source: [`projectbluefin/common/docs/skills/factory-onboarding.md`](https://github.com/projectbluefin/common/blob/main/docs/skills/factory-onboarding.md)
+
+Every skill file must have:
+- Frontmatter: `name` + `description` with "Use when" trigger phrases
+- `## When to Use`
+- `## When NOT to Use`
+- `## Core Process` (numbered workflow)
+- `## Common Rationalizations`
+- `## Red Flags`
+- `## Verification`

--- a/docs/skills/bst-overrides.md
+++ b/docs/skills/bst-overrides.md
@@ -1,7 +1,7 @@
 ---
 
 name: bst-overrides
-description: Governs when and how to create junction overrides in dakota. Upstream-first principle — local overrides are last resort. Covers patch_queue overrides, exit conditions, and how to evaluate whether an override is justified.
+description: Governs when and how to create junction overrides in dakota. Upstream-first principle — local overrides are last resort. Covers patch_queue overrides, exit conditions, and how to evaluate whether an override is justified. Use when deciding whether to override gnome-build-meta or freedesktop-sdk content, adding temporary local overrides, or removing override debt after upstream catches up.
 metadata:
   context7-sources:
     - /apache/buildstream

--- a/docs/skills/ci-reference.md
+++ b/docs/skills/ci-reference.md
@@ -1,6 +1,6 @@
 ---
 name: ci-reference
-description: Historical Dakota CI deep cuts and accumulated failure patterns. Use only after the focused CI skills when you need long-tail prior art or exact past failure signatures.
+description: Historical Dakota CI deep cuts and accumulated failure patterns. Use when the focused CI skills did not explain a failure and you need long-tail prior art, exact past failure signatures, or old workflow behavior that still shapes today's pipeline.
 metadata:
   context7-sources:
     - /websites/github_en_actions

--- a/docs/skills/installer.md
+++ b/docs/skills/installer.md
@@ -1,7 +1,7 @@
 ---
 
 name: installer
-description: bootc-installer (GTK4/Adwaita Flatpak) for Dakota. Covers two-component architecture (Python GUI + Go fisherman backend), dev setup, demo mode, and the dakota/dakota-iso boundary. Load when working on installer UI, recipe, or firstboot installer-cleanup behavior.
+description: bootc-installer (GTK4/Adwaita Flatpak) for Dakota. Covers two-component architecture (Python GUI + Go fisherman backend), dev setup, demo mode, and the dakota/dakota-iso boundary. Use when working on installer UI, the Flatpak recipe, fisherman integration, or firstboot installer-cleanup behavior.
 metadata:
   context7-sources:
     - /bootc-dev/bootc

--- a/docs/skills/local-ota.md
+++ b/docs/skills/local-ota.md
@@ -1,7 +1,7 @@
 ---
 
 name: local-ota
-description: Tests bootc upgrades via a local zot registry — QEMU VM or physical hardware. Covers registry setup, insecure registry configuration, and the build-push-upgrade loop. Load when validating image changes without pushing to GHCR.
+description: Tests bootc upgrades via a local zot registry — QEMU VM or physical hardware. Covers registry setup, insecure registry configuration, and the build-push-upgrade loop. Use when validating image changes without pushing to GHCR, reproducing upgrade behavior on hardware, or testing a local bootc switch/upgrade path.
 metadata:
   context7-sources:
     - /bootc-dev/bootc

--- a/docs/skills/merge-queue.md
+++ b/docs/skills/merge-queue.md
@@ -1,7 +1,7 @@
 ---
 
 name: merge-queue
-description: Clears stuck dependency-update PRs, rebases chore branches against main, and handles fork PRs. Covers rebase loops, merge command, e2e retrigger, and cross-repository PR handling. Load when PRs are stuck, conflicting, or blocked.
+description: Clears stuck dependency-update PRs, rebases chore branches against main, and handles fork PRs. Covers rebase loops, merge command, e2e retrigger, and cross-repository PR handling. Use when PRs are stuck, conflicting, blocked in queue, or need maintainer-safe rebasing/retriggering.
 metadata:
   context7-sources:
     - /websites/github_en_actions

--- a/docs/skills/oci-layers.md
+++ b/docs/skills/oci-layers.md
@@ -1,7 +1,7 @@
 ---
 
 name: oci-layers
-description: Explains how packages flow from BST elements into the final OCI image layer. Covers compose vs stack kinds, BST weak-key caching bug, and layer verification. Load when packages go missing from the built image or when modifying layer assembly.
+description: Explains how packages flow from BST elements into the final OCI image layer. Covers compose vs stack kinds, BST weak-key caching bug, and layer verification. Use when packages go missing from the built image, when modifying layer assembly, or when checking why a successful build produced an empty layer.
 metadata:
   context7-sources:
     - /apache/buildstream

--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -1,7 +1,7 @@
 ---
 
 name: dakota-overview
-description: Provides context on what Dakota is, how it differs from bluefin/bluefin-lts, current package gaps, and build optimization notes. Load when planning new package additions or when someone asks what Dakota is.
+description: Provides context on what Dakota is, how it differs from bluefin/bluefin-lts, current package gaps, and build optimization notes. Use when planning new package additions, scoping whether a feature belongs in Dakota, or when someone asks what Dakota is.
 metadata:
   context7-sources:
     - /bootc-dev/bootc

--- a/docs/skills/packaging-gnome-extensions.md
+++ b/docs/skills/packaging-gnome-extensions.md
@@ -1,7 +1,7 @@
 ---
 
 name: packaging-gnome-extensions
-description: Packages GNOME Shell extensions for BuildStream in dakota. Covers UUID discovery, install path, extension stack wiring, GSettings schema compilation, and dconf keyfile last-writer-wins behavior.
+description: Packages GNOME Shell extensions for BuildStream in dakota. Covers UUID discovery, install path, extension stack wiring, GSettings schema compilation, and dconf keyfile last-writer-wins behavior. Use when adding, updating, or debugging GNOME Shell extensions in the Dakota image.
 metadata:
   context7-sources:
     - /apache/buildstream

--- a/docs/skills/packaging-go.md
+++ b/docs/skills/packaging-go.md
@@ -1,7 +1,7 @@
 ---
 
 name: packaging-go
-description: Packages a Go project from source using BST go_module sources or a vendored GOPATH tarball. Note: all current Go tools in Dakota use pre-built binaries — load packaging-binaries.md first to confirm source build is truly needed.
+description: Packages a Go project from source using BST go_module sources or a vendored GOPATH tarball. Note: all current Go tools in Dakota use pre-built binaries — load packaging-binaries.md first to confirm source build is truly needed. Use when a Go project must be built from source in Dakota instead of consuming an upstream release binary.
 metadata:
   context7-sources:
     - /apache/buildstream

--- a/docs/skills/packaging-rust.md
+++ b/docs/skills/packaging-rust.md
@@ -1,7 +1,7 @@
 ---
 
 name: packaging-rust
-description: Packages a Rust/Cargo project from source using BST cargo2 sources. Covers cargo2 generation, overlap-whitelist for conflicting binaries, and tracking group assignment. Use sudo-rs.bst as the reference template.
+description: Packages a Rust/Cargo project from source using BST cargo2 sources. Covers cargo2 generation, overlap-whitelist for conflicting binaries, and tracking group assignment. Use sudo-rs.bst as the reference template. Use when adding or updating a Rust package that must build from source in Dakota.
 metadata:
   context7-sources:
     - /apache/buildstream

--- a/docs/skills/packaging-zig.md
+++ b/docs/skills/packaging-zig.md
@@ -1,7 +1,7 @@
 ---
 
 name: packaging-zig
-description: Packages a Zig build system project from source. Covers two-stage cache population (zig fetch for HTTP deps, manual placement for git deps), DESTDIR pattern, and -Dcpu=baseline requirement. ghostty.bst is the reference implementation.
+description: Packages a Zig build system project from source. Covers two-stage cache population (zig fetch for HTTP deps, manual placement for git deps), DESTDIR pattern, and -Dcpu=baseline requirement. ghostty.bst is the reference implementation. Use when a Zig-based project must be packaged from source in Dakota.
 metadata:
   context7-sources:
     - /apache/buildstream

--- a/docs/skills/patch-junctions.md
+++ b/docs/skills/patch-junctions.md
@@ -1,7 +1,7 @@
 ---
 
 name: patch-junctions
-description: Lifecycle for patches applied to upstream junctions (freedesktop-sdk, gnome-build-meta). Covers adding patches, required Upstream-Status headers, rebasing after junction bumps, and dropping upstreamed patches.
+description: Lifecycle for patches applied to upstream junctions (freedesktop-sdk, gnome-build-meta). Covers adding patches, required Upstream-Status headers, rebasing after junction bumps, and dropping upstreamed patches. Use when patching junction content, rebasing patch queues after a bump, or removing patches that landed upstream.
 metadata:
   context7-sources:
     - /apache/buildstream

--- a/docs/skills/pr-review.md
+++ b/docs/skills/pr-review.md
@@ -1,7 +1,7 @@
 ---
 
 name: pr-review
-description: Consolidated review workflow for dakota pull requests. Covers review priorities, common rejection reasons, dep-update PR review, and ghost (agent-assisted PR) handling. Load when asked to review any PR in projectbluefin/dakota.
+description: Consolidated review workflow for dakota pull requests. Covers review priorities, common rejection reasons, dep-update PR review, and ghost (agent-assisted PR) handling. Use when asked to review any PR in projectbluefin/dakota or to sanity-check a branch before requesting maintainer review.
 metadata:
   context7-sources:
     - /websites/github_en_actions

--- a/docs/skills/remove-package.md
+++ b/docs/skills/remove-package.md
@@ -1,7 +1,7 @@
 ---
 
 name: remove-package
-description: Workflow for removing a software package from the Dakota image. Covers element deletion, deps.bst unwiring, dangling reference checks, and validation. Load for any "remove package from Dakota" task.
+description: Workflow for removing a software package from the Dakota image. Covers element deletion, deps.bst unwiring, dangling reference checks, and validation. Use when removing a package, service, shell extension, or other image content from Dakota.
 metadata:
   context7-sources:
     - /apache/buildstream

--- a/docs/skills/skill-improvement.md
+++ b/docs/skills/skill-improvement.md
@@ -1,6 +1,6 @@
 ---
 name: skill-improvement
-description: "The skill-improvement mandate for this repo. Every session produces work + a skill file update. Use when completing a task and deciding whether a skill update is needed."
+description: "The skill-improvement mandate for this repo. Every session produces work + a skill file update. Use when completing a task, deciding whether a learning belongs in docs/skills, or verifying the work+learning loop before handoff."
 metadata:
   type: procedure
 ---
@@ -13,6 +13,24 @@ Every agent session produces two outputs:
 2. **The learning** — what a future agent needs to know
 
 Output 1 without Output 2 leaves the factory no smarter.
+
+## When to Use
+
+Use when finishing any Dakota task, deciding whether a discovery belongs in `docs/skills/`, or reviewing a branch for factory-memory completeness before handoff.
+
+## When NOT to Use
+
+- You are still routing the task to the correct domain skill → start with `README.md` or the focused skill in `docs/skills/README.md`
+- You need implementation details for a specific subsystem → load the narrow domain skill first, then come back here before closing the work
+- You are writing ephemeral session notes, personal scratch work, or changelog-style narration — those are banned here
+
+## Core Process
+
+1. Identify what changed and what you had to learn to make it work.
+2. Decide whether that learning is durable, non-obvious, and likely to help the next agent.
+3. Route the learning to the narrowest existing skill file; create a new skill only if no focused home exists.
+4. Add the learning in the same branch/PR as the implementation so the factory gets both outputs together.
+5. Verify the updated skill contains concrete triggers, failure patterns, and checkable exit criteria before you mark the task done.
 
 ## Before Marking Work Done
 
@@ -37,5 +55,31 @@ All learnings → `docs/skills/` in this repo. Cross-cutting patterns affecting 
 - No changelog files (`IMPROVEMENTS.md`, `CHANGELOG.md` for agent notes, `SESSION.md`, etc.). Delete them if found.
 - No session notes committed to the repo.
 - No "append here" instructions. Route to a specific `docs/skills/<file>.md`.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "This fix was obvious once I found it." | If you had to discover it, the next agent will too. Write it down. |
+| "I'll update the skill later in a follow-up PR." | The loop breaks if work and learning ship separately or not at all. |
+| "A giant catch-all note is good enough." | Route to the narrowest skill so future agents can actually find it. |
+| "This only affected CI/docs, so it doesn't need a skill update." | Operational patterns are exactly what skills are for. |
+| "The rule already exists in AGENTS.md, so I can skip the local skill." | AGENTS carries hard rules; the task-specific workflow and examples belong in the focused skill. |
+
+## Red Flags
+
+- A branch changes behavior but touches no relevant skill file
+- Learnings are written as session logs instead of reusable guidance
+- A new pattern gets stuffed into an unrelated catch-all file
+- The same mistake recurs across sessions because nobody wrote back the workaround
+- Task completion claims success before the work+learning loop is checked
+
+## Verification
+
+- [ ] The task produced both implementation work and any durable learning it uncovered
+- [ ] The learning was routed to the narrowest relevant skill file
+- [ ] No ephemeral notes or changelog-style scratch files were added to the repo
+- [ ] The updated skill gives future agents concrete triggers, anti-patterns, and exit criteria
+- [ ] The branch is not marked done until the skill contribution check passes
 
 Full mandate: [`projectbluefin/common/docs/skills/skill-improvement.md`](https://github.com/projectbluefin/common/blob/main/docs/skills/skill-improvement.md)

--- a/docs/skills/update-refs.md
+++ b/docs/skills/update-refs.md
@@ -1,7 +1,7 @@
 ---
 
 name: update-refs
-description: Workflow for updating an existing package version in dakota. Covers tarball ref tracking, git ref tracking, and cargo2 regeneration for Rust elements. Load for any "update package version" task.
+description: Workflow for updating an existing package version in dakota. Covers tarball ref tracking, git ref tracking, and cargo2 regeneration for Rust elements. Use when bumping package versions, refreshing tracked refs, or regenerating derived lock/vendor data after an upstream release.
 metadata:
   context7-sources:
     - /apache/buildstream


### PR DESCRIPTION
## What

Brings dakota's docs/skills/ up to the projectbluefin factory standard per common/docs/skills/factory-onboarding.md.

## Changes

- Add docs/skills/INDEX.md — factory-standard index file (common requires this alongside README.md)
- Add explicit banned-list block to AGENTS.md self-improvement section: changelog files, append-here docs, committed session notes
- Fix .github/workflows/skill-drift.yml: SHA pin -> @v1 (consistent with repo internal-action policy)
- Expand docs/skills/skill-improvement.md to full canonical spec (When to Use, Core Process, Rationalizations, Red Flags, Verification)
- Update frontmatter trigger phrases across 16 skill files to include explicit Use when language

## Verification

All 31 docs/skills/*.md files now have all 7 canonical sections (Common Rationalizations, Red Flags, Verification present in every file).

Factory onboarding checklist (from common/docs/skills/factory-onboarding.md):
- [x] docs/skills/ with skill-improvement.md and INDEX.md
- [x] skill-drift.yml wired and using @v1
- [x] AGENTS.md includes self-improvement mandate and banned list
- [x] No changelog files in repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced skill documentation with clearer descriptions and expanded "when to use" guidance across multiple skill guides.
  * Added new skills index defining standard structure and validation for documentation organization.
  * Expanded skill-improvement guidance with detailed checklists, verification steps, and decision criteria for routing learnings.

* **Chores**
  * Updated CI workflow configuration to use floating tag reference.
  * Added documentation guidelines prohibiting certain patterns in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->