### PR TITLE
fix(ci): fix automerge and auto-update for mergeraptor dep PRs

### DIFF
--- a/.github/workflows/pr-autoupdate.yml
+++ b/.github/workflows/pr-autoupdate.yml
@@ -29,12 +29,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Find all open PRs targeting main that are BEHIND and not from bots.
+          # Find all open PRs targeting main that are BEHIND and need updating.
           # Renovate PRs target testing, not main — skip them.
-          # Mergeraptor manages its own branches — skip those too.
           # auto/promote-testing-to-main is always rebuilt fresh by promote-testing-to-main.yml;
           # a merge commit here changes the tree, defeats the tree-identity check, triggers a
           # force-push, and dismisses approvals. Let the promote workflow keep it current.
+          # Mergeraptor PRs (distrobox, junction bumps) DO target main and need auto-update
+          # so renovate-automerge can fire. They are intentionally included here.
           STALE_PRS=$(gh pr list \
             --repo "$REPO" \
             --base main \
@@ -44,7 +45,6 @@ jobs:
               .[] |
               select(.mergeStateStatus == "BEHIND") |
               select(.author.login != "renovate[bot]") |
-              select(.author.login != "app/mergeraptor") |
               select(.headRefName != "auto/promote-testing-to-main") |
               .number
             ')

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -55,6 +55,12 @@ jobs:
             echo "Automated next-branch junction update — skipping main-target gate."
             exit 0
           fi
+          # Allow all PRs targeting next — next is a legitimate development branch
+          # (GNOME master stream). Unlike stable/latest, next accepts direct PRs.
+          if [ "$BASE_REF" = "next" ]; then
+            echo "PR targets next development branch — skipping main-target gate."
+            exit 0
+          fi
           # Allow Renovate PRs targeting testing — testing is the staging branch
           # for the testing→main promotion pipeline (parity with bluefin).
           if [ "$BASE_REF" = "testing" ] && [[ "$HEAD_REF" == renovate/* ]]; then

--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -15,3 +15,4 @@ jobs:
     uses: projectbluefin/actions/.github/workflows/reusable-renovate-automerge.yml@99d867d662ab64a1f82b4f5f24f73b4051dbff01 # v1
     with:
       head_sha: ${{ github.event.workflow_run.head_sha }}
+      base_branch: main


### PR DESCRIPTION
Three workflow bugs causing dep PRs (distrobox, junctions) to get permanently stuck:

**Bug 1 — renovate-automerge.yml: wrong base_branch**
The reusable workflow defaults to `base_branch: testing`. Dakota's dep bumps target `main`. The auto-merge workflow ran on every build completion but found nothing on `testing` and silently skipped. Fixed: add `base_branch: main`.

**Bug 2 — pr-autoupdate.yml: excludes mergeraptor**
Comment said "Mergeraptor manages its own branches" but mergeraptor PRs targeting `main` were never self-updated when main advanced. Result: they went BEHIND and auto-merge could never fire. Fixed: remove the `app/mergeraptor` exclusion.

**Bug 3 — pr-triage.yml: gate blocks all fix/* → next PRs**
Only `auto/track-next-junction → next` was allowed. Any manual `fix/*` branch targeting `next` got a hard failure with a bot comment. Fixed: allow all PRs targeting `next` since next is a legitimate dev branch.

- [ ] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR triage workflow to support pull requests targeting the `next` branch in addition to `main`.
  * Adjusted stale pull request detection logic to include automated Mergeraptor PRs.
  * Enhanced Renovate auto-merge workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->