### PR TITLE
fix(ci): run validate job on merge_group events

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
   # both variants. Zero remote-execution — does not touch cache.projectbluefin.io.
   # Expected runtime: <15 min (BST cache hit), <30 min (cold start).
   validate:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
The validate job was gated on pull_request only. The main branch ruleset requires validate to pass before merge. Promotion PRs (bot-created) have all pull_request runs blocked at org level (action_required), so validate never posts a passing status. Merge queue fires merge_group events which bypass the bot restriction — but validate was not wired to respond to them, causing the required check to never post and the merge queue to time out.

Fix: add merge_group to validate's event condition.

This directly unblocks promotion PR #970 (testing -> main) which has been stuck.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot