### PR TITLE
ci(build): drop push-to-testing trigger — eliminates redundant 5h build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,11 @@ on:
   merge_group:
     branches: [main, next, testing]
   push:
-    branches: [main, next, testing]
+    # testing is excluded: publish.yml fast-forwards testing after every main
+    # build, which would re-trigger an identical 5h BST build. :testing is
+    # already published by the main build. PRs targeting testing still build
+    # via pull_request and merge_group above.
+    branches: [main, next]
   workflow_dispatch:
     # WARNING: Do not manually dispatch immediately after auto/track-* ref bumps
     # (e.g. Renovate PRs updating gnome-build-meta.bst). Cold builds of GNOME


### PR DESCRIPTION
Every merge to main triggers two full BST builds:

1. The push-to-main build (correct — publishes :testing)
2. publish.yml fast-forwards the testing branch after the main build succeeds, which triggers a push-to-testing build — an identical 5h rebuild of the exact same commit

The second build is pure waste: same code, same cache, same output. It burns a runner for 5 hours, blocks the merge queue, and publishes nothing new.

Fix: remove testing from the push: trigger. PRs targeting testing still get full BST validation via pull_request and merge_group (unchanged). :testing is published by the main build.