### PR TITLE
ci(build): add daily 13:00 schedule; trigger ARM from publish

### DIFF
--- a/.github/workflows/build-aarch64.yml
+++ b/.github/workflows/build-aarch64.yml
@@ -10,10 +10,10 @@ name: Build Bluefin dakota (aarch64)
 #   - No remote execution (no RE service for ARM); enable-push: true so artifacts
 #     land in the remote CAS for subsequent builds and warm-cache runs.
 #
-# Triggers mirror x86_64 build.yml:
+# Triggers:
 #   - push: testing / main (BST-affecting paths only; docs/workflow-only changes ignored)
-#   - schedule: Tuesday 04:00 UTC — same cadence as promote-testing-to-main so the
-#     aarch64 image may be current when execute-release creates a multi-arch manifest
+#   - workflow_run: fires after x86_64 publish completes on testing — ARM builds
+#     after x86 CAS writes are done, avoiding CAS write contention
 #   - workflow_dispatch: manual recovery / on-demand
 #
 # Published tags (when qualifying event on testing/main):
@@ -29,9 +29,12 @@ on:
       - '**.md'
       - 'AGENTS.md'
       - 'files/scripts/**'
-  schedule:
-    # Tuesday 04:00 UTC — same window as promote-testing-to-main.yml schedule
-    - cron: '0 4 * * 2'
+  # Triggered after x86_64 publish completes — ARM builds after x86 CAS writes
+  # are done, avoiding CAS write contention.
+  workflow_run:
+    workflows: ["Publish Bluefin dakota"]
+    types: [completed]
+    branches: [testing]
   workflow_dispatch:
 
 permissions: read-all
@@ -49,6 +52,10 @@ jobs:
   build-aarch64:
     name: Build OCI image (aarch64)
     runs-on: ubuntu-24.04-arm
+    # Skip if triggered by workflow_run but the upstream publish failed.
+    if: >
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     # ARM failures are non-blocking and never affect x86_64 publication.
     continue-on-error: true
     timeout-minutes: 420
@@ -136,7 +143,7 @@ jobs:
       - name: Login to GHCR
         if: >-
           github.event_name == 'push' ||
-          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_run' ||
           github.event_name == 'workflow_dispatch'
         env:
           GH_ACTOR: ${{ github.actor }}
@@ -146,7 +153,7 @@ jobs:
       - name: Tag image for GHCR
         if: >-
           github.event_name == 'push' ||
-          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_run' ||
           github.event_name == 'workflow_dispatch'
         run: |
           sudo podman tag "localhost/${{ steps.export.outputs.image_ref }}" \
@@ -158,7 +165,7 @@ jobs:
         id: push
         if: >-
           github.event_name == 'push' ||
-          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_run' ||
           github.event_name == 'workflow_dispatch'
         run: |
           for tag in aarch64 "aarch64-${{ github.sha }}"; do

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,20 @@
 name: Build Bluefin dakota
 
 on:
+  # Fires daily at 13:00 UTC — 5 hours after the gnome-build-meta nightly
+  # (~08:00 UTC) to absorb nightly deltas before building.
+  # NOTE: schedule triggers run on the default branch; set testing as the
+  # default branch in repo settings for this to target testing.
+  schedule:
+    - cron: '0 13 * * *'
   pull_request:
-    branches: [main, next, testing]
+    branches: [testing, next, main]
   merge_group:
-    branches: [main, next, testing]
+    branches: [testing, next, main]
   push:
-    branches: [main, next, testing]
+    # main is a release bookmark — pushes to main after promotion should not
+    # trigger a full BST build. Only testing (trunk) and next (rolling) build.
+    branches: [next, testing]
     paths-ignore:
       # Workflow files and docs don't affect the built image.
       # .github/actions/** is intentionally NOT ignored — local composite


### PR DESCRIPTION
Part of the OCI-native promotion redesign (issue 1073).

build.yml: adds daily schedule trigger at 13:00 UTC (5h after gnome-build-meta nightly). Removes push: main — main is now a release bookmark.

build-aarch64.yml: replaces the Tuesday 04:00 cron with workflow_run from publish.yml. ARM now builds after x86 CAS writes are complete, eliminating CAS write contention.