### PR TITLE
feat(countme): report to Fedora countme infrastructure

### DIFF
--- a/elements/bluefin/countme.bst
+++ b/elements/bluefin/countme.bst
@@ -15,3 +15,4 @@ config:
   - install -Dm644 bluefin-countme.{service,timer} -t "%{install-root}/usr/lib/systemd/system/"
   - mkdir -p "%{install-root}/usr/lib/systemd/system/timers.target.wants/"
   - ln -sf ../bluefin-countme.timer "%{install-root}/usr/lib/systemd/system/timers.target.wants/bluefin-countme.timer"
+  - install -Dm755 dakota-countme "%{install-root}/usr/libexec/dakota-countme"

--- a/elements/oci/os-release.bst
+++ b/elements/oci/os-release.bst
@@ -24,6 +24,10 @@ environment:
   BUG_SUPPORT_URL: "https://github.com/projectbluefin/dakota/issues"
   CODE_NAME: "Dakotaraptor"
   ID: "bluefin-dakota"
+  # Fedora platform ID — update alongside the gnome-build-meta junction when
+  # the Fedora base bumps. The countme script reads this at runtime to build
+  # the Fedora metalink URL (repo=fedora-NN).
+  PLATFORM_ID: "platform:f42"
 
 config:
   build-commands:
@@ -49,6 +53,7 @@ config:
       IMAGE_TAG="${IMAGE_TAG}"
       VERSION_ID="${VERSION_ID}"
       IMAGE_VERSION="${IMAGE_VERSION}"
+      PLATFORM_ID="${PLATFORM_ID}"
       EOF
       mkdir -p %{install-root}%{sysconfdir}/
       ln -sf ../usr/lib/os-release %{install-root}%{sysconfdir}/os-release

--- a/files/countme/bluefin-countme.service
+++ b/files/countme/bluefin-countme.service
@@ -1,13 +1,12 @@
 [Unit]
-Description=Report Bluefin active user count
-Documentation=https://countme.projectbluefin.io
+Description=Weekly Dakota countme report to Fedora infrastructure
+Documentation=https://github.com/projectbluefin/dakota
 After=network-online.target
 Wants=network-online.target
+# Requires ostree-booted — we need /run/ostree-booted to reliably track installs
+ConditionPathExists=/run/ostree-booted
 ConditionPathExists=!/etc/bluefin-countme-opt-out
 
 [Service]
 Type=oneshot
-EnvironmentFile=/etc/os-release
-ExecStart=/usr/bin/bash -c '/usr/bin/curl -sf --max-time 10 \
-  "https://countme.projectbluefin.io/count?os=${ID}&version=${VERSION_ID}&arch=$(uname -m)&countme=1" \
-  -o /dev/null'
+ExecStart=/usr/libexec/dakota-countme

--- a/files/countme/dakota-countme
+++ b/files/countme/dakota-countme
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Report Dakota to Fedora's countme infrastructure.
+# Mimics the libdnf5 countme protocol: a GET to Fedora's metalink with
+# countme=N in the query string and a libdnf5-format User-Agent carrying
+# the OS name. Fedora's metalink servers log this and the ublue-os/countme
+# pipeline reads it from Fedora's public countme dataset.
+#
+# We identify as "Dakota" so it shows up distinctly in the data.
+# Ref: coreos/rpm-ostree#5464, projectbluefin/dakota
+
+set -euo pipefail
+
+# shellcheck source=/dev/null
+. /usr/lib/os-release
+
+COOKIE_FILE=/var/lib/dakota-countme-epoch
+
+# Create cookie on first run to track installation age
+if [[ ! -f "$COOKIE_FILE" ]]; then
+    printf '%s\n' "$(date +%s)" > "$COOKIE_FILE"
+fi
+
+INSTALL_EPOCH=$(< "$COOKIE_FILE")
+NOW=$(date +%s)
+DAYS=$(( (NOW - INSTALL_EPOCH) / 86400 ))
+
+# Fedora countme age buckets (matches libdnf5 spec):
+#   1 = first 7 days, 2 = 8–27 days, 3 = 28–140 days, 4 = 141+ days
+if   (( DAYS <   8 )); then COUNTME=1
+elif (( DAYS <  28 )); then COUNTME=2
+elif (( DAYS < 141 )); then COUNTME=3
+else                        COUNTME=4
+fi
+
+ARCH=$(uname -m)
+
+# User-Agent in libdnf5 format — Fedora's metalink server parses NAME and
+# VERSION_ID from this field to populate os_name/os_version in countme data.
+# Using "Dakota" as NAME makes Dakota's users distinguishable from Bluefin.
+UA="libdnf5/5.2.9 (Dakota;${VERSION_ID};${ARCH}) hawkey"
+
+# Extract Fedora base version from PLATFORM_ID (e.g. "platform:f42" → "42").
+# PLATFORM_ID is written to os-release by os-release.bst and updated alongside
+# the gnome-build-meta junction when the Fedora base bumps.
+FEDORA_VER="${PLATFORM_ID#platform:f}"
+
+exec /usr/bin/curl -sf --max-time 30 \
+    -A "$UA" \
+    "https://mirrors.fedoraproject.org/metalink?repo=fedora-${FEDORA_VER}&arch=${ARCH}&countme=${COUNTME}" \
+    -o /dev/null

--- a/files/countme/dakota-countme
+++ b/files/countme/dakota-countme
@@ -15,12 +15,19 @@ set -euo pipefail
 
 COOKIE_FILE=/var/lib/dakota-countme-epoch
 
-# Create cookie on first run to track installation age
+# Create cookie on first run to track installation age.
+# Also regenerate if empty or non-numeric (e.g. truncated write, disk-full).
 if [[ ! -f "$COOKIE_FILE" ]]; then
     printf '%s\n' "$(date +%s)" > "$COOKIE_FILE"
 fi
 
 INSTALL_EPOCH=$(< "$COOKIE_FILE")
+# ponytail: empty/corrupt cookie would make bash arithmetic treat epoch as 0
+# (~1970), giving DAYS≈20000 and permanent COUNTME=4 misreporting.
+if ! [[ "$INSTALL_EPOCH" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$(date +%s)" > "$COOKIE_FILE"
+    INSTALL_EPOCH=$(< "$COOKIE_FILE")
+fi
 NOW=$(date +%s)
 DAYS=$(( (NOW - INSTALL_EPOCH) / 86400 ))
 

--- a/files/countme/dakota-countme
+++ b/files/countme/dakota-countme
@@ -24,11 +24,13 @@ INSTALL_EPOCH=$(< "$COOKIE_FILE")
 NOW=$(date +%s)
 DAYS=$(( (NOW - INSTALL_EPOCH) / 86400 ))
 
-# Fedora countme age buckets (matches libdnf5 spec):
-#   1 = first 7 days, 2 = 8–27 days, 3 = 28–140 days, 4 = 141+ days
-if   (( DAYS <   8 )); then COUNTME=1
+# Fedora countme age buckets (matches libdnf5 week-based logic):
+#   libdnf5 computes age_weeks = (now - epoch) / 604800 (integer division)
+#   bucket 1 = weeks 0 (days 0–6), 2 = weeks 1–3 (days 7–27),
+#   3 = weeks 4–19 (days 28–139), 4 = weeks 20+ (days 140+)
+if   (( DAYS <   7 )); then COUNTME=1
 elif (( DAYS <  28 )); then COUNTME=2
-elif (( DAYS < 141 )); then COUNTME=3
+elif (( DAYS < 140 )); then COUNTME=3
 else                        COUNTME=4
 fi
 


### PR DESCRIPTION
Report to fedora countme for now we're at least a bootc image. shrug. 


**How it works:**

- `/usr/libexec/dakota-countme` tracks installation age in `/var/lib/dakota-countme-epoch` and maps it to Fedora's age buckets (1–4), matching the libdnf5 spec and avoiding double-counting
- Sends a GET to Fedora's metalink URL with `countme=N` and a `libdnf5` User-Agent identifying the OS as `Dakota` so it's distinguishable in Fedora's dataset
- All version info is read from os-release at runtime — no hardcoded versions. `VERSION_ID` goes in the User-Agent; `PLATFORM_ID` (new standard field, e.g. `platform:f42`) is parsed to derive the `fedora-NN` repo tag for the URL
- `PLATFORM_ID` lives in `os-release.bst` alongside the gnome-build-meta junction and gets updated when the Fedora base bumps

**Opt-out:** `/etc/bluefin-countme-opt-out` (existing mechanism unchanged).

Ref: coreos/rpm-ostree issue 5464

- [x] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Implemented installation telemetry reporting to Fedora’s counting infrastructure, honoring the existing opt-out setting.
  * Added platform identification metadata to the system’s `/usr/lib/os-release` output for improved runtime identification.

* **Changes**
  * Updated the countme reporting service to use the new dedicated reporting executable and only run when the system meets the required boot condition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->