### PR TITLE
fix(bst-progress): correct action priority dedup and count step exit handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,12 +185,16 @@ jobs:
         env:
           BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
         run: |
-          if TOTAL=$(just bst show --deps all --format '%{name}' \
-              ${{ matrix.element }} 2>&1 | wc -l); then
+          BST_SHOW_OUT=$(just bst show --deps all --format '%{name}' \
+            ${{ matrix.element }} 2>&1)
+          rc=$?
+          if [ "$rc" -eq 0 ]; then
+            TOTAL=$(echo "$BST_SHOW_OUT" | wc -l)
             echo "total=${TOTAL}" >> "$GITHUB_OUTPUT"
             echo "Element graph: ${TOTAL} elements"
           else
-            echo "::warning::bst show failed — progress will show absolute counts only"
+            echo "$BST_SHOW_OUT"
+            echo "::warning::bst show failed (rc=${rc}) — progress will show absolute counts only"
             echo "total=0" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -72,12 +72,16 @@ jobs:
         env:
           BST_FLAGS: -o x86_64_v3 true --no-interactive
         run: |
-          if TOTAL=$(just bst show --deps all --format '%{name}' \
-              oci/bluefin.bst 2>&1 | wc -l); then
+          BST_SHOW_OUT=$(just bst show --deps all --format '%{name}' \
+            oci/bluefin.bst 2>&1)
+          rc=$?
+          if [ "$rc" -eq 0 ]; then
+            TOTAL=$(echo "$BST_SHOW_OUT" | wc -l)
             echo "total=${TOTAL}" >> "$GITHUB_OUTPUT"
             echo "Element graph: ${TOTAL} elements"
           else
-            echo "::warning::bst show failed — progress will show absolute counts only"
+            echo "$BST_SHOW_OUT"
+            echo "::warning::bst show failed (rc=${rc}) — progress will show absolute counts only"
             echo "total=0" >> "$GITHUB_OUTPUT"
           fi
 

--- a/files/scripts/bst-progress.py
+++ b/files/scripts/bst-progress.py
@@ -46,7 +46,10 @@ TERMINAL = re.compile(
     r"(SUCCESS|SKIPPED)\s+\S+\.log\s*$"
 )
 
-done_hashes: set[str] = set()
+# Priority: build (local compile, highest) > pull (CAS hit) > fetch (source) > push
+ACTION_PRIORITY: dict[str, int] = {"build": 3, "pull": 2, "fetch": 1, "push": 0}
+
+done_hashes: dict[str, str] = {}  # artifact_hash -> best action seen so far
 action_counts: collections.Counter = collections.Counter()
 start_time = time.monotonic()
 last_report = start_time
@@ -138,16 +141,23 @@ def main() -> None:
         m = TERMINAL.search(ANSI_ESCAPE.sub("", line))
         if m:
             artifact_hash, action, _element, _state = m.groups()
-            if artifact_hash not in done_hashes:
-                done_hashes.add(artifact_hash)
+            prev_action = done_hashes.get(artifact_hash)
+            if prev_action is None:
+                # First terminal line for this hash — count it as a new element
+                done_hashes[artifact_hash] = action
                 action_counts[action] += 1
                 done += 1
+            elif ACTION_PRIORITY.get(action, 0) > ACTION_PRIORITY.get(prev_action, 0):
+                # Higher-priority action for same element (e.g. build after fetch)
+                action_counts[prev_action] -= 1
+                action_counts[action] += 1
+                done_hashes[artifact_hash] = action
 
-                now = time.monotonic()
-                elapsed = now - start_time
-                if now - last_report >= INTERVAL:
-                    _emit_progress(done, elapsed)
-                    last_report = now
+            now = time.monotonic()
+            elapsed = now - start_time
+            if now - last_report >= INTERVAL:
+                _emit_progress(done, elapsed)
+                last_report = now
 
     elapsed = time.monotonic() - start_time
     done = len(done_hashes)


### PR DESCRIPTION
Fixes two bugs in 2efe3df (BST progress monitor):

Bug 1 — action misclassification: the first-seen dedup meant an element that fetches source then builds locally was permanently counted as 'fetch' not 'build', making cache miss stats wrong. Fix: track highest-priority action per hash (build > pull > fetch > push) and upgrade when a later higher-priority terminal line arrives.

Bug 2 — unreachable error branch in count steps: `if TOTAL=$(... | wc -l)` tests wc -l's exit code (always 0), so bst show failures silently produced a bogus total. Fix: capture bst show output + exit code separately, count lines only on success, echo the error output and emit a warning annotation on failure.

[ ] I am using an agent and I take responsibility for this PR