### PR TITLE
fix(ci): add workflows permission to sync-next-from-main

### DIFF
--- a/.github/workflows/sync-next-from-main.yml
+++ b/.github/workflows/sync-next-from-main.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: write
+  workflows: write
 
 jobs:
   sync-next:


### PR DESCRIPTION
Push was rejected when merging main into next includes workflow file changes.

Error seen in runs 27970750004 and 27969646325:
```
! [remote rejected] next -> next (refusing to allow a GitHub App to create or update workflow .github/workflows/build.yml without workflows permission)
```

The fix adds `workflows: write` permission alongside the existing `contents: write`. This is required for GITHUB_TOKEN to push commits that include workflow file changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to support enhanced CI/CD capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->