### PR TITLE
fix(ci): remove persist-credentials: false from sync workflow

### DIFF
--- a/.github/workflows/sync-next-from-main.yml
+++ b/.github/workflows/sync-next-from-main.yml
@@ -27,7 +27,6 @@ jobs:
           ref: next
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
 
       - name: Merge main into next (restore junction refs after merge)
         run: |


### PR DESCRIPTION
The sync-next-from-main workflow failed immediately on first run with:

```
fatal: No url found for submodule path '.workflow-scripts' in .gitmodules
```

`persist-credentials: false` causes `actions/checkout` to run `git submodule foreach` during credential cleanup. That fails because `.workflow-scripts` is a submodule path referenced in the repo but with no URL in `.gitmodules`.

Removing the flag. The `GITHUB_TOKEN` used here is short-lived and scoped to `contents: write` only — the credential risk is acceptable.

- [ ] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for repository branch synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->