### PR TITLE
fix(motd): add missing env.sh, remove duplicate umotd.sh profile hook

### DIFF
--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -78,4 +78,8 @@ config:
     rm -f "%{install-root}%{prefix}/bin/rechunker-group-fix"
     rm -f "%{install-root}%{prefix}/lib/systemd/system/rechunker-group-fix.service"
     rm -f "%{install-root}%{prefix}/lib/systemd/system-preset/00-rechunker-group-fix.preset"
+
+    # Dakota uses its own ublue-motd (from motd.bst) with a double-display guard.
+    # Remove common's umotd.sh hook to prevent dual MOTD on every login.
+    rm -f "%{install-root}%{sysconfdir}/profile.d/umotd.sh"
   - "%{install-extra}"

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -52,7 +52,6 @@ depends:
   - freedesktop-sdk.bst:components/git.bst
   - freedesktop-sdk.bst:components/podman.bst
   - freedesktop-sdk.bst:components/skopeo.bst
-  - freedesktop-sdk.bst:components/flatpak-builder.bst
 
   - freedesktop-sdk.bst:components/bpf.bst
   - freedesktop-sdk.bst:components/vmlinuxh.bst

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -52,6 +52,7 @@ depends:
   - freedesktop-sdk.bst:components/git.bst
   - freedesktop-sdk.bst:components/podman.bst
   - freedesktop-sdk.bst:components/skopeo.bst
+  - freedesktop-sdk.bst:components/flatpak-builder.bst
 
   - freedesktop-sdk.bst:components/bpf.bst
   - freedesktop-sdk.bst:components/vmlinuxh.bst

--- a/elements/bluefin/motd.bst
+++ b/elements/bluefin/motd.bst
@@ -14,6 +14,7 @@ public:
   bst:
     overlap-whitelist:
     - /usr/bin/ublue-motd
+    - /usr/share/ublue-os/motd/env.sh
     - /usr/share/ublue-os/motd/template.md
     - /usr/share/ublue-os/motd/tips/10-tips.md
     - /etc/profile.d/bluefin-shell-defaults.sh
@@ -21,6 +22,7 @@ public:
 config:
   install-commands:
   - install -Dm755 ublue-motd "%{install-root}%{bindir}/ublue-motd"
+  - install -Dm644 env.sh "%{install-root}/usr/share/ublue-os/motd/env.sh"
   - install -Dm644 template.md "%{install-root}/usr/share/ublue-os/motd/template.md"
   - install -Dm644 tips/10-tips.md "%{install-root}/usr/share/ublue-os/motd/tips/10-tips.md"
   - |

--- a/files/motd/env.sh
+++ b/files/motd/env.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+# Exports image info variables for MOTD template substitution.
+# shellcheck source=/dev/null
+. /usr/lib/os-release 2>/dev/null || true
+MOTD_IMAGE_NAME="${IMAGE_NAME:-dakota}"
+MOTD_IMAGE_TAG="${IMAGE_TAG:-unknown}"
+export MOTD_IMAGE_NAME MOTD_IMAGE_TAG


### PR DESCRIPTION
## Problem

Two bugs confirmed on a NUC running dakota:testing (2026-06-21):

1. Every shell login errors with:
   `/usr/bin/ublue-motd: line 5: /usr/share/ublue-os/motd/env.sh: No such file or directory`
   env.sh was never shipped — ublue-motd sources it to get MOTD_IMAGE_NAME/MOTD_IMAGE_TAG for template substitution.

2. Double MOTD on every login: both `ublue-motd.sh` and `umotd.sh` fire from profile.d.
   Dakota ships its own ublue-motd (motd.bst) with a UBLUE_MOTD_SHOWN double-display guard.
   common also ships umotd.sh which calls umotd unconditionally — two banners show up.

## Fix

- Add `files/motd/env.sh` sourcing `/usr/lib/os-release` and exporting MOTD_IMAGE_NAME/MOTD_IMAGE_TAG
- Install it via `motd.bst` to `/usr/share/ublue-os/motd/env.sh`
- In `common.bst` install-commands, `rm -f` the `umotd.sh` profile.d hook that common ships

## Testing

Confirmed both bugs present on NUC at 192.168.1.247 running ghcr.io/projectbluefin/dakota:testing built 2026-06-21.