### PR TITLE
feat(deps): add flatpak-builder

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -52,6 +52,7 @@ depends:
   - freedesktop-sdk.bst:components/git.bst
   - freedesktop-sdk.bst:components/podman.bst
   - freedesktop-sdk.bst:components/skopeo.bst
+  - freedesktop-sdk.bst:components/flatpak-builder.bst
 
   - freedesktop-sdk.bst:components/bpf.bst
   - freedesktop-sdk.bst:components/vmlinuxh.bst


### PR DESCRIPTION
Adds `freedesktop-sdk.bst:components/flatpak-builder.bst` to `elements/bluefin/deps.bst`.

flatpak-builder is already in the freedesktop-sdk junction — one line addition.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->