### PR TITLE
fix(ci): restore :testing publishing — independent branch, paths-ignore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,15 @@ on:
   merge_group:
     branches: [main, next, testing]
   push:
-    # testing is excluded: publish.yml fast-forwards testing after every main
-    # build, which would re-trigger an identical 5h BST build. :testing is
-    # already published by the main build. PRs targeting testing still build
-    # via pull_request and merge_group above.
-    branches: [main, next]
+    branches: [main, next, testing]
+    paths-ignore:
+      # Workflow files and docs don't affect the built image.
+      # .github/actions/** is intentionally NOT ignored — local composite
+      # actions (check-bst2-pin, generate-bst-ci-config) are used in the build.
+      - '.github/workflows/**'
+      - 'docs/**'
+      - '**.md'
+      - 'AGENTS.md'
   workflow_dispatch:
     # WARNING: Do not manually dispatch immediately after auto/track-* ref bumps
     # (e.g. Renovate PRs updating gnome-build-meta.bst). Cold builds of GNOME

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -734,31 +734,3 @@ jobs:
             [ "$attempt" -lt 3 ] && sleep 5
           done
           $PUSH_OK || { echo "ERROR: all copy attempts failed for :btw"; exit 1; }
-
-      - name: Fast-forward testing branch
-        # Removed: testing is now an independent branch (like bluefin/bluefin-lts).
-        # BST-changing merges to testing trigger their own build and :testing publish.
-        # Fast-forwarding testing from main caused a redundant 5h rebuild (PR 997 / PR 1004).
-        if: false
-        env:
-          BUILD_SHA: ${{ needs.setup.outputs.sha }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Fast-forward the testing branch to the promoted SHA.
-          # Creates the branch if it doesn't exist yet (first run after setup).
-          # No-op if testing is already at BUILD_SHA (idempotent re-runs).
-          CURRENT_SHA=$(gh api repos/${{ github.repository }}/git/refs/heads/testing \
-            --jq .object.sha 2>/dev/null || echo "")
-          if [ "$CURRENT_SHA" = "$BUILD_SHA" ]; then
-            echo "testing branch already at $BUILD_SHA — nothing to do"
-          elif [ -z "$CURRENT_SHA" ]; then
-            gh api repos/${{ github.repository }}/git/refs \
-              --method POST \
-              --field ref="refs/heads/testing" \
-              --field sha="$BUILD_SHA"
-          else
-            gh api repos/${{ github.repository }}/git/refs/heads/testing \
-              --method PATCH \
-              --field sha="$BUILD_SHA" \
-              --field force=true
-          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -736,7 +736,10 @@ jobs:
           $PUSH_OK || { echo "ERROR: all copy attempts failed for :btw"; exit 1; }
 
       - name: Fast-forward testing branch
-        if: matrix.image_suffix == '' && (needs.setup.outputs.branch == 'main' || startsWith(needs.setup.outputs.branch, 'gh-readonly-queue/main/'))
+        # Removed: testing is now an independent branch (like bluefin/bluefin-lts).
+        # BST-changing merges to testing trigger their own build and :testing publish.
+        # Fast-forwarding testing from main caused a redundant 5h rebuild (PR 997 / PR 1004).
+        if: false
         env:
           BUILD_SHA: ${{ needs.setup.outputs.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -2002,3 +2002,34 @@ gh pr view <n> --repo projectbluefin/dakota --json autoMergeRequest \
 ```
 If `false`, the `gh pr merge --auto` call failed — check the workflow's declared
 `permissions` first.
+
+### testing branch is independent — no fast-forward from main (2026-06-21)
+
+`testing` is an independent branch, identical to bluefin/bluefin-lts. It does NOT get
+fast-forwarded from `main`. BST-changing merges to `testing` trigger their own build
+and `:testing` publish. GHA-only merges (Renovate workflow pins) are filtered out.
+
+**Push trigger paths-ignore** in `build.yml`:
+```yaml
+push:
+  branches: [main, next, testing]
+  paths-ignore:
+    - '.github/workflows/**'   # workflows don't affect the image
+    # .github/actions/** intentionally NOT ignored — local composite actions are used in build
+    - 'docs/**'
+    - '**.md'
+    - 'AGENTS.md'
+```
+
+**Flow:**
+```
+BST PR → testing → build → :testing published
+GHA-only PR → testing → filtered, no build
+promote PR: testing → main → build → stable
+```
+
+The previous `Fast-forward testing branch` step in `publish.yml` was disabled (`if: false`)
+in PR 1004. It caused a redundant 5h rebuild: main build → fast-forward testing → push
+to testing → second full rebuild of identical content. Fix: PR 997 removed testing from
+push triggers entirely (broke :testing publishing); PR 1004 restored push trigger with
+paths-ignore and removed the fast-forward instead.


### PR DESCRIPTION
PR 997 removed `testing` from push triggers to stop a redundant 5h rebuild caused by `publish.yml` fast-forwarding `testing` from `main` (the fast-forward push re-triggered `build.yml`).

The fix in 997 broke `:testing` publishing: BST-changing merges to testing now produced no image at all.

**Root cause:** the fast-forward itself was wrong. `bluefin` and `bluefin-lts` don't fast-forward testing from main — they are independent branches.

**This PR:**
- Re-adds `testing` to `push:` trigger with `paths-ignore` (`.github/workflows/**`, `docs/**`, `**.md`) so GHA-only Renovate PRs don't trigger 5h builds
- Disables the fast-forward step in `publish.yml` (`if: false`)
- `.github/actions/**` is intentionally NOT ignored — local composite actions (`check-bst2-pin`, `generate-bst-ci-config`) affect the build

**Result:** same flow as bluefin/bluefin-lts.

- [x] I am using an agent and I take responsibility for this PR

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflow to skip redundant builds when only documentation and workflow configuration files change.
  * Changed testing branch to operate independently instead of automatically synchronizing from main.

* **Documentation**
  * Added comprehensive CI routing documentation explaining branch promotion flow and build trigger behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->