### PR TITLE
ci(build): enforce serial BST builds — max-parallel: 1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,11 +109,11 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 360
-    # Both variants build in parallel. NVIDIA is continue-on-error so its
-    # failure does not block the default image's merge or publication.
+    # Variants build serially — one BST build at a time per the hard rule.
+    # Shared runners and CAS write bandwidth cannot sustain concurrent builds.
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 1
       matrix:
         include:
           - variant: default


### PR DESCRIPTION
Concurrent matrix builds saturate shared runners and CAS write bandwidth, causing 6+ hour builds or timeouts.

Set `max-parallel: 1` so default and nvidia variants build sequentially.

- [ ] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified OCI build pipeline to execute build variants sequentially.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->