### PR TITLE
fix(ci): guard count-elements step against bst show failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,9 +193,11 @@ jobs:
         env:
           BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
         run: |
+          set +e
           BST_SHOW_OUT=$(just bst show --deps all --format '%{name}' \
             ${{ matrix.element }} 2>&1)
           rc=$?
+          set -e
           if [ "$rc" -eq 0 ]; then
             TOTAL=$(echo "$BST_SHOW_OUT" | wc -l)
             echo "total=${TOTAL}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -75,9 +75,11 @@ jobs:
         env:
           BST_FLAGS: -o x86_64_v3 true --no-interactive
         run: |
+          set +e
           BST_SHOW_OUT=$(just bst show --deps all --format '%{name}' \
             oci/bluefin.bst 2>&1)
           rc=$?
+          set -e
           if [ "$rc" -eq 0 ]; then
             TOTAL=$(echo "$BST_SHOW_OUT" | wc -l)
             echo "total=${TOTAL}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Root Cause

With `bash -e` active (GHA default shell), `BST_SHOW_OUT=$(cmd 2>&1)` exits immediately if `cmd` exits non-zero. The `rc=$?` line never executes and the step propagates the bst show exit code (255) instead of falling through to the graceful warning path.

This caused the **Count elements for progress tracking** step to kill the build job when `bst show` fails for any reason (e.g. a patch in `patch_queue` not applying to a new junction ref).

## Failing runs

- 28056225668 (next branch) — both default and nvidia builds exit 255 at count step
- 28056221904 (auto/track-next-junction) — validate bst show fails, entire build skipped

## Fix

Wrap the assignment with `set +e` / `set -e` in both `build.yml` and `cache-warm.yml`. When `bst show` fails, `rc` is captured correctly and the existing graceful fallback (emit a warning, set `total=0`) runs instead of aborting the step.

The build itself will still fail if BST cannot load the element graph — this only prevents a spurious CI infrastructure failure from masking the real error.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow stability by improving error handling during progress tracking steps, ensuring workflows continue gracefully even if element counting operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->