### PR TITLE
fix(ci): restore next branch workflows after main merge

### DIFF
--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -21,4 +21,3 @@ jobs:
     with:
       brand_name: "Dakota"
     secrets: inherit
-

--- a/.github/workflows/run-testsuite.yml
+++ b/.github/workflows/run-testsuite.yml
@@ -30,4 +30,3 @@ jobs:
       image: ${{ inputs.image }}
       suites: ${{ inputs.suites }}
     secrets: inherit
-

--- a/.github/workflows/sync-next-from-main.yml
+++ b/.github/workflows/sync-next-from-main.yml
@@ -61,6 +61,10 @@ jobs:
             exit 1
           fi
 
+          # Restore next's own workflow files so this sync never pushes
+          # .github/workflows/** changes that require special credentials.
+          git checkout 'HEAD@{1}' -- .github/workflows/
+
           # Restore next's junction ref/track (the only intentional divergence).
           # Use ^\s* anchor on track: to avoid matching comments or URLs.
           sed -i "0,/^\s*track:/{s|^\(\s*\)track:.*|\1track: $GNOME_TRACK|}" elements/gnome-build-meta.bst
@@ -69,7 +73,7 @@ jobs:
           sed -i "0,/^\s*ref:/{s|^\(\s*\)ref:.*|\1ref: $FDO_REF|}" elements/freedesktop-sdk.bst
 
           # Amend the merge commit to include the ref restoration.
-          git add elements/gnome-build-meta.bst elements/freedesktop-sdk.bst
+          git add .github/workflows/ elements/gnome-build-meta.bst elements/freedesktop-sdk.bst
           git commit --amend --no-edit
 
           git push origin next

--- a/.github/workflows/sync-next-from-main.yml
+++ b/.github/workflows/sync-next-from-main.yml
@@ -63,7 +63,9 @@ jobs:
 
           # Restore next's own workflow files so this sync never pushes
           # .github/workflows/** changes that require special credentials.
-          git checkout 'HEAD@{1}' -- .github/workflows/
+          # Use git restore (not git checkout) so files added by main are also
+          # deleted — git checkout only restores existing paths, not deletions.
+          git restore --source='HEAD@{1}' --staged --worktree -- .github/workflows/
 
           # Restore next's junction ref/track (the only intentional divergence).
           # Use ^\s* anchor on track: to avoid matching comments or URLs.

--- a/docs/skills/ci-tooling.md
+++ b/docs/skills/ci-tooling.md
@@ -186,9 +186,11 @@ force you into unnecessary credential escalation.
 
 **Fix:** After `git merge origin/main -X theirs --no-edit`, restore the target
 branch's pre-merge `.github/workflows/` tree with
-`git checkout HEAD@{1} -- .github/workflows/`, then stage
+`git restore --source='HEAD@{1}' --staged --worktree -- .github/workflows/`, then stage
 `.github/workflows/` before amending the merge commit. This preserves the target
-branch's workflow files while still syncing other `.github/` content from `main`.
+branch's workflow files while also removing any new workflow files main introduced.
+Use `git restore` (not `git checkout`) — `git checkout` only restores existing paths
+and will not delete files newly added by the merge.
 
 
 ## Red Flags

--- a/docs/skills/ci-tooling.md
+++ b/docs/skills/ci-tooling.md
@@ -178,6 +178,19 @@ Bots create PRs but do not self-update branches when the base advances.
 **Fix:** Remove all actor exclusions from `pr-autoupdate`. Any PR targeting `main`
 that has gone behind should be updated, regardless of who opened it.
 
+### 10) Branch syncs should restore the target branch's own `.github/workflows/`
+
+When a branch-sync workflow merges `main` into another branch, the merge can pull in
+changes under `.github/workflows/**`. Pushing those workflow file changes can fail or
+force you into unnecessary credential escalation.
+
+**Fix:** After `git merge origin/main -X theirs --no-edit`, restore the target
+branch's pre-merge `.github/workflows/` tree with
+`git checkout HEAD@{1} -- .github/workflows/`, then stage
+`.github/workflows/` before amending the merge commit. This preserves the target
+branch's workflow files while still syncing other `.github/` content from `main`.
+
+
 ## Red Flags
 
 - `permissions: {}` on a reusable workflow caller
@@ -187,6 +200,7 @@ that has gone behind should be updated, regardless of who opened it.
 - relying on `GITHUB_TOKEN` for bot PRs that need PR checks to fire
 - `persist-credentials: false` in a workflow that runs in a repo with submodules
 - a sync workflow living only on the non-default branch (it will never fire)
+- a branch-sync workflow that would push `.github/workflows/**` instead of restoring the target branch's own `.github/workflows/`
 - `base_branch` not passed to `reusable-renovate-automerge` or passed with wrong value
 - bot actors excluded from `pr-autoupdate` while their PRs go behind
 - pr-triage gate only allowing `renovate/*` to target `testing`, blocking feature PRs
@@ -201,6 +215,7 @@ that has gone behind should be updated, regardless of who opened it.
 - [ ] The fix reduces CI ambiguity instead of adding more magic
 - [ ] `persist-credentials: false` not added to repos with incomplete `.gitmodules`
 - [ ] Branch-sync workflow lives on the default branch, not on the target branch
+- [ ] Branch-sync workflows that would carry `.github/workflows/**` restore the target branch's own `.github/workflows/` before push
 - [ ] `reusable-renovate-automerge` calls omit `base_branch` (default is `testing`) or pass the correct branch
 - [ ] `pr-autoupdate` has no actor exclusions that would strand bot PRs
 - [ ] pr-triage gate allows all PRs targeting `testing`, not just `renovate/*`


### PR DESCRIPTION
Push was rejected when merging main into next includes workflow file changes:
```
! [remote rejected] next -> next (refusing to allow a GitHub App to create or update workflow .github/workflows/build.yml without workflows permission)
```

Instead of adding workflows: write (which would let the bot overwrite next's workflows with main's), restore next's own workflow files after the merge. This preserves the intended behaviour: next gets all non-workflow changes from main, but keeps its own workflow files.

Fixes: runs 27970750004 and 27969646325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal GitHub Actions workflow permissions to improve CI/CD pipeline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->