### PR TITLE
ci: add sync-next-from-main workflow to main branch

### DIFF
--- a/.github/workflows/sync-next-from-main.yml
+++ b/.github/workflows/sync-next-from-main.yml
@@ -1,0 +1,66 @@
+name: Sync next branch from main
+
+# Keeps next identical to main except for junction refs.
+# next = main + (track: master, GNOME master ref, freedesktop-sdk ref).
+#
+# Strategy: merge main normally, then restore next's junction ref/track lines.
+# This ensures ALL config/overrides/CI changes from main land on next
+# automatically — including bootc override additions, new elements, etc.
+# Only the ref: and track: lines for gnome-build-meta and freedesktop-sdk
+# are pinned to next's values.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync-next:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout next
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: next
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge main into next (restore junction refs after merge)
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Save next's junction-specific values before merging.
+          GNOME_TRACK=$(grep -m1 '^\s*track:' elements/gnome-build-meta.bst | awk '{print $2}')
+          GNOME_REF=$(grep -m1 '^\s*ref:' elements/gnome-build-meta.bst | awk '{print $2}')
+          FDO_TRACK=$(grep -m1 '^\s*track:' elements/freedesktop-sdk.bst | awk '{print $2}')
+          FDO_REF=$(grep -m1 '^\s*ref:' elements/freedesktop-sdk.bst | awk '{print $2}')
+
+          echo "Preserving gnome-build-meta: track=$GNOME_TRACK ref=$GNOME_REF"
+          echo "Preserving freedesktop-sdk:  track=$FDO_TRACK ref=$FDO_REF"
+
+          git fetch origin main
+
+          # Merge main — accept everything from main on conflict (-X theirs).
+          # Junction config/overrides should now always match main.
+          if ! git merge origin/main -X theirs --no-edit; then
+            echo "ERROR: merge failed — manual intervention required"
+            git merge --abort
+            exit 1
+          fi
+
+          # Restore next's junction ref/track (the only intentional divergence).
+          sed -i "0,/track:/{s|track:.*|track: $GNOME_TRACK|}" elements/gnome-build-meta.bst
+          sed -i "0,/^\s*ref:/{s|ref:.*|ref: $GNOME_REF|}" elements/gnome-build-meta.bst
+          sed -i "0,/track:/{s|track:.*|track: $FDO_TRACK|}" elements/freedesktop-sdk.bst
+          sed -i "0,/^\s*ref:/{s|ref:.*|ref: $FDO_REF|}" elements/freedesktop-sdk.bst
+
+          # Amend the merge commit to include the ref restoration.
+          git add elements/gnome-build-meta.bst elements/freedesktop-sdk.bst
+          git commit --amend --no-edit
+
+          git push origin next
+          echo "Synced main → next (junction refs preserved)"

--- a/.github/workflows/sync-next-from-main.yml
+++ b/.github/workflows/sync-next-from-main.yml
@@ -27,6 +27,7 @@ jobs:
           ref: next
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Merge main into next (restore junction refs after merge)
         run: |
@@ -38,6 +39,15 @@ jobs:
           GNOME_REF=$(grep -m1 '^\s*ref:' elements/gnome-build-meta.bst | awk '{print $2}')
           FDO_TRACK=$(grep -m1 '^\s*track:' elements/freedesktop-sdk.bst | awk '{print $2}')
           FDO_REF=$(grep -m1 '^\s*ref:' elements/freedesktop-sdk.bst | awk '{print $2}')
+
+          # Fail fast if any extraction is empty — prevents sed from corrupting files.
+          for var_name in GNOME_TRACK GNOME_REF FDO_TRACK FDO_REF; do
+            val="${!var_name}"
+            if [ -z "$val" ]; then
+              echo "ERROR: failed to extract $var_name from junction file — aborting"
+              exit 1
+            fi
+          done
 
           echo "Preserving gnome-build-meta: track=$GNOME_TRACK ref=$GNOME_REF"
           echo "Preserving freedesktop-sdk:  track=$FDO_TRACK ref=$FDO_REF"
@@ -53,10 +63,11 @@ jobs:
           fi
 
           # Restore next's junction ref/track (the only intentional divergence).
-          sed -i "0,/track:/{s|track:.*|track: $GNOME_TRACK|}" elements/gnome-build-meta.bst
-          sed -i "0,/^\s*ref:/{s|ref:.*|ref: $GNOME_REF|}" elements/gnome-build-meta.bst
-          sed -i "0,/track:/{s|track:.*|track: $FDO_TRACK|}" elements/freedesktop-sdk.bst
-          sed -i "0,/^\s*ref:/{s|ref:.*|ref: $FDO_REF|}" elements/freedesktop-sdk.bst
+          # Use ^\s* anchor on track: to avoid matching comments or URLs.
+          sed -i "0,/^\s*track:/{s|^\(\s*\)track:.*|\1track: $GNOME_TRACK|}" elements/gnome-build-meta.bst
+          sed -i "0,/^\s*ref:/{s|^\(\s*\)ref:.*|\1ref: $GNOME_REF|}" elements/gnome-build-meta.bst
+          sed -i "0,/^\s*track:/{s|^\(\s*\)track:.*|\1track: $FDO_TRACK|}" elements/freedesktop-sdk.bst
+          sed -i "0,/^\s*ref:/{s|^\(\s*\)ref:.*|\1ref: $FDO_REF|}" elements/freedesktop-sdk.bst
 
           # Amend the merge commit to include the ref restoration.
           git add elements/gnome-build-meta.bst elements/freedesktop-sdk.bst


### PR DESCRIPTION
The sync-next-from-main workflow lived only on the next branch. GitHub only fires push-triggered workflows from the default branch (main), so the auto-sync never worked — next drifted ~90 files behind main.

This adds the workflow to main so every push to main automatically syncs next.

Pairs with PR 986 (the manual catch-up sync for next).

- [ ] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated branch synchronization workflow to maintain consistency between development branches while preserving essential configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->