### PR TITLE
docs: require Context7 tool lookup before any tool or library use

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,11 @@ Dakota is a [BuildStream 2](https://buildstream.build/) project producing **Dako
 
 Load **[docs/SKILL.md](docs/SKILL.md)** for the full reference skill tree. Only load docs relevant to your task.
 
+> **Before using any tool or library: look up its docs via Context7 first. Always.**
+> BuildStream, bootc, cosign, skopeo, GitHub Actions — every tool has live, authoritative docs.
+> Pattern: `resolve-library-id` → `get-library-docs` → implement → cite the section.
+> Guessing, flag-hunting, and trial-and-error are banned. The docs exist. Read them.
+
 ## Org pipeline — projectbluefin
 
 ### Repo map


### PR DESCRIPTION
Training data is stale. Agents must resolve tool docs via Context7 before writing code. Pattern: resolve-library-id → get-library-docs → implement → cite.