### PR TITLE
fix(ci): restore next branch workflows after main merge

### DIFF
--- a/.github/workflows/sync-next-from-main.yml
+++ b/.github/workflows/sync-next-from-main.yml
@@ -61,6 +61,10 @@ jobs:
             exit 1
           fi
 
+          # Restore next's own workflow files so this sync never pushes
+          # .github/workflows/** changes that require special credentials.
+          git checkout 'HEAD@{1}' -- .github/workflows/
+
           # Restore next's junction ref/track (the only intentional divergence).
           # Use ^\s* anchor on track: to avoid matching comments or URLs.
           sed -i "0,/^\s*track:/{s|^\(\s*\)track:.*|\1track: $GNOME_TRACK|}" elements/gnome-build-meta.bst
@@ -69,7 +73,7 @@ jobs:
           sed -i "0,/^\s*ref:/{s|^\(\s*\)ref:.*|\1ref: $FDO_REF|}" elements/freedesktop-sdk.bst
 
           # Amend the merge commit to include the ref restoration.
-          git add elements/gnome-build-meta.bst elements/freedesktop-sdk.bst
+          git add .github/workflows/ elements/gnome-build-meta.bst elements/freedesktop-sdk.bst
           git commit --amend --no-edit
 
           git push origin next

--- a/docs/skills/ci-tooling.md
+++ b/docs/skills/ci-tooling.md
@@ -178,6 +178,19 @@ Bots create PRs but do not self-update branches when the base advances.
 **Fix:** Remove all actor exclusions from `pr-autoupdate`. Any PR targeting `main`
 that has gone behind should be updated, regardless of who opened it.
 
+### 10) Branch syncs should restore the target branch's own `.github/workflows/`
+
+When a branch-sync workflow merges `main` into another branch, the merge can pull in
+changes under `.github/workflows/**`. Pushing those workflow file changes can fail or
+force you into unnecessary credential escalation.
+
+**Fix:** After `git merge origin/main -X theirs --no-edit`, restore the target
+branch's pre-merge `.github/workflows/` tree with
+`git checkout HEAD@{1} -- .github/workflows/`, then stage
+`.github/workflows/` before amending the merge commit. This preserves the target
+branch's workflow files while still syncing other `.github/` content from `main`.
+
+
 ## Red Flags
 
 - `permissions: {}` on a reusable workflow caller
@@ -187,6 +200,7 @@ that has gone behind should be updated, regardless of who opened it.
 - relying on `GITHUB_TOKEN` for bot PRs that need PR checks to fire
 - `persist-credentials: false` in a workflow that runs in a repo with submodules
 - a sync workflow living only on the non-default branch (it will never fire)
+- a branch-sync workflow that would push `.github/workflows/**` instead of restoring the target branch's own `.github/workflows/`
 - `base_branch` not passed to `reusable-renovate-automerge` or passed with wrong value
 - bot actors excluded from `pr-autoupdate` while their PRs go behind
 - pr-triage gate only allowing `renovate/*` to target `testing`, blocking feature PRs
@@ -201,6 +215,7 @@ that has gone behind should be updated, regardless of who opened it.
 - [ ] The fix reduces CI ambiguity instead of adding more magic
 - [ ] `persist-credentials: false` not added to repos with incomplete `.gitmodules`
 - [ ] Branch-sync workflow lives on the default branch, not on the target branch
+- [ ] Branch-sync workflows that would carry `.github/workflows/**` restore the target branch's own `.github/workflows/` before push
 - [ ] `reusable-renovate-automerge` calls omit `base_branch` (default is `testing`) or pass the correct branch
 - [ ] `pr-autoupdate` has no actor exclusions that would strand bot PRs
 - [ ] pr-triage gate allows all PRs targeting `testing`, not just `renovate/*`


### PR DESCRIPTION
sync-next-from-main.yml fails when a main push includes .github/workflows/** changes:

refusing to allow a GitHub App to create or update workflow without workflows permission

GITHUB_TOKEN cannot push workflow file changes by design. The fix restores next's own .github/workflows/ after merging main (git checkout HEAD@{1} -- .github/workflows/), so the push never contains workflow changes and GITHUB_TOKEN works fine.

Non-workflow files under .github/ (renovate.json5, CODEOWNERS, etc.) continue to sync normally from main — only .github/workflows/ is preserved from next's pre-merge state.

Workflow updates reach next via normal PRs targeting next, same as any sensitive path.

Sensitive path: .github/workflows/ — maintainer review required.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>