### PR TITLE
ci(build): live BST progress monitor with cache hit/miss stats

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,11 +176,33 @@ jobs:
       # bst2 container. CI-specific flags (--no-interactive, --config)
       # are injected via BST_FLAGS env var.
 
-      - name: Build OCI image with BuildStream
+      # Count the full element graph so the progress script can show %.
+      # bst show only reads element YAML + fetches junction refs — no CAS
+      # traffic, typically <60s. Runs after Generate BuildStream CI config
+      # so the remote CAS address is available.
+      - name: Count elements for progress tracking
+        id: count
         env:
           BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
         run: |
-          just bst build ${{ matrix.element }}
+          if TOTAL=$(just bst show --deps all --format '%{name}' \
+              ${{ matrix.element }} 2>&1 | wc -l); then
+            echo "total=${TOTAL}" >> "$GITHUB_OUTPUT"
+            echo "Element graph: ${TOTAL} elements"
+          else
+            echo "::warning::bst show failed — progress will show absolute counts only"
+            echo "total=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build OCI image with BuildStream
+        env:
+          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
+          ELEMENT_TOTAL: ${{ steps.count.outputs.total }}
+        run: |
+          # pipefail: propagate non-zero exit from `just bst build` through the pipe
+          set -o pipefail
+          just bst build ${{ matrix.element }} 2>&1 \
+            | python3 files/scripts/bst-progress.py
         timeout-minutes: 330
 
       # Push the built artifact to the remote CAS so the export job can pull it.

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -67,15 +67,31 @@ jobs:
           enable-remote-execution: false
           enable-push: true
 
+      - name: Count elements for progress tracking
+        id: count
+        env:
+          BST_FLAGS: -o x86_64_v3 true --no-interactive
+        run: |
+          if TOTAL=$(just bst show --deps all --format '%{name}' \
+              oci/bluefin.bst 2>&1 | wc -l); then
+            echo "total=${TOTAL}" >> "$GITHUB_OUTPUT"
+            echo "Element graph: ${TOTAL} elements"
+          else
+            echo "::warning::bst show failed — progress will show absolute counts only"
+            echo "total=0" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build default variant (warm-cache mode, non-blocking)
         env:
           BST_FLAGS: -o x86_64_v3 true --no-interactive
+          ELEMENT_TOTAL: ${{ steps.count.outputs.total }}
         run: |
           set +e
           # Build only — no checkout, no push to GHCR. Goal is to populate
           # the remote CAS so subsequent merge-queue builds get cache hits.
-          just bst build oci/bluefin.bst
-          rc=$?
+          just bst build oci/bluefin.bst 2>&1 \
+            | python3 files/scripts/bst-progress.py
+          rc=${PIPESTATUS[0]}
           if [ "$rc" -ne 0 ]; then
             echo "::warning::Cache warm build failed (rc=${rc}) — non-blocking."
             echo "::warning::Likely causes: gnome-build-meta upstream rebuilding, junction ref skew."
@@ -84,11 +100,31 @@ jobs:
 
       - name: Report cache state
         if: always()
+        env:
+          BST_FLAGS: -o x86_64_v3 true --no-interactive
         run: |
           echo "::notice::Cache warm completed at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          CACHED=$(just bst show --deps all --format '%{name} %{state}' oci/bluefin.bst 2>/dev/null \
-            | grep -c "cached" || echo 0)
-          echo "::notice::Cached elements after warm: ${CACHED}"
+          BST_STATES=$(just bst show --deps all \
+            --format '%{name} %{state}' oci/bluefin.bst 2>/dev/null || true)
+          CACHED=$(echo "$BST_STATES" | grep -c " cached" || echo 0)
+          BUILDABLE=$(echo "$BST_STATES" | grep -c " buildable" || echo 0)
+          FETCH=$(echo "$BST_STATES" | grep -c " fetch" || echo 0)
+          TOTAL=$(echo "$BST_STATES" | grep -c '.' || echo 0)
+          echo "::notice::Cached elements after warm: ${CACHED}/${TOTAL}"
+          # Write structured summary for historical comparison
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          ## Cache Warm Report
+
+          | State | Count |
+          |---|---|
+          | cached | ${CACHED} |
+          | buildable (miss) | ${BUILDABLE} |
+          | fetch needed | ${FETCH} |
+          | **total** | **${TOTAL}** |
+
+          Run at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+          EOF
+
 
   # ── aarch64 warm cache ────────────────────────────────────────────────────
   # Parallel to warm-cache — no `needs:` dependency, separate concurrency group.

--- a/files/scripts/bst-progress.py
+++ b/files/scripts/bst-progress.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""BST build progress monitor for GitHub Actions.
+
+Pipe BST build stdout through this script to get live progress lines and a
+final step summary without losing any of the original output.
+
+Usage (in build.yml):
+    just bst build oci/bluefin.bst 2>&1 | python3 files/scripts/bst-progress.py
+
+Environment variables:
+    ELEMENT_TOTAL       Total element count from a preceding `bst show` step.
+                        If unset, progress shows absolute counts without %.
+    GITHUB_STEP_SUMMARY Path to the GHA step summary file (set by runner).
+    BST_PROGRESS_INTERVAL Seconds between progress lines (default: 30).
+
+Exit code:
+    Exits 0 on clean EOF. The build step must use `set -o pipefail` so that
+    a non-zero exit from `just bst build` propagates through the pipe.
+
+Element completion detection:
+    BST emits a terminal SUCCESS line whose message field is a log file path
+    (ends in .log). One such line per element operation (pull, build, fetch).
+    We deduplicate by artifact hash so each element counts exactly once,
+    regardless of how many sub-operations it runs.
+"""
+
+import os
+import re
+import sys
+import time
+import collections
+
+TOTAL = int(os.environ.get("ELEMENT_TOTAL", "0"))
+INTERVAL = int(os.environ.get("BST_PROGRESS_INTERVAL", "30"))
+SUMMARY_FILE = os.environ.get("GITHUB_STEP_SUMMARY", "")
+
+# Strip ANSI color/control codes before matching (just bst passes --colors by default).
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*[mABCDEFGHJKLMSTsuhl]")
+
+# Matches a terminal SUCCESS/SKIPPED line whose message is a log file path.
+# Groups: (artifact_hash, action_type, element_name, state)
+# Example line (GHA prefix and ANSI codes stripped):
+#   [23:37:43][00:00:04][d37613a5][    pull:fds.bst:steam-devices.bst] SUCCESS fds/.../d37613a5-pull.20260622.log
+TERMINAL = re.compile(
+    r"\[([0-9a-f]+)\]\[[ ]*(pull|build|fetch|push):([^\]]+)\] "
+    r"(SUCCESS|SKIPPED)\s+\S+\.log\s*$"
+)
+
+done_hashes: set[str] = set()
+action_counts: collections.Counter = collections.Counter()
+start_time = time.monotonic()
+last_report = start_time
+
+
+def _format_elapsed(seconds: float) -> str:
+    m, s = divmod(int(seconds), 60)
+    h, m = divmod(m, 60)
+    return f"{h:02d}:{m:02d}:{s:02d}" if h else f"{m:02d}:{s:02d}"
+
+
+def _emit_progress(done: int, elapsed: float, final: bool = False) -> None:
+    pct = int(done * 100 / TOTAL) if TOTAL else 0
+    rate = done / elapsed * 60 if elapsed > 0 else 0
+    remaining = int((TOTAL - done) / (done / elapsed)) if done > 0 and elapsed > 0 and TOTAL > done else 0
+
+    label = "Final" if final else "Progress"
+    if TOTAL:
+        eta = f"  ETA ~{remaining // 60}m{remaining % 60:02d}s" if not final else ""
+        line = (
+            f"\n>>> BST {label}: {done}/{TOTAL} ({pct}%) "
+            f"pull:{action_counts['pull']} build:{action_counts['build']} "
+            f"fetch:{action_counts['fetch']}  "
+            f"{rate:.0f} elem/min{eta}\n"
+        )
+        notice = (
+            f"::notice::BST {pct}% — {done}/{TOTAL} elements  "
+            f"pull:{action_counts['pull']} build:{action_counts['build']}"
+            + (f"  ETA ~{remaining // 60}m" if not final else "  done")
+        )
+    else:
+        line = (
+            f"\n>>> BST {label}: {done} elements completed "
+            f"pull:{action_counts['pull']} build:{action_counts['build']} "
+            f"fetch:{action_counts['fetch']}  "
+            f"{rate:.0f} elem/min  elapsed:{_format_elapsed(elapsed)}\n"
+        )
+        notice = (
+            f"::notice::BST {done} elements — "
+            f"pull:{action_counts['pull']} build:{action_counts['build']}"
+        )
+
+    print(line, end="", flush=True)
+    print(notice, flush=True)
+
+
+def _write_summary(done: int, elapsed: float) -> None:
+    if not SUMMARY_FILE:
+        return
+
+    pct = f"{done * 100 / TOTAL:.1f}" if TOTAL else "n/a"
+    miss_pct = (
+        f"{action_counts['build'] * 100 / done:.1f}" if done else "0.0"
+    )
+    rate = f"{done / elapsed * 60:.0f}" if elapsed > 0 else "0"
+
+    table = f"""
+## BST Cache Performance
+
+| Metric | Value |
+|---|---|
+| Total elements | {TOTAL or "unknown"} |
+| Completed | {done} ({pct}%) |
+| Cache hits (pull) | {action_counts['pull']} |
+| Local builds (miss) | {action_counts['build']} |
+| Fetches | {action_counts['fetch']} |
+| Cache miss rate | {miss_pct}% |
+| Wall time | {_format_elapsed(elapsed)} |
+| Throughput | {rate} elem/min |
+
+"""
+    try:
+        with open(SUMMARY_FILE, "a") as f:
+            f.write(table)
+    except OSError:
+        pass
+
+
+def main() -> None:
+    global last_report
+    done = 0
+
+    for raw_line in sys.stdin.buffer:
+        # Pass every byte through unchanged
+        sys.stdout.buffer.write(raw_line)
+        sys.stdout.buffer.flush()
+
+        line = raw_line.decode("utf-8", errors="replace")
+        m = TERMINAL.search(ANSI_ESCAPE.sub("", line))
+        if m:
+            artifact_hash, action, _element, _state = m.groups()
+            if artifact_hash not in done_hashes:
+                done_hashes.add(artifact_hash)
+                action_counts[action] += 1
+                done += 1
+
+                now = time.monotonic()
+                elapsed = now - start_time
+                if now - last_report >= INTERVAL:
+                    _emit_progress(done, elapsed)
+                    last_report = now
+
+    elapsed = time.monotonic() - start_time
+    done = len(done_hashes)
+    _emit_progress(done, elapsed, final=True)
+    _write_summary(done, elapsed)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a Python passthrough script that monitors BST build stdout and emits live progress lines visible in GHA step output.

What it does:
- Strips ANSI color codes (just bst passes --colors by default) before matching BST terminal lines
- Detects completed elements by artifact hash deduplication (SUCCESS *.log lines)
- Reports every 30s: percentage complete, pull/build/fetch breakdown, throughput, ETA
- Writes a BST Cache Performance table to GITHUB_STEP_SUMMARY at end

Wired into:
- build.yml: count step + pipefail pipe through script
- cache-warm.yml: same, with PIPESTATUS[0] for non-blocking error capture

Count step hardened: explicit if/else with warning annotation on failure instead of broken || echo 0 inside command substitution.

[ ] I am using an agent and I take responsibility for this PR