### PR TITLE
docs(agents): add CI verification command and done-means-verified rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,9 @@ Examples of what "check the docs" means in practice:
 
 **Operator accountability:** The human deploying the agent is responsible for all decisions. PR template checkbox: `[ ] I am using an agent and I take responsibility for this PR`
 
-**Verification:** Every PR must confirm `just lint` passed and the image booted. Use `just boot-test` for automated pass/fail. No WIP PRs.
+**Verification:** Every PR must confirm `just lint` passed and the image booted. Use `just boot-test` for automated pass/fail. No WIP PRs. After pushing, verify CI is green before claiming done: `gh run list --repo projectbluefin/dakota --limit 5` — read the output; running or failing = not done. "Done" means CI green, not "I pushed."
+
+**Never claim a task complete without verifying.** "I've updated the file" is not done. Run the checks. Read the output.
 
 **Pre-commit guard:** `no-floating-action-tags` blocks third-party `@main`/`@v*` floating action tags at commit time. `projectbluefin/actions/` refs (`@v1`) are intentional managed tags and are exempted.
 


### PR DESCRIPTION
Agents are claiming tasks complete without verifying CI is green after pushing. None of the project AGENTS.md files had the explicit check command or a hard rule against declaring success before verifying.

Added to mandatory gates:
- After pushing, verify CI is green with the repo-specific gh run list command
- Never claim a task complete without verifying — done means verified, not 'I pushed'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced verification gate with explicit post-push CI verification steps and validation rules
  * Added requirement that work is not complete until verification checks are run and output is reviewed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->