### PR TITLE
fix(ci): pin bonedigger lifecycle.yml SHA instead of floating @v1 tag

### DIFF
--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   lifecycle:
-    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@v1
+    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@d53076732c23203efd7856eaee7c502742897603 # v1
     with:
       brand_name: "Dakota"
     secrets: inherit


### PR DESCRIPTION
Floating tags are mutable and will break pre-commit SHA pinning enforcement. Pin to the exact SHA for v1.