### PR TITLE
ci(cache-warm): add parallel aarch64 warm-cache job

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -127,7 +127,6 @@ jobs:
           key: bst-warm-aarch64-${{ hashFiles('elements/gnome-build-meta.bst', 'elements/freedesktop-sdk.bst', 'Justfile') }}
           restore-keys: |
             bst-warm-aarch64-
-            bst-show-
 
       - name: Generate BuildStream CI config
         env:

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -89,3 +89,73 @@ jobs:
           CACHED=$(just bst show --deps all --format '%{name} %{state}' oci/bluefin.bst 2>/dev/null \
             | grep -c "cached" || echo 0)
           echo "::notice::Cached elements after warm: ${CACHED}"
+
+  # ── aarch64 warm cache ────────────────────────────────────────────────────
+  # Parallel to warm-cache — no `needs:` dependency, separate concurrency group.
+  # ARM failures are non-blocking (continue-on-error: true).
+  # Uses enable-remote-execution: false (no RE service for ARM yet) but
+  # enable-push: true so artifacts land in the remote CAS for subsequent builds.
+  warm-cache-aarch64:
+    name: Build to warm remote CAS (aarch64)
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 360
+    continue-on-error: true
+    concurrency:
+      group: dakota-cache-warm-aarch64
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Check bst2 image pin consistency
+        uses: ./.github/actions/check-bst2-pin
+
+      - name: Setup runner
+        uses: projectbluefin/actions/bootc-build/setup-runner@v1
+        with:
+          storage-backend: btrfs
+          update-podman: true
+          install-tools: '["just"]'
+
+      - name: Restore BST workspace cache (aarch64)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.cache/buildstream
+          key: bst-warm-aarch64-${{ hashFiles('elements/gnome-build-meta.bst', 'elements/freedesktop-sdk.bst', 'Justfile') }}
+          restore-keys: |
+            bst-warm-aarch64-
+            bst-show-
+
+      - name: Generate BuildStream CI config
+        env:
+          CASD_CLIENT_CERT: ${{ vars.CASD_CLIENT_CERT }}
+          CASD_CLIENT_KEY: ${{ secrets.CASD_CLIENT_KEY }}
+        uses: ./.github/actions/generate-bst-ci-config
+        with:
+          enable-remote-execution: false
+          enable-push: true
+
+      - name: Build default variant (aarch64 warm-cache mode, non-blocking)
+        env:
+          BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf --option arch aarch64
+        run: |
+          set +e
+          just bst build oci/bluefin.bst
+          rc=$?
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning::aarch64 cache warm build failed (rc=${rc}) — non-blocking."
+            echo "::warning::Likely causes: gnome-build-meta upstream rebuilding, junction ref skew."
+          fi
+          exit 0
+
+      - name: Report cache state (aarch64)
+        if: always()
+        run: |
+          echo "::notice::aarch64 cache warm completed at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          CACHED=$(just bst show --deps all --format '%{name} %{state}' \
+            --option arch aarch64 oci/bluefin.bst 2>/dev/null \
+            | grep -c "cached" || echo 0)
+          echo "::notice::Cached aarch64 elements after warm: ${CACHED}"

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -84,7 +84,7 @@ Use this skill when the task mentions:
 
 **Merge queue path:** `build` fires on `merge_group` — full OCI build, real CI gate before merge.
 
-**Cache-warm path:** `cache-warm.yml` runs Monday and Thursday at 06:00 UTC and on manual dispatch. Builds the default variant against the remote CAS so merge-queue builds land on cache hits even after junction ref bumps or upstream `gnome-build-meta` rebuilds. Failures are non-blocking — the warm build is best-effort. Addresses the cold-start non-determinism documented in [common automation-audit ND1](https://github.com/projectbluefin/common/blob/main/docs/factory/automation-audit/non-deterministic-steps.md).
+**Cache-warm path:** `cache-warm.yml` runs Monday and Thursday at 06:00 UTC and on manual dispatch. Two parallel jobs — `warm-cache` (x86_64) and `warm-cache-aarch64` — run independently with no `needs:` dependency between them. Each has its own concurrency group (`dakota-cache-warm` and `dakota-cache-warm-aarch64`) so they never serialise. Both use `continue-on-error: true` and failures are non-blocking — best-effort. Addresses the cold-start non-determinism documented in [common automation-audit ND1](https://github.com/projectbluefin/common/blob/main/docs/factory/automation-audit/non-deterministic-steps.md).
 
 ## Remote Cache Architecture
 
@@ -212,6 +212,24 @@ gh run list --repo projectbluefin/dakota --limit 5
 | `update-refs.md` | Understanding the source tracking workflow |
 
 ## Lessons Learned
+
+### ARM warm-cache must be a parallel job with its own concurrency group (2026-06-22)
+
+The `cache-warm.yml` originally had only an x86_64 job. Adding ARM as a second
+step inside the same job would serialise the two architectures and block x86 on
+ARM failures. The correct pattern:
+
+- Add a **second top-level job** (`warm-cache-aarch64`) — no `needs:` dependency.
+- Use a **separate `concurrency.group`** (`dakota-cache-warm-aarch64`) so the two
+  jobs never queue behind each other.
+- Set `continue-on-error: true` on the ARM job — ARM failures never block x86.
+- Use `BST_FLAGS: --no-interactive --config /src/buildstream-ci.conf --option arch aarch64`
+  — the `--config` flag is required for the generated BST CI config (and the
+  remote CAS push) to actually take effect.
+- Use `enable-remote-execution: false`, `enable-push: true` — no RE service for
+  ARM yet, but artifacts should still be pushed to the remote CAS.
+- Use a distinct BST workspace cache key: `bst-warm-aarch64-${{ hashFiles(...) }}`
+  — sharing a key with x86 will cause cross-arch cache pollution.
 
 ### crun 1.21 (resolute) breaks just sbom on GHA — use --runtime runc (2026-06-08)
 


### PR DESCRIPTION
Add a second warm-cache job to cache-warm.yml that runs on ubuntu-24.04-arm in parallel with the existing x86_64 job.

The two jobs are fully decoupled:
- No needs: between them — start simultaneously
- Separate concurrency groups (dakota-cache-warm-aarch64 vs dakota-cache-warm)
- continue-on-error: true on the ARM job — ARM failures never affect x86

The ARM job pushes artifacts to cache.projectbluefin.io:11002 (enable-push: true, enable-remote-execution: false) with BST_FLAGS including --config /src/buildstream-ci.conf so the generated config is actually loaded. Separate BST workspace cache key avoids cross-arch pollution.

[ ] I am using an agent and I take responsibility for this PR