### PR TITLE
fix(ci): add statuses:write permission to promote caller

### DIFF
--- a/.github/workflows/promote-testing-to-main.yml
+++ b/.github/workflows/promote-testing-to-main.yml
@@ -26,6 +26,7 @@ permissions:
   issues: write         # open / close failure-tracking issues
   packages: read        # read image digests in release-gate checks
   actions: read         # inspect workflow-run statuses in release-gate
+  statuses: write       # post validate status on squash branch head
 
 jobs:
   promote:


### PR DESCRIPTION
## Problem

The `reusable-promote-squash.yml@v1` was updated today (2026-06-23) to post a `validate=success` commit status on the squash branch HEAD, so the merge queue can accept the PR in the same run without re-triggering. This requires `statuses: write` in the promote job.

Caller-level permissions set the **maximum** grants available to called workflow jobs. `promote-testing-to-main.yml` did not grant `statuses: write`, so GitHub rejects the workflow at startup before any job runs (`startup_failure` on every dispatch).

**Root cause of PR #1055 being closed UNSTABLE:** The `workflows: write` permission added in #1054 caused actionlint to fail (it's not in actionlint's known-scope list). The promote workflow detected the UNSTABLE lint check and eventually closed the stale PR once `testing == main`.

**Root cause of current startup_failures:** Missing `statuses: write` in the caller — all 3 retrigger attempts after 23:00 UTC fail at startup.

## Fix

Add `statuses: write` to `promote-testing-to-main.yml`'s top-level permissions block.

## Verification

After merge, retrigger the promote workflow to confirm it runs (even if no-op since testing == main).

Closes #1055 (indirectly — fixes the promote pipeline)