### PR TITLE
fix(ci): use BST SBOM for release notes, add variants table

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -42,7 +42,7 @@ jobs:
       issues: write
       packages: write
       pull-requests: write
-    uses: projectbluefin/actions/.github/workflows/reusable-execute-release.yml@99d867d662ab64a1f82b4f5f24f73b4051dbff01 # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-execute-release.yml@v1
     with:
       registry: ghcr.io/projectbluefin
       variants: >-
@@ -61,11 +61,15 @@ jobs:
       contents: write
       id-token: write
       packages: read
-    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@99d867d662ab64a1f82b4f5f24f73b4051dbff01 # v1
+    uses: projectbluefin/actions/.github/workflows/reusable-release.yml@v1
     with:
       stream_name: stable
       image: ghcr.io/projectbluefin/dakota
-      generate_sbom_inline: true
+      # Use the BST-native SBOM from publish.yml's publish-sbom job.
+      # Inline syft with rpm cataloger returns 0 packages on BST images.
+      build_workflow: publish.yml
+      build_branch: main
+      sbom_artifact: sbom-dakota
       checkout_ref: main
       project_name: Dakota
       badge_label: Stable
@@ -74,10 +78,52 @@ jobs:
         ^https://github\.com/projectbluefin/(dakota|actions)/\.github/workflows/
       notable_packages: >-
         [
-          {"sbom_name": "kernel", "label": "Kernel"},
+          {"sbom_name": "linux",       "label": "Kernel"},
           {"sbom_name": "gnome-shell", "label": "GNOME Shell"},
-          {"sbom_name": "flatpak", "label": "Flatpak"},
-          {"sbom_name": "bootc", "label": "bootc"}
+          {"sbom_name": "flatpak",     "label": "Flatpak"},
+          {"sbom_name": "bootc",       "label": "bootc"}
         ]
       docs_url: https://docs.projectbluefin.io/changelogs
     secrets: inherit
+
+  post-release-variants:
+    needs: [execute, release-notes]
+    if: always() && needs.release-notes.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Resolve promoted digests
+        id: digests
+        run: |
+          set -euo pipefail
+          for image in dakota dakota-nvidia; do
+            digest=$(skopeo inspect --no-tags "docker://ghcr.io/projectbluefin/${image}:stable" \
+              | jq -r '.Digest' | cut -c1-19)
+            echo "${image}=${digest}" >> "$GITHUB_OUTPUT"
+          done
+
+      - name: Prepend variants table to release
+        env:
+          DAKOTA_DIGEST: ${{ steps.digests.outputs.dakota }}
+          NVIDIA_DIGEST: ${{ steps.digests.outputs.dakota-nvidia }}
+        run: |
+          set -euo pipefail
+          TAG=$(gh release list --repo "${{ github.repository }}" --limit 1 --json tagName --jq '.[0].tagName')
+          CURRENT=$(gh release view "$TAG" --repo "${{ github.repository }}" --json body --jq '.body')
+
+          VARIANTS_SECTION=$(printf '%s\n' \
+            '## Variants promoted' \
+            '' \
+            '| Variant | Tag | Digest |' \
+            '|---|---|---|' \
+            "| \`dakota\` | \`:stable\` | \`${DAKOTA_DIGEST}\` |" \
+            "| \`dakota-nvidia\` | \`:stable\` | \`${NVIDIA_DIGEST}\` |" \
+            '' \
+            '---' \
+            '')
+          printf '%s\n%s' "$VARIANTS_SECTION" "$CURRENT" > /tmp/updated-body.md
+          gh release edit "$TAG" --repo "${{ github.repository }}" --notes-file /tmp/updated-body.md

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -605,10 +605,12 @@ jobs:
 
       - name: Upload SBOM artifact for release workflow
         if: matrix.variant == 'default'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        run: cp dakota.spdx.json dakota.sbom.json
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: matrix.variant == 'default'
         with:
-          name: sbom-${{ needs.setup.outputs.sha }}
-          path: dakota.spdx.json
+          name: sbom-dakota
+          path: dakota.sbom.json
           retention-days: 30
 
       - name: Login to GHCR

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -552,7 +552,7 @@ jobs:
             element: oci/bluefin.bst
             image_suffix: ''
             sbom_filename: dakota.spdx.json
-            continue: true
+            continue: false
           - variant: nvidia
             element: oci/bluefin-nvidia.bst
             image_suffix: '-nvidia'


### PR DESCRIPTION
Three bugs fixed:

1. Inline syft with `--select-catalogers rpm` returns 0 packages on BST-built images. Switch to artifact-based path using the BST-native SBOM (`just sbom`) generated by publish.yml.

2. `notable_packages` used `kernel` but BST SPDX names the kernel package `linux`. Fixed.

3. No variants table in releases — add `post-release-variants` job (matches bluefin and bluefin-lts pattern).

publish.yml: fixed artifact name from `sbom-$SHA` (dynamic, unfindable) to `sbom-dakota` (static). File renamed `dakota.spdx.json` → `dakota.sbom.json` to match reusable-release.yml convention.

Consumer PR: N/A (this IS the consumer)
Consumer CI run: N/A
Out-of-org consumer impact: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configurations to use stable version references
  * Release notes now include variants promotion information with digests
  * Improved artifact handling for build outputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->