### PR TITLE
docs: update CI/promotion docs for OCI-native daily promotion

### DIFF
--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -19,7 +19,7 @@ Load this file, identify the failure class, then load only the next skill you ne
 Use this skill when the task mentions:
 - GitHub Actions failures
 - `startup_failure`, `action_required`, missing jobs, or flaky checks
-- `publish.yml`, `build.yml`, `promote-testing-to-main.yml`, `execute-release.yml`
+- `publish.yml`, `build.yml`, `execute-release.yml`
 - boot-check, smoke, testsuite, SBOM, or GHCR publish problems
 - merge queue, promotion PRs, or stable release flow
 
@@ -94,27 +94,27 @@ The rationalizations that have caused real production failures:
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| `build.yml` | `push: main/next/testing` (paths-ignore: docs/workflows/md), `merge_group`, `workflow_dispatch` — NOT `pull_request` | BST build → artifacts into remote CAS. Does NOT push to GHCR. `validate` job runs on `pull_request` only; `build` job runs on everything else. |
-| `publish.yml` | `workflow_run` from `build.yml` (branches: main, next, testing, + their gh-readonly-queue/* paths) | Export from CAS → push `:$sha` → sign/attest → promote to `:testing`/`:next`. No build happens here. |
-| `promote-testing-to-main.yml` | `push: testing`, `schedule: Tue 04:00 UTC`, `workflow_dispatch` | Opens/updates promotion PR from testing into main. |
-| `pr-release-gate.yml` | `pull_request` to `main` | Gates the promotion PR via cosign verify of `:testing`. |
-| `execute-release.yml` | `push: main`, `workflow_dispatch` | `check-trigger` job gates on commit message matching `^ci\(promote\): dakota testing` or `^chore: promote testing to main`. `workflow_dispatch` bypasses the gate. Copies `:testing` → `:stable`/`:latest`, creates GitHub Release. |
-| `cache-warm.yml` | `schedule: Mon/Thu 06:00 UTC`, `workflow_dispatch` | Pre-warms remote CAS. Two parallel jobs (x86_64, aarch64), `continue-on-error: true`. **Not exempt from pre-flight — cancel before any real build.** |
+| `build.yml` | `push: testing/next` (paths-ignore: docs/workflows/md), `merge_group`, `workflow_dispatch`, `schedule: daily 13:00 UTC` — NOT `pull_request` | BST build → artifacts into remote CAS. Does NOT push to GHCR. `validate` job runs on `pull_request` only; `build` job runs on everything else. |
+| `publish.yml` | `workflow_run` from `build.yml` (branches: testing, next, + their gh-readonly-queue/* paths) | Export from CAS → push `:$sha` → sign/attest → promote to `:testing`/`:next`. No build happens here. |
+| `execute-release.yml` | `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch` | SHA freshness check (:testing vs :stable). If different: cosign verify → boot-check → skopeo copy `:testing` → `:stable`/`:latest` → fast-forward main → create GitHub Release. Skips if equal. |
+| ~~`promote-testing-to-main.yml`~~ | DELETED | Was: `push: testing`, schedule Tue 04:00 UTC, manual. |
+| ~~`pr-release-gate.yml`~~ | DELETED | Was: `pull_request` to `main`. |
+| ~~`sync-main-to-testing.yml`~~ | DELETED | Was: `push: main`. |
+| ~~`cache-warm.yml`~~ | DELETED | Was: Mon/Thu 06:00 UTC schedule. Daily 13:00 UTC builds keep CAS warm. |
 
 ## Trigger Behavior
 
-| Job | pull_request | push main/next/testing | merge_group | workflow_dispatch | schedule |
+| Job | pull_request | push testing/next | merge_group | workflow_dispatch | schedule |
 |---|---|---|---|---|---|
 | `validate` | Yes | No | No | No | No |
 | `e2e` | Yes (change-detected) | No | No | Yes | No |
-| `build` | No | Yes (paths-ignore) | Yes | Yes | No |
-| `cache-warm` | No | No | No | Yes | Mon/Thu 06:00 UTC |
-| Push to GHCR? | No | Via publish.yml | Via publish.yml | Via publish.yml | No |
+| `build` | No | Yes (paths-ignore) | Yes | Yes | Daily 13:00 UTC |
+| `execute-release` | No | No | No | Yes | Via workflow_run from publish |
+| Push to GHCR? | No | Via publish.yml | Via publish.yml | Via publish.yml | Via publish.yml |
 
 **push paths-ignore:** `.github/workflows/**`, `docs/**`, `**.md`, `AGENTS.md` — doc/workflow-only pushes do NOT trigger a build. This is intentional; it means a CI-only commit advancing the branch HEAD will leave no build artifact for that SHA.
 
 **Branch → tag mapping** (verified from publish.yml source):
-- `main` or `gh-readonly-queue/main/*` → `:testing`
 - `testing` or `gh-readonly-queue/testing/*` → `:testing`
 - `next` or `gh-readonly-queue/next/*` → `:next`
 
@@ -122,9 +122,11 @@ The rationalizations that have caused real production failures:
 
 **e2e change detection:** `e2e` uses a `should-run` job that diffs the PR branch against its base. It runs when `elements/`, `files/`, `patches/`, `Justfile`, or `project.conf` change; otherwise the `e2e` job is skipped. Skipped satisfies the required status check.
 
-**Merge queue path:** `build` fires on `merge_group` — full OCI build, real CI gate before merge.
+**Merge queue path:** `build` fires on `merge_group` — full OCI build, real CI gate before merge. PRs target `testing`; `next` retains its own merge queue.
 
-**Cache-warm path:** `cache-warm.yml` runs Monday and Thursday at 06:00 UTC and on manual dispatch. Two parallel jobs — `warm-cache` (x86_64) and `warm-cache-aarch64` — run independently with no `needs:` dependency between them. Each has its own concurrency group (`dakota-cache-warm` and `dakota-cache-warm-aarch64`) so they never serialise. Both use `continue-on-error: true` and failures are non-blocking — best-effort. Addresses the cold-start non-determinism documented in [common automation-audit ND1](https://github.com/projectbluefin/common/blob/main/docs/factory/automation-audit/non-deterministic-steps.md).
+**Daily build schedule:** `build.yml` fires at 13:00 UTC daily (after `nightly-next-build` completes). This keeps CAS warm and ensures a fresh `:testing` tag each day even without a code push. `cache-warm.yml` was deleted — the daily build replaces it.
+
+**ARM build:** `build-aarch64.yml` fires via `workflow_run` from `publish.yml` on the `testing` branch. This serializes ARM after x86 CAS writes complete, preventing contention. The previous Tuesday cron trigger was removed.
 
 ## Remote Cache Architecture
 
@@ -151,16 +153,16 @@ Must exit clean before `git commit`. Catches invalid option names, types, and el
 
 ## ⚠️ Branch Base Rule
 
-Always branch from `upstream/main`, never from local `main`:
+Always branch from `upstream/testing` (the development trunk), never from local `testing` or `main`:
 
 ```bash
-git checkout upstream/main -b feature/my-change
-git diff upstream/main...HEAD --stat   # verify before pushing
+git checkout upstream/testing -b feature/my-change
+git diff upstream/testing...HEAD --stat   # verify before pushing
 ```
 
 **Recovery when a branch is already dirty:**
 ```bash
-git rebase --onto upstream/main <last-unwanted-commit-sha> <branch-name>
+git rebase --onto upstream/testing <last-unwanted-commit-sha> <branch-name>
 git push --force-with-lease origin <branch-name>
 ```
 
@@ -220,14 +222,33 @@ PRs created by a workflow using `GITHUB_TOKEN` do NOT fire `pull_request` events
 
 ## Ruleset
 
-Ruleset: `main-review-required-with-renovate-bypass`
+### testing (development trunk)
+
+Ruleset: `testing-merge-queue-no-review`
 
 | Rule | Value |
 |---|---|
-| Required reviews | 1 approving review |
+| Required reviews | 0 (fully automated) |
 | Required status checks | `validate` + `e2e` |
-| Merge queue | ALLGREEN, max_entries_to_build=1, check_response_timeout=120 min |
-| Bypass actors | OrganizationAdmin, Renovate, mergeraptor |
+| Merge queue | enabled (SQUASH, ALLGREEN) |
+| Force push | blocked |
+| Deletion | blocked |
+
+**`testing` is the GitHub default branch and the merge target for all PRs.**
+
+### main (release bookmark)
+
+Ruleset: `main-bookmark-protection`
+
+| Rule | Value |
+|---|---|
+| Required reviews | none |
+| Required status checks | none |
+| Merge queue | none |
+| Non-fast-forward | blocked |
+| Deletion | blocked |
+
+`main` is written only by `execute-release.yml` via fast-forward after each successful stable promotion.
 
 **e2e change detection:** `e2e` only tests PRs touching `elements/`, `files/`, `patches/`, `Justfile`, or `project.conf`. For all other paths (e.g. workflow pin bumps) the `e2e` job is skipped, which satisfies the required check. The `should-run` job uses `git diff` against the PR base — no `paths:` filter on the trigger.
 
@@ -2215,3 +2236,29 @@ fi
 ```
 
 Without the fallback, approved PRs with already-green CI sit permanently unmerged.
+
+### OCI-native daily promotion model — pipeline timing and deleted workflows (2026-06-23)
+
+Dakota migrated from a weekly squash-PR ceremony to a daily OCI-native promotion
+flow (issue 1073). Key operational facts for CI debugging:
+
+**Deleted workflows (do not recreate):** `promote-testing-to-main.yml`, `pr-release-gate.yml`, `sync-main-to-testing.yml`, `cache-warm.yml`.
+
+**Daily BST build windows (serialized for CAS):**
+```
+03:00 UTC  nightly-next-build → next branch (x86, 90-210 min)
+13:00 UTC  build.yml schedule → testing x86 default+nvidia serial (max-parallel:1, 90-390 min)
+~18:00     publish.yml fires → :testing + :testing-nvidia published
+~18:00     build-aarch64.yml fires (workflow_run from publish) → ARM default (~90-210 min)
+~18:00     execute-release.yml fires (workflow_run from publish) → freshness check → promote
+20:00      track-next-junctions → may trigger next junction build
+```
+
+**`cache-warm.yml` is deleted.** The daily 13:00 UTC `build.yml` schedule replaces it. CAS stays warm as long as the daily build runs. If the daily build is absent for >48 hours, expect cold-start non-determinism.
+
+**ARM build trigger changed.** `build-aarch64.yml` now fires via `workflow_run` from `publish.yml` on `testing` — not a Tuesday cron. This ensures ARM starts only after x86 CAS writes complete, preventing write contention that was causing `Cached elements after warm: 0`.
+
+**SHA-based freshness check.** `execute-release.yml` compares the `:testing` image digest to the current `:stable` digest. If they are equal, promotion is skipped (nothing new to ship). If different, the promote path runs: cosign verify → boot-check → skopeo copy → fast-forward main. The SHA used for cosign verify comes from `github.event.workflow_run.head_sha`, not a live `:testing` tag lookup.
+
+**`testing` is now the default GitHub branch.** All PRs target `testing`. The old `main`-targeting PRs pattern is gone. `main` is a bookmark.
+

--- a/docs/skills/release-promotion.md
+++ b/docs/skills/release-promotion.md
@@ -1,6 +1,6 @@
 ---
 name: release-promotion
-description: Dakota publish and promotion flow from testing to main to stable, including promotion PRs, merge queue wiring, release gate behavior, and manual recovery. Use when working on promote-testing-to-main.yml, action_required on promotion PRs, merge queue setup, branch protection, or stable-cut logic.
+description: Dakota publish and promotion flow from testing to stable, including the daily OCI-native execute-release flow, SHA-based freshness check, cosign verify, boot-check gate, and manual recovery. Use when working on execute-release.yml, stable promotion failures, branch bookmark state, or the daily build pipeline.
 metadata:
   context7-sources:
     - /websites/github_en_actions
@@ -11,25 +11,31 @@ metadata:
 
 ## Overview
 
-Promotion from `testing` to `main` is **fully automated** — no human approval required at any stage.
+Promotion from `testing` to `:stable`/`:latest` is **fully automated and daily** — no human approval required at any stage.
 
 ```text
-testing → promotion PR (cosign gate) → merge queue → main → :latest / :stable
+testing (trunk) → build.yml → publish.yml → :testing tag
+                                                  │
+                                         execute-release.yml (workflow_run from publish)
+                                         SHA freshness check → cosign verify → boot-check
+                                                  │
+                                         :stable / :latest + fast-forward main bookmark
 ```
+
+`main` is a release bookmark only. It is fast-forwarded by `execute-release.yml` after each successful promotion. Do not open PRs against `main`.
 
 Do not conflate "publish is healthy" with "stable promotion is healthy".
 
 ## When to Use
 
 Use when the task mentions:
-- `promote-testing-to-main.yml`
-- `pr-release-gate.yml`
 - `execute-release.yml`
-- promotion PRs from `auto/promote-testing-to-main`
-- `action_required` on promotion PR checks
-- merge queue, `use_merge_queue`, `enqueuePullRequest`
-- branch protection or ruleset on `main`
-- stable release, `:latest`, `:stable`, or promotion PR flow
+- stable promotion failures (`:testing` not promoted to `:stable`)
+- SHA-based freshness check or `workflow_run` from `publish.yml`
+- `main-bookmark-protection` ruleset
+- cosign verify in the release path
+- stable release, `:latest`, `:stable`, or daily promotion flow
+- `testing-merge-queue-no-review` ruleset
 
 ## When NOT to Use
 
@@ -43,120 +49,129 @@ Use when the task mentions:
    See Hard Rule #9 in `.github/copilot-instructions.md`. No exceptions.
 2. **Identify the stage.**
    - publish to `:testing`
-   - open/update promotion PR
-   - gate the promotion PR (cosign verify)
-   - execute stable release after merge
-3. **`action_required` on promotion PR checks is expected and normal.**
-   The org blocks `github-actions[bot]`-triggered PR workflow runs. This means
-   `validate` and all other `pull_request` checks show `action_required` on every
-   promotion PR. This is NOT a failure — the merge queue bypasses it.
-4. **The merge queue is the only correct auto-merge path for dakota.**
-   `gh pr merge --auto` (`enablePullRequestAutoMerge`) is blocked by the merge queue
-   ruleset. Only `enqueuePullRequest` (triggered by `use_merge_queue: true`) works.
-5. **Do not add e2e back into the promotion PR path.**
-   Dakota intentionally gates stable at the later human-approved release stage.
-6. **Automatic promotion cadence is Tuesday 04:00 UTC.**
-   That schedule re-evaluates the promotion PR for the weekly stable cut.
-7. **For manual recovery, re-run the failed publish/promote workflow that owns the stage.**
+   - `execute-release.yml` SHA freshness check
+   - cosign verify `:testing`
+   - boot-check gate
+   - skopeo copy `:testing` → `:stable`/`:latest`
+   - fast-forward `main` bookmark
+3. **`execute-release.yml` fires via `workflow_run` from `publish.yml` on the `testing` branch.**
+   It checks whether the SHA published as `:testing` differs from the current `:stable`. If
+   they are equal, promotion is skipped (already up to date). If they differ, cosign verify
+   runs, then boot-check, then the copy and fast-forward.
+4. **`workflow_run` from publish — not a push trigger.** `execute-release.yml` starts
+   automatically after every successful `publish.yml` run on the `testing` branch. No cron
+   or commit-message gate required.
+5. **Do not add a promotion PR or merge queue step.** The squash PR ceremony was eliminated
+   in the OCI-native redesign (issue 1073). Promotion is a direct OCI tag copy + git
+   fast-forward; there is no PR to gate.
+6. **For manual recovery, dispatch `execute-release.yml` directly** after verifying the
+   `:testing` image is fresh and cosign-verified.
 
 ## Promotion Map
 
 ```text
 push to testing (BST-affecting paths)
-  → build.yml (build job)
+  → build.yml (build job, including daily 13:00 UTC schedule)
   → publish.yml (workflow_run)
       → :testing tag published to GHCR
-  → promote-testing-to-main.yml
-      → auto/promote-testing-to-main PR
-           → pr-release-gate.yml (cosign verify :testing)
-           → enqueuePullRequest → merge queue
-               → merge_group event → validate check (bypasses action_required)
-               → merge to main
-                   → execute-release.yml (commit message gate)
-                       → :latest / :stable + GitHub Release
+  → execute-release.yml (workflow_run from publish on testing)
+      → SHA freshness check (:testing SHA vs :stable SHA)
+          → skip if equal (already up to date)
+          → cosign verify :testing
+          → boot-check gate
+          → skopeo copy :testing → :stable / :latest
+          → fast-forward main bookmark
+          → create GitHub Release
 ```
 
 ## Branch Protection and Ruleset State
 
-Ruleset: `main-merge-queue-no-review` (id: 18008292)
+### testing (development trunk)
+
+Ruleset: `testing-merge-queue-no-review`
 
 | Rule | Value |
 |---|---|
 | Required reviews | 0 (fully automated) |
-| Required status checks | `validate` (strict) |
-| Merge queue | SQUASH, ALLGREEN, max_entries_to_build=2, timeout=120 min |
-| Bypass actors | OrganizationAdmin (always), Renovate (PR), mergeraptor (PR) |
-| Non-fast-forward | enforced |
+| Required status checks | `validate` + `e2e` |
+| Merge queue | enabled |
+| Force push | blocked |
+| Deletion | blocked |
+| Default branch | Yes — `testing` is the GitHub default branch |
+
+### main (release bookmark)
+
+Ruleset: `main-bookmark-protection`
+
+| Rule | Value |
+|---|---|
+| Required reviews | none |
+| Required status checks | none |
+| Merge queue | none |
+| Non-fast-forward | blocked |
 | Deletion | blocked |
 
-Classic branch protection on `main`: `required_approving_review_count: 0`.
+`main` accepts only fast-forward commits from `execute-release.yml`. No PRs target `main`.
 
-**Never re-add a required review count to classic protection or the ruleset.** It blocks every automated promotion PR permanently — the GHA bot cannot approve its own PRs.
+**Never add required review counts or merge queue rules to the main bookmark ruleset.** No PRs should ever land on `main` directly.
 
 ## Workflow Configuration
 
-`promote-testing-to-main.yml` must always have `use_merge_queue: true`:
+`execute-release.yml` fires via `workflow_run` from `publish.yml` on the `testing` branch:
 
 ```yaml
-jobs:
-  promote:
-    uses: projectbluefin/actions/.github/workflows/reusable-promote-squash.yml@v1
-    with:
-      variants: '[{"image":"dakota"},{"image":"dakota-nvidia"}]'
-      cosign_identity_regexp: >-
-        ^https://github\.com/projectbluefin/(dakota|actions)/\.github/workflows/
-      run_e2e: false
-      use_merge_queue: true
+on:
+  workflow_run:
+    workflows: ["Publish Bluefin dakota"]
+    branches: [testing]
+    types: [completed]
+  workflow_dispatch: {}
 ```
 
-Do not make `use_merge_queue` conditional on event type. It must always be `true`.
+The first job reads `head_sha` from the triggering `workflow_run` event — never the floating `:testing` tag. This anchors cosign verify and the freshness check to the exact SHA that was just built and published.
+
+```yaml
+steps:
+  - name: Get tested SHA
+    id: tested-sha
+    run: echo "sha=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+```
+
+Do not substitute `github.event.workflow_run.head_sha` with a `skopeo inspect` lookup of `:testing` — that is a TOCTOU race. Use the event SHA.
 
 ## Hard Rules
 
-- `promote-testing-to-main.yml` is a thin caller. Treat caller-level `permissions:` as critical.
-- `pr-release-gate.yml` must not starve the reusable gate token.
-- Promotion PRs do **not** run the full e2e quality gate; that belongs at the weekly stable gate.
-- `use_merge_queue: true` — unconditional, always. Not conditional on `github.event_name`.
-- The merge queue ruleset (`merge_queue` rule type) must exist on `main`. Without it, `enqueuePullRequest` fails silently.
-- `required_approving_review_count` must be 0 in both ruleset and classic branch protection.
-- Weekly automatic stable evaluation runs Tuesday at `0 4 * * 2`.
-- Keep `run_e2e: false` in dakota's promotion caller.
+- `execute-release.yml` must use `head_sha` from the `workflow_run` event, not a floating `:testing` tag lookup.
+- `main` is a bookmark only. No PRs target main. `execute-release.yml` is the only writer.
+- The `main-bookmark-protection` ruleset must block non-fast-forward and deletion. No merge queue, no required checks.
+- The `testing-merge-queue-no-review` ruleset must require `validate` + `e2e` and enable the merge queue.
+- Stable promotion cadence is daily — triggered by `workflow_run` from `publish.yml` after each successful build.
+- The SHA freshness check compares the `:testing` SHA with the current `:stable` SHA. Equal → skip. Different → promote.
+- cosign `--certificate-identity-regexp` must be anchored with `^...$` and restricted to the publishing workflow file.
+- `execute-release.yml` `workflow_dispatch` bypass is allowed for manual recovery only.
 
 ## Manual Recovery Shortcuts
 
 ```bash
-# open promotion PR status
-gh pr list --repo projectbluefin/dakota \
-  --search 'head:auto/promote-testing-to-main state:open'
+# check recent execute-release runs
+gh run list --repo projectbluefin/dakota --workflow 'Execute Release' --limit 10
 
-# recent gate runs
-gh run list --repo projectbluefin/dakota --workflow 'PR Release Gate' --limit 10
+# check recent publish runs (execute-release fires after these)
+gh run list --repo projectbluefin/dakota --workflow 'Publish Bluefin dakota' --limit 10
 
-# recent promote runs
-gh run list --repo projectbluefin/dakota --workflow 'Promote testing to main' --limit 10
+# dispatch execute-release manually (bypasses freshness check — use only for recovery)
+gh workflow run execute-release.yml --repo projectbluefin/dakota --ref testing
 
-# verify ruleset is correct
+# verify ruleset state
 gh api repos/projectbluefin/dakota/rulesets | jq '[.[] | {id, name}]'
-gh api repos/projectbluefin/dakota/rulesets/18008292 | jq '[.rules[].type]'
 
-# verify classic branch protection has 0 reviews
-gh api repos/projectbluefin/dakota/branches/main/protection \
-  | jq '.required_pull_request_reviews.required_approving_review_count'
+# inspect main bookmark (should match last :stable SHA)
+gh api repos/projectbluefin/dakota/branches/main | jq '.commit.sha'
+
+# compare :testing and :stable digests
+skopeo inspect docker://ghcr.io/projectbluefin/dakota:testing | jq '.Digest'
+skopeo inspect docker://ghcr.io/projectbluefin/dakota:stable  | jq '.Digest'
 ```
-
-## Why `use_merge_queue: true` is required (not optional)
-
-The `projectbluefin` org blocks `github-actions[bot]`-triggered PR workflow runs.
-Every workflow fired by the promotion PR (`pull_request` event) gets `action_required`
-conclusion — the run is paused waiting for org approval. This means `validate` is never
-posted as a passing check, so `gh pr merge --auto` waits forever.
-
-The merge queue fires `merge_group` events instead of `pull_request` events. `merge_group`
-is NOT subject to the bot approval policy. `validate` runs clean, passes, and the queue
-merges. This is why `use_merge_queue: true` is unconditional — without it, the promotion
-PR never merges automatically.
-
-Bluefin uses exactly this pattern. Dakota must match it.
 
 ## Ruleset Management
 
@@ -176,74 +191,36 @@ curl -X POST \
   -H "Accept: application/vnd.github+json" \
   -H "Content-Type: application/json" \
   "https://api.github.com/repos/projectbluefin/dakota/rulesets" \
-  -d '{
-    "name": "main-merge-queue-no-review",
-    "target": "branch",
-    "enforcement": "active",
-    "conditions": {"ref_name": {"include": ["refs/heads/main"], "exclude": []}},
-    "bypass_actors": [
-      {"actor_id": null, "actor_type": "OrganizationAdmin", "bypass_mode": "always"},
-      {"actor_id": 2740, "actor_type": "Integration", "bypass_mode": "pull_request"},
-      {"actor_id": 3069633, "actor_type": "Integration", "bypass_mode": "pull_request"}
-    ],
-    "rules": [
-      {"type": "pull_request", "parameters": {
-        "required_approving_review_count": 0,
-        "dismiss_stale_reviews_on_push": true,
-        "require_code_owner_review": false,
-        "require_last_push_approval": false,
-        "required_review_thread_resolution": true,
-        "allowed_merge_methods": ["squash"]
-      }},
-      {"type": "required_status_checks", "parameters": {
-        "strict_required_status_checks_policy": true,
-        "do_not_enforce_on_create": false,
-        "required_status_checks": [{"context": "validate", "integration_id": 15368}]
-      }},
-      {"type": "merge_queue", "parameters": {
-        "merge_method": "SQUASH",
-        "max_entries_to_build": 2,
-        "min_entries_to_merge": 1,
-        "max_entries_to_merge": 5,
-        "min_entries_to_merge_wait_minutes": 5,
-        "grouping_strategy": "ALLGREEN",
-        "check_response_timeout_minutes": 120
-      }},
-      {"type": "non_fast_forward"},
-      {"type": "deletion"}
-    ]
-  }'
+  -d '{ ... }'
 ```
 
 ## Common Rationalizations
 
 | Rationalization | Reality |
 |---|---|
-| "Release gate is red, so publish is broken." | Different layer. Publish may be healthy while promotion is blocked. |
-| "Let's just add more checks to the promotion PR." | That slows the queue and duplicates the real stable gate. |
-| "`action_required` means rerun the same gate." | It means the org is blocking bot PR runs. Only the merge queue bypasses this. |
-| "`use_merge_queue` only needs to be true for schedule/dispatch." | Wrong. It must always be true. The bot approval block applies to push events too. |
-| "Adding a required review adds safety." | It permanently blocks every automated promotion PR. |
+| "execute-release failed, so publish is broken." | Different layer. Publish may be healthy while promotion is blocked. |
+| "Let's use the floating :testing tag as the anchor." | TOCTOU race. Always use `head_sha` from the `workflow_run` event. |
+| "main has diverged — let's open a PR to fix it." | main is a bookmark. Only `execute-release.yml` writes to it via fast-forward. |
+| "The freshness check is too conservative." | Equal SHAs mean `:stable` is already current. Promotion is not needed. |
 | "This reusable caller only needs job-level permissions." | Wrong often enough to deserve a scar. Check top-level caller permissions first. |
 
 ## Red Flags
 
-- `use_merge_queue` is conditional on `github.event_name`
-- `required_approving_review_count` is greater than 0 in ruleset or classic protection
-- The ruleset is missing the `merge_queue` rule type
-- editing stable-promotion logic while the real failure is earlier publish plumbing
-- adding full e2e to the promotion PR path
-- rerunning `action_required` workflow runs — they cannot be rerun, they are bot-blocked
+- `execute-release.yml` using `skopeo inspect :testing` to get the SHA instead of `github.event.workflow_run.head_sha`
+- Any PR targeting `main` (main is a bookmark, not a development branch)
+- Adding a merge queue or required checks to the `main-bookmark-protection` ruleset
+- `testing-merge-queue-no-review` ruleset missing `validate` or `e2e` required checks
+- Editing stable-promotion logic while the real failure is earlier in publish plumbing
 
 ## Verification
 
-- [ ] `use_merge_queue: true` unconditionally in `promote-testing-to-main.yml`
-- [ ] Ruleset `main-merge-queue-no-review` exists and has `merge_queue` rule
-- [ ] Classic branch protection `required_approving_review_count` is 0
-- [ ] `run_e2e: false` unchanged in the caller
-- [ ] Promotion PR enqueued and merged without any human interaction
-- [ ] Weekly cadence remains Tuesday `04:00 UTC`
-- [ ] You did not collapse publish, promotion, and stable release into one mental model
+- [ ] `execute-release.yml` trigger is `workflow_run` from `publish.yml` on `testing`
+- [ ] `head_sha` from `workflow_run` event anchors cosign verify and the freshness check
+- [ ] `main-bookmark-protection` ruleset: non_fast_forward + deletion blocked, no merge queue
+- [ ] `testing-merge-queue-no-review` ruleset: `validate` + `e2e` required, merge queue enabled
+- [ ] No PRs exist targeting `main`
+- [ ] `testing` is the GitHub default branch
+- [ ] Stable promoted without any human interaction after a successful publish
 
 ## Lessons Learned
 
@@ -261,7 +238,7 @@ This is not a pipeline failure. The resolution is automatic:
 ### One BST build at a time — cancel everything before starting a new build
 
 Before triggering or landing any change that starts a new BST build, cancel ALL
-in-progress BST jobs — including cache-warm runs.
+in-progress BST jobs.
 
 ```bash
 gh run list --repo projectbluefin/dakota --json databaseId,status,name \
@@ -269,28 +246,30 @@ gh run list --repo projectbluefin/dakota --json databaseId,status,name \
 gh run cancel <run-id> --repo projectbluefin/dakota
 ```
 
-Cache-warm runs are NOT exempt. Cancel everything, let one build finish, then re-trigger warm separately.
+Cancel everything, let one build finish, then re-trigger if needed.
 
-### startup_failure on promote dispatch — statuses:write missing in caller (2026-06-23)
+### OCI-native daily promotion model (2026-06-23)
 
-**Symptom:** Every `promote-testing-to-main.yml` dispatch returns `startup_failure` before any job runs. No log output available.
+Dakota migrated from a weekly squash-PR ceremony to a daily OCI-native promotion
+flow (issue 1073). The key differences:
 
-**Root cause:** `projectbluefin/actions` updated `reusable-promote-squash.yml@v1` to post a `validate=success` commit status on the squash branch HEAD (so the merge queue accepts the PR in the same run). This requires `statuses: write` in the promote job.
-
-Caller-level `permissions:` sets the **ceiling** for all called workflow jobs. If `statuses: write` is not in the caller's top-level block, GitHub rejects the reusable workflow at startup — no job is queued, no log is written.
-
-**Fix:** Add `statuses: write` to `promote-testing-to-main.yml` permissions:
-
-```yaml
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  packages: read
-  actions: read
-  statuses: write       # post validate status on squash branch head
-```
-
-**Detection:** When `projectbluefin/actions@v1` adds a new permission to a reusable job, check whether the dakota caller's `permissions:` block covers it. Missing permissions produce `startup_failure` with no log output — not a runtime error.
-
-**Related:** See also `ci-tooling.md` note about `workflows: write` being an invalid actionlint scope (use a GitHub App token instead for workflow file updates).
+- **Deleted workflows:** `promote-testing-to-main.yml`, `pr-release-gate.yml`,
+  `sync-main-to-testing.yml`, `cache-warm.yml`.
+- **`execute-release.yml`** now fires via `workflow_run` from `publish.yml` on the
+  `testing` branch — no cron, no commit-message gate.
+- **SHA anchor:** `head_sha` from the `workflow_run` event is the source of truth for
+  cosign verify and the freshness check. Never use `skopeo inspect :testing` as the
+  anchor — that is a TOCTOU race.
+- **Freshness check:** compare the `:testing` digest to the `:stable` digest. Equal →
+  skip promotion (already up to date). Different → promote.
+- **`main` is a bookmark.** Fast-forwarded by `execute-release.yml` only. No PRs
+  target `main`. The `main-bookmark-protection` ruleset enforces this.
+- **`testing` is the development trunk.** All contributor, Renovate, and BST source
+  bump PRs target `testing`. The `testing-merge-queue-no-review` ruleset requires
+  `validate` + `e2e` and enables the merge queue.
+- **Daily build schedule:** `build.yml` has a `schedule: '0 13 * * *'` trigger that
+  fires at 13:00 UTC daily, keeping CAS warm and ensuring a fresh `:testing` each
+  day even without a code push.
+- **ARM trigger change:** `build-aarch64.yml` now fires via `workflow_run` from
+  `publish.yml` — not a Tuesday cron. This serializes ARM after x86 CAS writes
+  complete, preventing CAS contention.

--- a/docs/skills/workflow-map.md
+++ b/docs/skills/workflow-map.md
@@ -46,7 +46,7 @@ PR touching image paths
   ├─ validate (PR syntax / graph checks)
   └─ e2e (testsuite wrapper; change-detected)
 
-Merge queue → main or next
+Merge queue → testing or next
   └─ build.yml
        └─ publish.yml (workflow_run from build)
             ├─ publish-image
@@ -54,62 +54,70 @@ Merge queue → main or next
             ├─ publish-sbom [parallel]
             └─ promote to :testing / :next / :btw
 
-Successful publish.yml
-  └─ publish-smoke.yml
-       └─ smoke suite [observational only]
+Daily 13:00 UTC / push: testing (BST-affecting paths) / manual
+  └─ build.yml (schedule or push trigger)
+       └─ publish.yml (workflow_run from build)
+            └─ promote to :testing
 
-push: testing / weekly Tuesday 04:00 UTC / manual
-  └─ promote-testing-to-main.yml
-       └─ opens or updates promotion PR
-            └─ pr-release-gate.yml on that PR
+Successful publish.yml on testing
+  ├─ publish-smoke.yml
+  │    └─ smoke suite [observational only]
+  └─ execute-release.yml (workflow_run from publish, testing branch)
+       ├─ SHA freshness check (:testing vs :stable digest)
+       │    └─ skip if equal (already up to date)
+       ├─ cosign verify :testing
+       ├─ boot-check gate
+       ├─ skopeo copy :testing → :stable / :latest
+       ├─ fast-forward main bookmark
+       └─ create GitHub Release
 
-merge promotion PR to main
-  └─ execute-release.yml
-       ├─ stable tag copy + release notes
-       └─ create-multiarch-stable [continue-on-error, ARM never blocks]
-
-push: testing/main (BST paths) / Tuesday 04:00 UTC / manual   ← PARALLEL, DECOUPLED
-  └─ build-aarch64.yml [continue-on-error throughout]
+Successful publish.yml on testing   ← PARALLEL, DECOUPLED
+  └─ build-aarch64.yml (workflow_run from publish on testing)
        └─ :aarch64 and :aarch64-<sha> published to GHCR
-          (no effect on x86_64 builds, publish, promote, or release)
+          (no effect on x86_64 builds, publish, or release)
 ```
+
+**Deleted workflows (OCI-native redesign, 2026-06-23):** `promote-testing-to-main.yml`, `pr-release-gate.yml`, `sync-main-to-testing.yml`, `cache-warm.yml`.
 
 ## Workflow Ownership Table
 
 | Workflow | Owns | Normal trigger |
 |---|---|---|
-| `.github/workflows/build.yml` | BST build into remote CAS | `push: main/next/testing` (paths-ignore: docs, workflows, md, `files/scripts/**`), `merge_group`, `workflow_dispatch`. `validate` job runs on `pull_request` only; `build` job skips `pull_request`. |
-| `.github/workflows/build-aarch64.yml` | aarch64 OCI build + GHCR push | `push: main/testing` (same paths-ignore as build.yml including `files/scripts/**`), `schedule: Tuesday 04:00 UTC`, `workflow_dispatch`. Fully decoupled — never in `needs:` of publish/promote/release. |
+| `.github/workflows/build.yml` | BST build into remote CAS | `push: testing/next` (paths-ignore: docs, workflows, md, `files/scripts/**`), `merge_group`, `workflow_dispatch`, `schedule: daily 13:00 UTC`. `validate` job runs on `pull_request` only; `build` job skips `pull_request`. |
+| `.github/workflows/build-aarch64.yml` | aarch64 OCI build + GHCR push | `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch`. Fully decoupled — never in `needs:` of publish/promote/release. |
 | `.github/workflows/publish.yml` | export, sign, boot-check, promote tags | `workflow_run` from build |
 | `.github/workflows/publish-smoke.yml` | observational smoke only | `workflow_run` from publish |
 | `.github/workflows/e2e.yml` | PR-facing testsuite check | `pull_request` |
-| `.github/workflows/promote-testing-to-main.yml` | open/update promotion PR | `push: testing`, schedule, manual |
-| `.github/workflows/pr-release-gate.yml` | promotion PR gate | `pull_request` to `main` |
-| `.github/workflows/execute-release.yml` | stable release execution | `push: main`, `workflow_dispatch`. `check-trigger` job gates on commit message matching `^ci\(promote\): dakota testing` or `^chore: promote testing to main`; `workflow_dispatch` bypasses the gate. |
+| `.github/workflows/execute-release.yml` | SHA freshness check → cosign verify → boot-check → stable release | `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch`. Skips if `:testing` digest equals `:stable` digest. |
 | `.github/workflows/sync-next-from-main.yml` | merge main into next (preserve junction refs) | `push: main`, `workflow_dispatch` |
+| ~~`promote-testing-to-main.yml`~~ | DELETED | Was: `push: testing`, schedule, manual |
+| ~~`pr-release-gate.yml`~~ | DELETED | Was: `pull_request` to `main` |
+| ~~`sync-main-to-testing.yml`~~ | DELETED | Was: `push: main` |
+| ~~`cache-warm.yml`~~ | DELETED | Was: Mon/Thu 06:00 UTC schedule |
 
 ## Branch / Tag Map
 
 | Branch | Trigger | Published tag(s) | Notes |
 |---|---|---|---|
-| `testing` | `push` (BST-affecting paths only) | `:testing` | **Primary `:testing` publish path.** Every BST-affecting push builds → publishes → promotes. Doc/workflow-only pushes are ignored (paths-ignore). |
-| `main` | merge of promotion PR | `:latest`, `:stable` | Only via `execute-release.yml` and only when commit message starts with `ci: promote testing images to stable`. Normal merges do NOT produce a new tag. |
+| `testing` | `push` (BST-affecting paths only) or `schedule: 13:00 UTC` | `:testing` | **Development trunk. Primary `:testing` publish path.** Every BST-affecting push builds → publishes → promotes. Doc/workflow-only pushes are ignored (paths-ignore). |
+| `main` | fast-forward from `execute-release.yml` | `:latest`, `:stable` | **Release bookmark only.** Only `execute-release.yml` writes here after a successful SHA freshness check + cosign verify + boot-check. No PRs target `main`. |
 | `next` | `push` or `sync-next-from-main` dispatch | `:next`, `:btw` | Rolling GNOME master; never stable. No PR requirement on branch protection. |
-| `gh-readonly-queue/main/*` | merge-queue | (build only, no tag) | Gate before merge to `main`. |
+| `gh-readonly-queue/testing/*` | merge-queue | (build only, no tag) | Gate before merge to `testing`. |
 | `gh-readonly-queue/next/*` | merge-queue | (build only, no tag) | Gate before merge to `next`. |
-| `testing` or `main` (BST paths) | `push`, Tuesday schedule, dispatch | `:aarch64`, `:aarch64-<sha>` | Published by `build-aarch64.yml`. Completely decoupled from x86_64 flow. Never blocks release. |
+| `testing` (BST paths) | `workflow_run` from publish | `:aarch64`, `:aarch64-<sha>` | Published by `build-aarch64.yml`. Completely decoupled from x86_64 flow. Never blocks release. |
 
 **What testing does (not just PRs):**
 ```
-push to testing (BST-affecting)
+push to testing (BST-affecting) or daily 13:00 UTC schedule
   → build.yml (build job)
   → publish.yml (workflow_run)
       → :testing tag published to GHCR
-  → promote-testing-to-main.yml
-      → opens/updates auto/promote-testing-to-main PR
-           → pr-release-gate.yml gates it
-           → auto-merge → push to main
-               → execute-release.yml → :stable / :latest
+  → execute-release.yml (workflow_run from publish on testing)
+      → SHA freshness check → cosign verify → boot-check
+      → skopeo copy :testing → :stable / :latest
+      → fast-forward main bookmark
+  → build-aarch64.yml (workflow_run from publish on testing)
+      → :aarch64 / :aarch64-<sha> published (decoupled, never blocks release)
 ```
 
 ## Common Rationalizations

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -160,49 +160,52 @@ Copy `files/hive/hive-project.yaml.example` to `/etc/hive/hive-project.yaml` and
 
 ## Image stream and branch model
 
-Dakota publishes three streams from the `main` branch:
+Dakota uses trunk-based development. `testing` is the development trunk; `main` is a release bookmark fast-forwarded by `execute-release.yml` after each daily promotion.
 
 ```
-main (source of truth)
+testing (development trunk — all PRs land here)
   │
-  └─► build.yml (nightly + merge_group + workflow_dispatch)
+  └─► build.yml (daily 13:00 UTC + merge_group + workflow_dispatch)
           │
           └─► publish.yml (workflow_run on build success)
                   │
                   ├─► :sha     — immutable per-build tag
-                  └─► :testing — promoted after e2e smoke passes
+                  └─► :testing — published after boot-check passes
                                        │
-                              weekly-testing-promotion.yml
-                              (Sunday 06:00 UTC, production environment approval)
+                              execute-release.yml
+                              (workflow_run from publish, daily if :testing != :stable)
+                              SHA-based freshness check → cosign verify → boot-check gate
                                        │
-                                       ├─► :latest  (+ fast-forwards latest branch)
-                                       └─► :stable  (+ fast-forwards stable branch)
+                                       ├─► :latest  (+ fast-forwards main bookmark)
+                                       └─► :stable  (+ fast-forwards main bookmark)
 ```
 
 | Stream | Tag | Cadence | Gate |
 |---|---|---|---|
-| Development | `:sha` | Every merge to `main` | None |
-| Testing | `:testing` | Nightly | e2e smoke |
-| Latest | `:latest` | Weekly (Sunday) | production environment approval |
-| Stable | `:stable` | Weekly (Sunday) | Same as `:latest` |
+| Development | `:sha` | Every merge to `testing` | None |
+| Testing | `:testing` | Daily (13:00 UTC build) | boot-check |
+| Latest | `:latest` | Daily (if :testing != :stable) | SHA freshness check + cosign verify + boot-check |
+| Stable | `:stable` | Daily (if :testing != :stable) | Same as `:latest` |
 
-**All code merges to `main`.** The `:testing` Docker tag is the published nightly result built from `main`. The `testing`, `latest`, and `stable` git branches are bookmarks fast-forwarded by the promotion workflows — they are not development branches.
+**All PRs target `testing`.** This includes contributor PRs, Renovate PRs, and BST source bump PRs. The `main` git branch is a release bookmark only — it is fast-forwarded by `execute-release.yml` after each successful promotion and must not be used as a PR base.
 
-**Branch protection is only on `main`.** Required status checks: `validate` + `e2e`.
+**Branch protection:** `testing` has the `testing-merge-queue-no-review` ruleset (required status checks: `validate` + `e2e`, merge queue). `main` has the `main-bookmark-protection` ruleset (deletion + non_fast_forward blocked; no merge queue, no required checks).
+
+**Deleted workflows (OCI-native redesign, 2026-06-23):** `promote-testing-to-main.yml`, `pr-release-gate.yml`, `sync-main-to-testing.yml`, `cache-warm.yml`.
 
 ### Branch flow for contributors
 
 ```bash
-# Branch from upstream/main (never fork's local main)
-git checkout upstream/main -b feat/my-change
+# Branch from upstream/testing (the development trunk)
+git checkout upstream/testing -b feat/my-change
 
 # Work, validate, commit
 just validate
 git commit -m "feat(bluefin): ..."
 
-# Push and open PR against main
+# Push and open PR against testing
 git push upstream feat/my-change
-gh pr create --repo projectbluefin/dakota --base main
+gh pr create --repo projectbluefin/dakota --base testing
 ```
 
 


### PR DESCRIPTION
Updates four documentation files to reflect the trunk-based development redesign (issue 1073). Documents the new daily build pipeline, deleted workflows, SHA-based freshness check, and ARM trigger change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect a redesigned CI/CD branching model: `testing` is now the primary development branch, while `main` is designated as a release bookmark.
  * Documented automated daily release promotion with no manual PR ceremony required.
  * Updated contributor guidance to base feature branches on `testing` instead of `main`.
  * Clarified updated workflow routing for publishing and release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->