### PR TITLE
fix(ci): renovate automerge base_branch testing (testing-first model)

### DIFF
--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -15,4 +15,4 @@ jobs:
     uses: projectbluefin/actions/.github/workflows/reusable-renovate-automerge.yml@99d867d662ab64a1f82b4f5f24f73b4051dbff01 # v1
     with:
       head_sha: ${{ github.event.workflow_run.head_sha }}
-      base_branch: main
+      base_branch: testing


### PR DESCRIPTION
Renovate dep PRs target `testing` (not `main`) since PR 1004 aligned dakota to the testing-first model. `base_branch: main` caused the automerge reusable to silently exit with No PR found on every build completion.

Fix: remove the explicit override so the reusable default (`testing`) takes effect.

Closes no issue — this is a follow-on fix from PR 1004.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management workflow configuration to target the testing branch for quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->