### PR TITLE
fix(release): harden OCI-native promotion (supply chain + ARM signing + post-release cleanup + rollback)

### DIFF
--- a/.github/workflows/build-aarch64.yml
+++ b/.github/workflows/build-aarch64.yml
@@ -62,9 +62,12 @@ jobs:
     outputs:
       pushed: ${{ steps.push.outputs.pushed }}
       sha: ${{ steps.context.outputs.sha }}
+      aarch64_digest: ${{ steps.push.outputs.digest }}
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Resolve build context
@@ -148,18 +151,11 @@ jobs:
         env:
           GH_ACTOR: ${{ github.actor }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "$GH_TOKEN" | sudo podman login ghcr.io --username "$GH_ACTOR" --password-stdin
-
-      - name: Tag image for GHCR
-        if: >-
-          github.event_name == 'push' ||
-          github.event_name == 'workflow_run' ||
-          github.event_name == 'workflow_dispatch'
         run: |
-          sudo podman tag "localhost/${{ steps.export.outputs.image_ref }}" \
-            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:aarch64"
-          sudo podman tag "localhost/${{ steps.export.outputs.image_ref }}" \
-            "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:aarch64-${{ github.sha }}"
+          echo "$GH_TOKEN" | sudo podman login ghcr.io --username "$GH_ACTOR" --password-stdin
+          mkdir -p ~/.docker
+          echo "$GH_TOKEN" | podman login ghcr.io --username "$GH_ACTOR" --password-stdin \
+            --compat-auth-file ~/.docker/config.json
 
       - name: Push to GHCR
         id: push
@@ -167,16 +163,57 @@ jobs:
           github.event_name == 'push' ||
           github.event_name == 'workflow_run' ||
           github.event_name == 'workflow_dispatch'
+        env:
+          BUILD_SHA: ${{ github.sha }}
         run: |
-          for tag in aarch64 "aarch64-${{ github.sha }}"; do
-            PUSH_OK=false
-            for attempt in 1 2 3; do
-              # zstd: plain (not chunked) — matches x86_64 push convention
-              sudo podman push --compression-format=zstd \
-                "${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${tag}" && { PUSH_OK=true; break; }
-              echo "Push attempt ${attempt} failed for tag ${tag}, retrying in 5s..."
-              sleep 5
-            done
-            $PUSH_OK || { echo "WARNING: all push attempts failed for :${tag} — non-blocking"; }
+          IMAGE="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}"
+          LOCAL="localhost/${{ steps.export.outputs.image_ref }}"
+
+          # Tag the immutable SHA-pinned ref first; push it with --digestfile so
+          # the captured digest matches exactly what was uploaded. The floating
+          # :aarch64 tag is pushed afterwards and points at the same manifest.
+          sudo podman tag "${LOCAL}" "${IMAGE}:aarch64-${BUILD_SHA}"
+          sudo podman tag "${LOCAL}" "${IMAGE}:aarch64"
+
+          PUSH_OK=false
+          for attempt in 1 2 3; do
+            sudo podman push --compression-format=zstd \
+              --digestfile "${RUNNER_TEMP}/digest.txt" \
+              "${IMAGE}:aarch64-${BUILD_SHA}" && { PUSH_OK=true; break; }
+            echo "Push attempt ${attempt} failed for :aarch64-${BUILD_SHA}, retrying in 5s..."
+            [ "$attempt" -lt 3 ] && sleep 5
           done
+          if [ "$PUSH_OK" != "true" ]; then
+            echo "ERROR: all push attempts failed for :aarch64-${BUILD_SHA} — aarch64 build not signed/published"
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          DIGEST="$(cat "${RUNNER_TEMP}/digest.txt")"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+          # Floating :aarch64 — best-effort, never blocks signing of the pinned tag.
+          for attempt in 1 2 3; do
+            sudo podman push --compression-format=zstd \
+              "${IMAGE}:aarch64" && break
+            echo "Push attempt ${attempt} failed for :aarch64, retrying in 5s..."
+            [ "$attempt" -lt 3 ] && sleep 5
+          done
+
           echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install oras
+        if: steps.push.outputs.pushed == 'true'
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+
+      - name: Sign image and create attestation
+        # Mirrors publish.yml exactly. generate-sbom: false — dakota uses BST-native
+        # provenance (just sbom) handled separately; Syft post-build scan is less
+        # accurate for BST builds.
+        if: steps.push.outputs.pushed == 'true'
+        uses: projectbluefin/actions/bootc-build/sign-and-publish@v1
+        with:
+          image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          digest: ${{ steps.push.outputs.digest }}
+          generate-sbom: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,9 @@ on:
   schedule:
     - cron: '0 13 * * *'
   pull_request:
-    branches: [testing, next, main]
+    branches: [testing, next]
   merge_group:
-    branches: [testing, next, main]
+    branches: [testing, next]
   push:
     # main is a release bookmark — pushes to main after promotion should not
     # trigger a full BST build. Only testing (trunk) and next (rolling) build.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,21 +36,11 @@ env:
   IMAGE_NAME: dakota
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
-# Concurrency: one BST build per branch at a time.
-# push/main and merge_group/main share group "bst-build-main" so they
-# never run simultaneously and starve the remote CAS.
-# cancel-in-progress: true for push/dispatch so stale builds are dropped
-# when a newer commit arrives. merge_group runs queue (false) so in-flight
-# gate checks are not cancelled by a concurrent push.
-concurrency:
-  group: >-
-    bst-build-${{
-      startsWith(github.ref_name, 'gh-readonly-queue/main') && 'main' ||
-      startsWith(github.ref_name, 'gh-readonly-queue/testing') && 'testing' ||
-      startsWith(github.ref_name, 'gh-readonly-queue/next') && 'next' ||
-      github.ref_name
-    }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+# Concurrency: enforced at the `build` job level (see below) using the
+# shared global group `dakota-bst-build-global`. The PR-only `validate`
+# job runs `bst show` (metadata only, no CAS traffic) and has its own
+# per-PR concurrency block — it intentionally does NOT join the global
+# group so PR validation is not blocked by long-running trunk builds.
 
 jobs:
   # ── Default-branch precondition ──────────────────────────────────────────
@@ -138,6 +128,16 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 360
+    # Global BST concurrency: only one BuildStream build may run across
+    # ALL branches and workflows. The remote CAS at cache.projectbluefin.io
+    # is rate-limited and supports a single build at a time — concurrent
+    # builds tank cache hit rate and risk 6-hour timeouts. The same group
+    # name is used by nightly-next-build.yml so cross-workflow dispatch
+    # also serializes here. cancel-in-progress: false so an in-flight
+    # build on one branch is never killed by a push to another branch.
+    concurrency:
+      group: dakota-bst-build-global
+      cancel-in-progress: false
     # Variants build serially — one BST build at a time per the hard rule.
     # Shared runners and CAS write bandwidth cannot sustain concurrent builds.
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,26 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
+  # ── Default-branch precondition ──────────────────────────────────────────
+  # Scheduled triggers always run on the repository default branch. If the
+  # default branch is not 'testing', the daily build silently targets the
+  # wrong ref. Fail fast and loudly when that invariant is violated.
+  verify-default-branch:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Verify repository default branch is 'testing'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          db=$(gh api "repos/${GITHUB_REPOSITORY}" --jq .default_branch)
+          if [ "$db" != "testing" ]; then
+            echo "::error::default branch is '$db', expected 'testing'. Daily schedule will silently target wrong branch. Fix repo settings."
+            exit 1
+          fi
+
   # ── Fast PR validation ───────────────────────────────────────────────────
   # Fires only on pull_request. Runs bst show on the full element graph for
   # both variants. Zero remote-execution — does not touch cache.projectbluefin.io.
@@ -114,6 +134,7 @@ jobs:
   # PRs are validated by the validate job above; the full build is the
   # merge-queue gate. This keeps cache.projectbluefin.io free from PR traffic.
   build:
+    needs: [verify-default-branch]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 360

--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -68,8 +68,10 @@ jobs:
             fi
           fi
 
-          # Compare :testing and :stable digests
-          TESTING_DIGEST=$(skopeo inspect --no-tags "docker://ghcr.io/projectbluefin/dakota:testing" \
+          # Compare the SHA-tagged build digest against :stable. Using the SHA tag
+          # (not floating :testing) guarantees the decision input matches the action
+          # input — the same image we will promote is the one we evaluated.
+          TESTING_DIGEST=$(skopeo inspect --no-tags "docker://ghcr.io/projectbluefin/dakota:${BUILD_SHA}" \
             | jq -r '.Digest')
 
           STABLE_DIGEST=""
@@ -80,11 +82,11 @@ jobs:
 
           if [ -n "$STABLE_DIGEST" ] && [ "$TESTING_DIGEST" = "$STABLE_DIGEST" ]; then
             echo "should-release=false" >> "$GITHUB_OUTPUT"
-            echo ":testing and :stable are identical ($TESTING_DIGEST) — nothing to promote"
+            echo ":${BUILD_SHA} and :stable are identical ($TESTING_DIGEST) — nothing to promote"
           else
             echo "should-release=true" >> "$GITHUB_OUTPUT"
             echo "build_sha=${BUILD_SHA}" >> "$GITHUB_OUTPUT"
-            echo ":testing ($TESTING_DIGEST) differs from :stable (${STABLE_DIGEST:-not found}) — promotion needed"
+            echo ":${BUILD_SHA} ($TESTING_DIGEST) differs from :stable (${STABLE_DIGEST:-not found}) — promotion needed"
           fi
 
   execute:
@@ -105,12 +107,13 @@ jobs:
           {"image":"dakota","source_tag":"${{ needs.freshness-check.outputs.build_sha }}","target_tag":"stable"},
           {"image":"dakota-nvidia","source_tag":"${{ needs.freshness-check.outputs.build_sha }}","target_tag":"stable"}
         ]
-      cosign_identity_regexp: ^https://github\.com/projectbluefin/(dakota|actions)/\.github/workflows/
+      cosign_identity_regexp: ^https://github\.com/projectbluefin/dakota/\.github/workflows/publish\.yml@refs/heads/(testing|gh-readonly-queue/testing/.+)$
       fast_forward_branch: main
+      fast_forward_sha: ${{ needs.freshness-check.outputs.build_sha }}
     secrets: inherit
 
   release-notes:
-    needs: [execute]
+    needs: [freshness-check, execute]
     if: always() && needs.execute.result == 'success'
     permissions:
       actions: read
@@ -125,13 +128,17 @@ jobs:
       # Inline syft with rpm cataloger returns 0 packages on BST images.
       build_workflow: publish.yml
       build_branch: testing
+      # Pin SBOM lookup to the specific publish run that produced the promoted
+      # image — eliminates drift between "latest publish on testing" and the
+      # exact workflow_run.id whose digests we just promoted.
+      build_run_id: ${{ github.event.workflow_run.id }}
       sbom_artifact: sbom-dakota
       checkout_ref: testing
       project_name: Dakota
       badge_label: Stable
       accent_color: "#0ea5e9"
       cert_identity_regexp: >-
-        ^https://github\.com/projectbluefin/(dakota|actions)/\.github/workflows/
+        ^https://github\.com/projectbluefin/dakota/\.github/workflows/publish\.yml@refs/heads/(testing|gh-readonly-queue/testing/.+)$
       notable_packages: >-
         [
           {"sbom_name": "linux",       "label": "Kernel"},
@@ -185,16 +192,28 @@ jobs:
           gh release edit "$TAG" --repo "${{ github.repository }}" --notes-file /tmp/updated-body.md
 
   # ── Multi-arch manifest (aarch64) ────────────────────────────────────────
-  # Non-gating: creates a multi-arch :stable manifest if :aarch64 exists in
-  # GHCR. Skips silently if aarch64 is absent — x86_64 stable is already live.
-  # ARM never gates this release. This is purely additive.
+  # Non-gating: creates a multi-arch :stable manifest if a SHA-pinned aarch64
+  # image exists in GHCR for this build. Skips silently if aarch64 is absent —
+  # x86_64 stable is already live. ARM never gates this release.
+  #
+  # Supply-chain note: both the x86_64 :stable image and the SHA-pinned
+  # aarch64 image are cosign-verified against the anchored publish.yml
+  # identity BEFORE the manifest is constructed. The aarch64 component is
+  # pinned to the digest reported by skopeo for `:aarch64-${BUILD_SHA}` so
+  # the manifest publishes exactly what was verified, not whatever the
+  # floating `:aarch64` tag happens to point at.
   create-multiarch-stable:
-    needs: [execute]
+    needs: [freshness-check, execute]
     if: always() && needs.execute.result == 'success'
     runs-on: ubuntu-latest
-    continue-on-error: true
     permissions:
+      contents: read
+      id-token: write
       packages: write
+    env:
+      BUILD_SHA: ${{ needs.freshness-check.outputs.build_sha }}
+      COSIGN_IDENTITY_REGEXP: ^https://github\.com/projectbluefin/dakota/\.github/workflows/publish\.yml@refs/heads/(testing|gh-readonly-queue/testing/.+)$
+      COSIGN_ISSUER: https://token.actions.githubusercontent.com
     steps:
       - name: Login to GHCR
         env:
@@ -202,29 +221,78 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: echo "$GH_TOKEN" | podman login ghcr.io --username "$GH_ACTOR" --password-stdin
 
-      - name: Check whether :aarch64 exists
+      - name: Check whether SHA-pinned :aarch64 exists
         id: check-aarch64
         run: |
-          if skopeo inspect --no-tags "docker://ghcr.io/projectbluefin/dakota:aarch64" \
+          set -euo pipefail
+          if skopeo inspect --no-tags "docker://ghcr.io/projectbluefin/dakota:aarch64-${BUILD_SHA}" \
               > /dev/null 2>&1; then
             echo "present=true" >> "$GITHUB_OUTPUT"
-            echo "aarch64 image found — will create multi-arch manifest"
+            echo "aarch64-${BUILD_SHA} image found — will create multi-arch manifest"
           else
             echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "aarch64 image not found — skipping multi-arch manifest"
+            echo "aarch64-${BUILD_SHA} image not found — skipping multi-arch manifest"
           fi
 
-      - name: Create multi-arch :stable manifest
+      - name: Install cosign
         if: steps.check-aarch64.outputs.present == 'true'
         run: |
           set -euo pipefail
-          # Create a new manifest list combining x86_64 :stable and :aarch64
+          curl -fsSL https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64 \
+            -o "$RUNNER_TEMP/cosign"
+          sudo install -m 0755 "$RUNNER_TEMP/cosign" /usr/local/bin/cosign
+          cosign version
+
+      - name: Resolve SHA-pinned aarch64 digest
+        if: steps.check-aarch64.outputs.present == 'true'
+        id: arm-digest
+        run: |
+          set -euo pipefail
+          AARCH64_DIGEST=$(skopeo inspect --no-tags \
+            "docker://ghcr.io/projectbluefin/dakota:aarch64-${BUILD_SHA}" \
+            | jq -r '.Digest')
+          if [ -z "$AARCH64_DIGEST" ] || [ "$AARCH64_DIGEST" = "null" ]; then
+            echo "::error::Failed to resolve digest for aarch64-${BUILD_SHA}"
+            exit 1
+          fi
+          echo "digest=${AARCH64_DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Resolved aarch64-${BUILD_SHA} → ${AARCH64_DIGEST}"
+
+      - name: Verify cosign signature on :stable (x86_64)
+        if: steps.check-aarch64.outputs.present == 'true'
+        run: |
+          set -euo pipefail
+          cosign verify \
+            --certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP" \
+            --certificate-oidc-issuer "$COSIGN_ISSUER" \
+            "ghcr.io/projectbluefin/dakota:stable"
+
+      - name: Verify cosign signature on SHA-pinned aarch64 by digest
+        if: steps.check-aarch64.outputs.present == 'true'
+        env:
+          AARCH64_DIGEST: ${{ steps.arm-digest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign verify \
+            --certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP" \
+            --certificate-oidc-issuer "$COSIGN_ISSUER" \
+            "ghcr.io/projectbluefin/dakota@${AARCH64_DIGEST}"
+
+      - name: Create multi-arch :stable manifest
+        if: steps.check-aarch64.outputs.present == 'true'
+        env:
+          AARCH64_DIGEST: ${{ steps.arm-digest.outputs.digest }}
+        run: |
+          set -euo pipefail
+          # Compose the manifest list from the just-verified images. The
+          # aarch64 component is referenced by its content digest (not the
+          # floating :aarch64 tag) so we publish exactly what cosign signed.
           podman manifest create \
             "ghcr.io/projectbluefin/dakota:stable-multiarch" \
             "ghcr.io/projectbluefin/dakota:stable" \
-            "ghcr.io/projectbluefin/dakota:aarch64"
+            "ghcr.io/projectbluefin/dakota@${AARCH64_DIGEST}"
           podman manifest push --all \
             "ghcr.io/projectbluefin/dakota:stable-multiarch" \
             "docker://ghcr.io/projectbluefin/dakota:stable-multiarch"
-          echo "Multi-arch stable manifest pushed as :stable-multiarch"
+          echo "Multi-arch stable manifest pushed as :stable-multiarch (aarch64=${AARCH64_DIGEST})"
 

--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -296,3 +296,93 @@ jobs:
             "docker://ghcr.io/projectbluefin/dakota:stable-multiarch"
           echo "Multi-arch stable manifest pushed as :stable-multiarch (aarch64=${AARCH64_DIGEST})"
 
+
+  post-release-verify:
+    name: Post-release verification + cleanup
+    if: ${{ !inputs.dry_run && needs.execute.result == 'success' && needs.create-multiarch-stable.result == 'success' }}
+    needs: [freshness-check, execute, create-multiarch-stable]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    env:
+      BUILD_SHA: ${{ needs.freshness-check.outputs.build_sha }}
+      IMAGE: ghcr.io/projectbluefin/dakota
+    steps:
+      - name: Verify main bookmark matches promoted SHA
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          main_sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/main" --jq .object.sha)
+          if [ "$main_sha" != "$BUILD_SHA" ]; then
+            echo "::error::main bookmark is at $main_sha but promoted SHA was $BUILD_SHA"
+            exit 1
+          fi
+          echo "main bookmark verified: $main_sha"
+
+      - name: Verify :stable points to promoted digest
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq && sudo apt-get install -y -qq skopeo
+          promoted_digest=$(skopeo inspect --no-tags "docker://${IMAGE}:${BUILD_SHA}" | jq -r .Digest)
+          stable_digest=$(skopeo inspect --no-tags "docker://${IMAGE}:stable" | jq -r .Digest)
+          if [ "$stable_digest" != "$promoted_digest" ]; then
+            echo "::error::stable digest=$stable_digest, expected $promoted_digest"
+            exit 1
+          fi
+          echo "stable digest verified: $stable_digest"
+
+      - name: Verify :stable-multiarch exists
+        run: |
+          set -euo pipefail
+          skopeo inspect --no-tags --raw "docker://${IMAGE}:stable-multiarch" > /dev/null \
+            || { echo "::error::stable-multiarch tag missing"; exit 1; }
+          echo "stable-multiarch present"
+
+      - name: Detect stale auto/* promotion branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # OCI-native flow does not create auto/* promotion branches. Detect any leftover.
+          stale=$(gh api "repos/${GITHUB_REPOSITORY}/branches" --paginate --jq '.[].name' \
+            | grep -E '^auto/promote-' || true)
+          if [ -n "$stale" ]; then
+            echo "::warning::stale promotion branches present (expected none under OCI-native flow):"
+            echo "$stale"
+          else
+            echo "no stale promotion branches"
+          fi
+
+      - name: Prune untagged GHCR versions for dakota
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
+        with:
+          package-name: dakota
+          package-type: container
+          min-versions-to-keep: 100
+          delete-only-untagged-versions: 'true'
+        continue-on-error: true
+
+      - name: Prune untagged GHCR versions for dakota-nvidia
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
+        with:
+          package-name: dakota-nvidia
+          package-type: container
+          min-versions-to-keep: 100
+          delete-only-untagged-versions: 'true'
+        continue-on-error: true
+
+      - name: Summary — ready for next cycle
+        run: |
+          {
+            echo "## Post-release verification"
+            echo ""
+            echo "- main bookmark: $BUILD_SHA"
+            echo "- :stable digest: verified"
+            echo "- :stable-multiarch: present"
+            echo "- stale auto/* branches: clean"
+            echo "- untagged GHCR versions: pruned"
+            echo ""
+            echo "Repo is ready for the next promotion cycle."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/nightly-next-build.yml
+++ b/.github/workflows/nightly-next-build.yml
@@ -20,6 +20,17 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch:
 
+# Join the global BST concurrency group so this dispatcher waits behind
+# any in-flight BuildStream build on testing or any merge-queue ref. The
+# actual BST run is on build.yml (whose `build` job also joins this
+# group), so this serves as defense in depth — preventing the dispatcher
+# from queueing a second build before the first one releases the CAS.
+# cancel-in-progress: false so a running build is never killed by a
+# scheduled dispatch.
+concurrency:
+  group: dakota-bst-build-global
+  cancel-in-progress: false
+
 jobs:
   dispatch:
     name: Trigger next branch build

--- a/.github/workflows/pr-autoupdate.yml
+++ b/.github/workflows/pr-autoupdate.yml
@@ -31,9 +31,6 @@ jobs:
 
           # Find all open PRs targeting testing that are BEHIND and need updating.
           # Renovate manages its own branch updates — skip them.
-          # auto/promote-testing-to-main is rebuilt fresh by promote-testing-to-main.yml;
-          # a merge commit here changes the tree, defeats the tree-identity check, triggers a
-          # force-push, and dismisses approvals. Let the promote workflow keep it current.
           # Mergeraptor PRs (distrobox, junction bumps) DO target testing and need auto-update
           # so renovate-automerge can fire. They are intentionally included here.
           STALE_PRS=$(gh pr list \
@@ -45,7 +42,6 @@ jobs:
               .[] |
               select(.mergeStateStatus == "BEHIND") |
               select(.author.login != "renovate[bot]") |
-              select(.headRefName != "auto/promote-testing-to-main") |
               .number
             ')
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,6 @@ on:
     workflows: ["Build Bluefin dakota"]
     types: [completed]
     branches:
-      - main
-      - 'gh-readonly-queue/main/**'
       - next
       - 'gh-readonly-queue/next/**'
       - testing
@@ -25,7 +23,7 @@ permissions:
   actions: read
 
 concurrency:
-  # Separate publish queues per branch so next and main don't collide.
+  # Separate publish queues per branch so next and testing don't collide.
   group: publish-${{ github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: false
 
@@ -43,9 +41,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event != 'pull_request' &&
-       (github.event.workflow_run.head_branch == 'main' ||
-        startsWith(github.event.workflow_run.head_branch, 'gh-readonly-queue/main/') ||
-        github.event.workflow_run.head_branch == 'next' ||
+       (github.event.workflow_run.head_branch == 'next' ||
         startsWith(github.event.workflow_run.head_branch, 'gh-readonly-queue/next/') ||
         github.event.workflow_run.head_branch == 'testing' ||
         startsWith(github.event.workflow_run.head_branch, 'gh-readonly-queue/testing/')))
@@ -67,13 +63,10 @@ jobs:
           # Only trunk branches (direct pushes / schedule) advance stream tags.
           # Merge-queue builds (gh-readonly-queue/**) publish an immutable :SHA
           # tag only — they must NOT move public stream tags before the commit lands.
-          # main     → :testing  (bookmark fast-forward; TODO: remove after #1079)
           # testing  → :testing  (every merge to testing publishes immediately)
           # next     → :next     (rolling GNOME master / bleeding edge)
           # queue/** → (empty)   :SHA only, no stream tag
-          if [[ "$BRANCH" == "main" ]]; then
-            echo "testing_tag=testing" >> "$GITHUB_OUTPUT"
-          elif [[ "$BRANCH" == "next" ]]; then
+          if [[ "$BRANCH" == "next" ]]; then
             echo "testing_tag=next" >> "$GITHUB_OUTPUT"
           elif [[ "$BRANCH" == "testing" ]]; then
             echo "testing_tag=testing" >> "$GITHUB_OUTPUT"
@@ -679,7 +672,7 @@ jobs:
       needs.publish-image.result == 'success' &&
       needs.boot-check.result == 'success' &&
       needs.setup.outputs.testing_tag != '' &&
-      (github.event_name == 'workflow_run' || github.ref_name == 'main')
+      github.event_name == 'workflow_run'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/rollback-stable.yml
+++ b/.github/workflows/rollback-stable.yml
@@ -1,0 +1,346 @@
+name: Rollback :stable
+
+# One-button rollback for ghcr.io/projectbluefin/dakota{,-nvidia}:stable when a
+# promoted image is bad. Mirrors the publish/promotion supply-chain checks:
+#   1. Inspect the target SHA-pinned images exist.
+#   2. cosign verify them against the anchored publish.yml identity.
+#   3. skopeo copy --preserve-digests --all into :stable.
+#   4. Rebuild :stable-multiarch from the verified images.
+#
+# workflow_dispatch only. Defaults to dry_run=true — humans must opt-in to
+# moving tags. Concurrency group is shared with execute-release so this cannot
+# race with a promotion in flight.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: 'SHA of the previously-promoted commit to roll back to. Must be a commit that previously held :stable. Find via: gh run list --workflow execute-release.yml --status success'
+        required: true
+        type: string
+      reason:
+        description: 'Human reason for rollback. Logged in step summary and GitHub Release notes.'
+        required: true
+        type: string
+      include_multiarch:
+        description: 'Also revert :stable-multiarch.'
+        required: false
+        type: boolean
+        default: true
+      dry_run:
+        description: 'Inspect + cosign verify only, do not move tags. Defaults to true — opt out only when ready to roll back live.'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dakota-execute-release
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify rollback target
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      dakota_digest: ${{ steps.digests.outputs.dakota_digest }}
+      nvidia_digest: ${{ steps.digests.outputs.nvidia_digest }}
+      aarch64_digest: ${{ steps.aarch64.outputs.aarch64_digest }}
+      aarch64_present: ${{ steps.aarch64.outputs.present }}
+    env:
+      TARGET_SHA: ${{ inputs.target_sha }}
+      COSIGN_IDENTITY_REGEXP: ^https://github\.com/projectbluefin/dakota/\.github/workflows/publish\.yml@refs/heads/(testing|gh-readonly-queue/testing/.+)$
+      COSIGN_ISSUER: https://token.actions.githubusercontent.com
+    steps:
+      - name: Install skopeo
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq skopeo
+
+      - name: Install cosign
+        run: |
+          set -euo pipefail
+          curl -fsSL https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64 \
+            -o "$RUNNER_TEMP/cosign"
+          sudo install -m 0755 "$RUNNER_TEMP/cosign" /usr/local/bin/cosign
+          cosign version
+
+      - name: Inspect SHA-pinned images and capture digests
+        id: digests
+        run: |
+          set -euo pipefail
+
+          # dakota
+          if ! skopeo inspect --no-tags \
+              "docker://ghcr.io/projectbluefin/dakota:${TARGET_SHA}" > /tmp/dakota.json 2>&1; then
+            echo "::error::ghcr.io/projectbluefin/dakota:${TARGET_SHA} not found in GHCR."
+            cat /tmp/dakota.json
+            exit 1
+          fi
+          DAKOTA_DIGEST=$(jq -r '.Digest' /tmp/dakota.json)
+          if [ -z "$DAKOTA_DIGEST" ] || [ "$DAKOTA_DIGEST" = "null" ]; then
+            echo "::error::Failed to resolve digest for dakota:${TARGET_SHA}"
+            exit 1
+          fi
+          echo "dakota_digest=${DAKOTA_DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "dakota:${TARGET_SHA} → ${DAKOTA_DIGEST}"
+
+          # dakota-nvidia — pair invariant: both must exist
+          if ! skopeo inspect --no-tags \
+              "docker://ghcr.io/projectbluefin/dakota-nvidia:${TARGET_SHA}" > /tmp/nvidia.json 2>&1; then
+            echo "::error::ghcr.io/projectbluefin/dakota-nvidia:${TARGET_SHA} not found. dakota and dakota-nvidia must be promoted as a pair — refusing to roll back a partial set."
+            cat /tmp/nvidia.json
+            exit 1
+          fi
+          NVIDIA_DIGEST=$(jq -r '.Digest' /tmp/nvidia.json)
+          if [ -z "$NVIDIA_DIGEST" ] || [ "$NVIDIA_DIGEST" = "null" ]; then
+            echo "::error::Failed to resolve digest for dakota-nvidia:${TARGET_SHA}"
+            exit 1
+          fi
+          echo "nvidia_digest=${NVIDIA_DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "dakota-nvidia:${TARGET_SHA} → ${NVIDIA_DIGEST}"
+
+      - name: Verify cosign signature on dakota:${{ inputs.target_sha }}
+        env:
+          DAKOTA_DIGEST: ${{ steps.digests.outputs.dakota_digest }}
+        run: |
+          set -euo pipefail
+          cosign verify \
+            --certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP" \
+            --certificate-oidc-issuer "$COSIGN_ISSUER" \
+            "ghcr.io/projectbluefin/dakota@${DAKOTA_DIGEST}"
+
+      - name: Verify cosign signature on dakota-nvidia:${{ inputs.target_sha }}
+        env:
+          NVIDIA_DIGEST: ${{ steps.digests.outputs.nvidia_digest }}
+        run: |
+          set -euo pipefail
+          cosign verify \
+            --certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP" \
+            --certificate-oidc-issuer "$COSIGN_ISSUER" \
+            "ghcr.io/projectbluefin/dakota-nvidia@${NVIDIA_DIGEST}"
+
+      - name: Inspect and verify aarch64 component (if include_multiarch)
+        id: aarch64
+        if: ${{ inputs.include_multiarch }}
+        run: |
+          set -euo pipefail
+          if ! skopeo inspect --no-tags \
+              "docker://ghcr.io/projectbluefin/dakota:aarch64-${TARGET_SHA}" > /tmp/arm.json 2>&1; then
+            echo "::error::include_multiarch=true but ghcr.io/projectbluefin/dakota:aarch64-${TARGET_SHA} not found. Set include_multiarch=false to revert x86_64 only, or pick a target_sha that has a published aarch64 image."
+            cat /tmp/arm.json
+            exit 1
+          fi
+          AARCH64_DIGEST=$(jq -r '.Digest' /tmp/arm.json)
+          if [ -z "$AARCH64_DIGEST" ] || [ "$AARCH64_DIGEST" = "null" ]; then
+            echo "::error::Failed to resolve digest for dakota:aarch64-${TARGET_SHA}"
+            exit 1
+          fi
+          echo "aarch64_digest=${AARCH64_DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "present=true" >> "$GITHUB_OUTPUT"
+          echo "dakota:aarch64-${TARGET_SHA} → ${AARCH64_DIGEST}"
+
+          cosign verify \
+            --certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP" \
+            --certificate-oidc-issuer "$COSIGN_ISSUER" \
+            "ghcr.io/projectbluefin/dakota@${AARCH64_DIGEST}"
+
+      - name: Verify summary
+        env:
+          DAKOTA_DIGEST: ${{ steps.digests.outputs.dakota_digest }}
+          NVIDIA_DIGEST: ${{ steps.digests.outputs.nvidia_digest }}
+          AARCH64_DIGEST: ${{ steps.aarch64.outputs.aarch64_digest }}
+          REASON: ${{ inputs.reason }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          INCLUDE_MULTIARCH: ${{ inputs.include_multiarch }}
+        run: |
+          {
+            echo "## Rollback target verified"
+            echo ""
+            echo "- **target_sha:** \`${TARGET_SHA}\`"
+            echo "- **reason:** ${REASON}"
+            echo "- **dry_run:** \`${DRY_RUN}\`"
+            echo "- **include_multiarch:** \`${INCLUDE_MULTIARCH}\`"
+            echo "- **dakota digest:** \`${DAKOTA_DIGEST}\`"
+            echo "- **dakota-nvidia digest:** \`${NVIDIA_DIGEST}\`"
+            if [ -n "${AARCH64_DIGEST:-}" ]; then
+              echo "- **aarch64 digest:** \`${AARCH64_DIGEST}\`"
+            fi
+            echo ""
+            echo "All cosign signatures verified against \`publish.yml@refs/heads/testing\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  rollback:
+    name: Move :stable tags
+    needs: verify
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    env:
+      TARGET_SHA: ${{ inputs.target_sha }}
+      DAKOTA_DIGEST: ${{ needs.verify.outputs.dakota_digest }}
+      NVIDIA_DIGEST: ${{ needs.verify.outputs.nvidia_digest }}
+      AARCH64_DIGEST: ${{ needs.verify.outputs.aarch64_digest }}
+    steps:
+      - name: Install skopeo
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq skopeo
+
+      - name: Login to GHCR (skopeo)
+        env:
+          GH_ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "$GH_TOKEN" | skopeo login ghcr.io --username "$GH_ACTOR" --password-stdin
+
+      - name: Revert dakota:stable to target_sha
+        run: |
+          set -euo pipefail
+          skopeo copy --preserve-digests --all \
+            "docker://ghcr.io/projectbluefin/dakota:${TARGET_SHA}" \
+            "docker://ghcr.io/projectbluefin/dakota:stable"
+
+      - name: Revert dakota-nvidia:stable to target_sha
+        run: |
+          set -euo pipefail
+          skopeo copy --preserve-digests --all \
+            "docker://ghcr.io/projectbluefin/dakota-nvidia:${TARGET_SHA}" \
+            "docker://ghcr.io/projectbluefin/dakota-nvidia:stable"
+
+      - name: Verify reverted :stable digests match target
+        run: |
+          set -euo pipefail
+          dakota_now=$(skopeo inspect --no-tags "docker://ghcr.io/projectbluefin/dakota:stable" | jq -r .Digest)
+          if [ "$dakota_now" != "$DAKOTA_DIGEST" ]; then
+            echo "::error::dakota:stable digest=$dakota_now, expected $DAKOTA_DIGEST"
+            exit 1
+          fi
+          nvidia_now=$(skopeo inspect --no-tags "docker://ghcr.io/projectbluefin/dakota-nvidia:stable" | jq -r .Digest)
+          if [ "$nvidia_now" != "$NVIDIA_DIGEST" ]; then
+            echo "::error::dakota-nvidia:stable digest=$nvidia_now, expected $NVIDIA_DIGEST"
+            exit 1
+          fi
+          echo "Both :stable tags now point at the verified target digests."
+
+      - name: Login to GHCR (podman)
+        if: ${{ inputs.include_multiarch && needs.verify.outputs.aarch64_present == 'true' }}
+        env:
+          GH_ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "$GH_TOKEN" | podman login ghcr.io --username "$GH_ACTOR" --password-stdin
+
+      - name: Rebuild :stable-multiarch from verified components
+        if: ${{ inputs.include_multiarch && needs.verify.outputs.aarch64_present == 'true' }}
+        run: |
+          set -euo pipefail
+          # Mirror execute-release.yml's create-multiarch-stable step shape. The
+          # x86_64 component references the just-reverted :stable tag; the
+          # aarch64 component references the verified digest directly so we
+          # publish exactly what cosign signed in the verify job.
+          podman manifest create \
+            "ghcr.io/projectbluefin/dakota:stable-multiarch" \
+            "ghcr.io/projectbluefin/dakota:stable" \
+            "ghcr.io/projectbluefin/dakota@${AARCH64_DIGEST}"
+          podman manifest push --all \
+            "ghcr.io/projectbluefin/dakota:stable-multiarch" \
+            "docker://ghcr.io/projectbluefin/dakota:stable-multiarch"
+          echo "Rebuilt :stable-multiarch (aarch64=${AARCH64_DIGEST})"
+
+  record:
+    name: Record rollback in audit trail
+    needs: [verify, rollback]
+    if: ${{ always() && !inputs.dry_run && needs.rollback.result == 'success' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TARGET_SHA: ${{ inputs.target_sha }}
+      REASON: ${{ inputs.reason }}
+      ACTOR: ${{ github.actor }}
+      DAKOTA_DIGEST: ${{ needs.verify.outputs.dakota_digest }}
+      NVIDIA_DIGEST: ${{ needs.verify.outputs.nvidia_digest }}
+      AARCH64_DIGEST: ${{ needs.verify.outputs.aarch64_digest }}
+      INCLUDE_MULTIARCH: ${{ inputs.include_multiarch }}
+    steps:
+      - name: Compose rollback notes
+        id: notes
+        run: |
+          set -euo pipefail
+          TS=$(date -u +%s)
+          TS_HUMAN=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          TAG="rollback-${TARGET_SHA}-${TS}"
+          {
+            echo "# :stable rollback"
+            echo ""
+            echo "**Actor:** @${ACTOR}"
+            echo "**Timestamp:** ${TS_HUMAN}"
+            echo "**Target SHA:** \`${TARGET_SHA}\`"
+            echo ""
+            echo "## Reason"
+            echo ""
+            echo "${REASON}"
+            echo ""
+            echo "## Reverted digests"
+            echo ""
+            echo "| Image | Tag | Digest |"
+            echo "|---|---|---|"
+            echo "| dakota | :stable | \`${DAKOTA_DIGEST}\` |"
+            echo "| dakota-nvidia | :stable | \`${NVIDIA_DIGEST}\` |"
+            if [ "${INCLUDE_MULTIARCH}" = "true" ] && [ -n "${AARCH64_DIGEST}" ]; then
+              echo "| dakota (aarch64) | :stable-multiarch | \`${AARCH64_DIGEST}\` |"
+            fi
+            echo ""
+            echo "All digests were cosign-verified against \`publish.yml@refs/heads/testing\` before tags were moved."
+          } > rollback-notes.md
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "ts_human=${TS_HUMAN}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release documenting rollback
+        env:
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.notes.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # The release is tagged at the target_sha so the audit trail points
+          # at the commit whose image now serves :stable. Marked prerelease so
+          # it does not displace the most-recent stable release listing.
+          gh release create "$TAG" \
+            --repo "$REPO" \
+            --target "$TARGET_SHA" \
+            --title "Rollback :stable → ${TARGET_SHA}" \
+            --notes-file rollback-notes.md \
+            --prerelease
+
+      - name: Step summary
+        env:
+          TAG: ${{ steps.notes.outputs.tag }}
+          TS_HUMAN: ${{ steps.notes.outputs.ts_human }}
+        run: |
+          {
+            echo "## :stable rolled back"
+            echo ""
+            echo "- **target_sha:** \`${TARGET_SHA}\`"
+            echo "- **actor:** @${ACTOR}"
+            echo "- **timestamp:** ${TS_HUMAN}"
+            echo "- **reason:** ${REASON}"
+            echo "- **dakota digest:** \`${DAKOTA_DIGEST}\`"
+            echo "- **dakota-nvidia digest:** \`${NVIDIA_DIGEST}\`"
+            if [ "${INCLUDE_MULTIARCH}" = "true" ] && [ -n "${AARCH64_DIGEST}" ]; then
+              echo "- **aarch64 digest:** \`${AARCH64_DIGEST}\`"
+            fi
+            echo "- **audit release:** \`${TAG}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       image_ref:
-        description: "Full image ref to scan (default: latest published image)"
+        description: "Full image ref to scan (default: stable image)"
         required: false
         default: ""
 
@@ -24,6 +24,6 @@ jobs:
     uses: projectbluefin/actions/.github/workflows/reusable-vulnerability-scan.yml@v1
     with:
       image_matrix: '{"include":[{"image_name":"dakota"},{"image_name":"dakota-nvidia"}]}'
-      default_tag: 'latest'
+      default_tag: 'stable'
       image_ref: ${{ inputs.image_ref || '' }}
     secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,11 +27,11 @@ dakota  (next→:next/:btw, rolling nightly, no stable promotion)
 ```
 
 Each image repo pulls `ghcr.io/projectbluefin/common:latest` as a base layer.
-testsuite gates `:testing` promotion nightly and `:latest`/`:stable` promotion weekly.
+testsuite gates `:testing` promotion nightly and `:stable` promotion weekly.
 
 **Dakota image streams:**
 - `:testing` — `testing` branch, publishes on every BST-changing push (GHA-only changes filtered)
-- `:latest` / `:stable` — `main` branch, promoted from `testing` weekly via e2e-gated squash PR
+- `:stable` — `main` branch, promoted from `testing` weekly via e2e-gated squash PR
 - `:next` / `:btw` — `next` branch, GNOME 51 master, fully automated rolling nightly, **no promotion to stable ever**
 
 **`elements/bluefin/common.bst` strips bluefin-only content from common.** Any file added to `common/system_files/shared/` that does not apply to a fresh dakota install must be explicitly `rm -f`'d in the `install-commands` block of that element. Current stripped files: `rechunker-group-fix` script, service, and preset (chunka migration aid — not needed on fresh dakota).

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Ready to build something? See the [agent-ready queue](https://github.com/project
 
 | Tag | Stream | What it is |
 |---|---|---|
-| `:latest` | Stable | GNOME 50 — production. Weekly promotion from `:testing`. |
+| `:stable` | Stable | GNOME 50 — production. Weekly promotion from `:testing`. |
 | `:testing` | Dev | GNOME 50 — daily builds from `main`. Gated by e2e before promotion. |
 | `:next` | Rolling | **GNOME master — the bleeding edge.** Tracks gnome-build-meta `master` daily. Auto-updates, zero maintenance. |
 | `:btw` | Rolling | Alias for `:next`. |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -28,7 +28,7 @@ build.yml (main|testing|next) → [workflow_run] → publish.yml
 
 `promote` depends only on `publish-image`, not on SBOM — saves 10–15 min on the critical path.
 
-**`execute-release.yml`** fires on `push: main` and `workflow_dispatch`. A `check-trigger` job reads the commit message — proceeds only when it matches `^ci\(promote\): dakota testing` or `^chore: promote testing to main`. `workflow_dispatch` bypasses the gate. On success: copies `:testing` → `:stable`/`:latest`, then generates a GitHub Release with SBOM diff.
+**`execute-release.yml`** fires on `push: main` and `workflow_dispatch`. A `check-trigger` job reads the commit message — proceeds only when it matches `^ci\(promote\): dakota testing` or `^chore: promote testing to main`. `workflow_dispatch` bypasses the gate. On success: copies `:testing` → `:stable`, then generates a GitHub Release with SBOM diff.
 
 **Critical ordering:** `publish.yml` pulls the OCI artifact from CAS. The artifact is only in CAS if `build.yml` ran first for that SHA. Always dispatch `build.yml --ref testing` (or let push trigger it) before manually dispatching `publish.yml`.
 
@@ -43,7 +43,7 @@ push to testing (BST-affecting)
        → pr-release-gate.yml (cosign verify)
        → auto-merge → push to main (commit: "ci(promote): dakota testing ...")
            → execute-release.yml (check-trigger passes)
-               → :testing copied to :stable / :latest
+               → :testing copied to :stable
                → GitHub Release created
 ```
 
@@ -59,17 +59,17 @@ No daily build schedule. Builds fire on push, merge_group, or workflow_dispatch 
 
 ## Published images
 
-`ghcr.io/projectbluefin/dakota:{testing,latest,stable}` and `ghcr.io/projectbluefin/dakota:<sha>`
+`ghcr.io/projectbluefin/dakota:{testing,stable,next,btw}` and `ghcr.io/projectbluefin/dakota:<sha>`
 
 Streams:
 - `:testing` — published on every BST-affecting push to `testing` or `main` branch
-- `:latest` / `:stable` — promoted from `:testing` via `execute-release.yml` after promotion PR merges to main (Tuesday 04:00 UTC scheduled path, or manual dispatch)
+- `:stable` — promoted from `:testing` via `execute-release.yml` after promotion PR merges to main (Tuesday 04:00 UTC scheduled path, or manual dispatch)
 
 Never bypass the merge queue with `--admin`.
 
 ## Manual stable promotion
 
-To manually cut a `:stable` and `:latest` release:
+To manually cut a `:stable` release:
 
 ```bash
 # 1. Ensure :testing exists and promotion PR is open

--- a/docs/skills/ci-reference.md
+++ b/docs/skills/ci-reference.md
@@ -52,7 +52,7 @@ Route through `ci.md` first, then come here only when the focused skills do not 
 | Build timeout | 330 min (job: 360 min) |
 | Remote cache server | `cache.projectbluefin.io:11002` |
 | Cache auth | mTLS — `CASD_CLIENT_CERT` (repo variable) + `CASD_CLIENT_KEY` (secret) |
-| Published image | `ghcr.io/projectbluefin/dakota:{testing,latest,stable}` and `:$SHA` |
+| Published image | `ghcr.io/projectbluefin/dakota:{testing,stable,next,btw}` and `:$SHA` |
 | Build logs artifact | `buildstream-logs-x86_64-<variant>` (7-day retention) |
 | Trigger (validate) | `pull_request` — `bst show --deps all`, no CAS |
 | Trigger (build) | `merge_group`, `workflow_dispatch` (no daily schedule) |

--- a/docs/skills/ci-reference.md
+++ b/docs/skills/ci-reference.md
@@ -9,6 +9,16 @@ metadata:
 
 # CI Reference
 
+> **HISTORICAL — superseded by `ci.md` and `release-promotion.md`. Retained for archaeology only.**
+>
+> This file documents workflows and patterns from the pre-OCI-native era, including
+> deleted workflows (`promote-testing-to-main.yml`, `pr-release-gate.yml`,
+> `sync-main-to-testing.yml`, `cache-warm.yml`). Sections may describe workflows
+> that no longer exist, daily schedules that were replaced by `build.yml`'s 13:00 UTC
+> trigger, or promotion flows that were replaced by `execute-release.yml`. For the
+> current workflow inventory, read `ci.md` and `workflow-map.md`. For current
+> promotion flow, read `release-promotion.md`.
+
 ## Overview
 
 This is the **deep-cut archive**, not the load-first CI skill.

--- a/docs/skills/ci-tooling.md
+++ b/docs/skills/ci-tooling.md
@@ -200,9 +200,12 @@ before `enqueuePullRequest` succeeds. A manually-posted commit status is rejecte
 as a non-bot actor — the org bot restriction does not apply to human pushes:
 
 ```bash
-git checkout -b unblock upstream/auto/promote-testing-to-main
+# Example for any auto-pr-bot branch stuck on first run.
+# Historical case was auto/promote-testing-to-main (workflow now deleted);
+# the same pattern unblocks any bot-authored PR branch.
+git checkout -b unblock upstream/<bot-branch>
 git commit --allow-empty -m "ci: trigger validate as non-bot actor"
-git push upstream unblock:auto/promote-testing-to-main
+git push upstream unblock:<bot-branch>
 # validate fires on pull_request:synchronize as human → posts check run
 # enqueuePullRequest now succeeds
 ```
@@ -333,7 +336,7 @@ if [ "$rc" -eq 0 ]; then
   ...
 ```
 
-This pattern is now used in both `build.yml` and `cache-warm.yml` (fixed in
+This pattern is now used in `build.yml` (fixed in
 commit `1f89a42`). Apply the same pattern to any future step that needs to capture
 both the output and exit code of a command that may fail.
 

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -96,7 +96,7 @@ The rationalizations that have caused real production failures:
 |---|---|---|
 | `build.yml` | `push: testing/next` (paths-ignore: docs/workflows/md), `merge_group`, `workflow_dispatch`, `schedule: daily 13:00 UTC` — NOT `pull_request` | BST build → artifacts into remote CAS. Does NOT push to GHCR. `validate` job runs on `pull_request` only; `build` job runs on everything else. |
 | `publish.yml` | `workflow_run` from `build.yml` (branches: testing, next, + their gh-readonly-queue/* paths) | Export from CAS → push `:$sha` → sign/attest → promote to `:testing`/`:next`. No build happens here. |
-| `execute-release.yml` | `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch` | SHA freshness check (:testing vs :stable). If different: cosign verify → boot-check → skopeo copy `:testing` → `:stable`/`:latest` → fast-forward main → create GitHub Release. Skips if equal. |
+| `execute-release.yml` | `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch` | SHA freshness check (:testing vs :stable). If different: cosign verify → boot-check → skopeo copy `:testing` → `:stable` → fast-forward main → create GitHub Release. Skips if equal. |
 | ~~`promote-testing-to-main.yml`~~ | DELETED | Was: `push: testing`, schedule Tue 04:00 UTC, manual. |
 | ~~`pr-release-gate.yml`~~ | DELETED | Was: `pull_request` to `main`. |
 | ~~`sync-main-to-testing.yml`~~ | DELETED | Was: `push: main`. |
@@ -771,17 +771,17 @@ The GitHub release (notes + card + SBOM) is created automatically by
 
 ### check-diff skip silently skips missing variant :stable tags (2026-06-08)
 
-`check-diff` compares `dakota:testing` vs `dakota:latest` only. If they match,
+`check-diff` compares `dakota:testing` vs `dakota:stable` only. If they match,
 `has_diff=false` and the entire `promote` matrix is skipped — including the
 nvidia variant. This means if `dakota-nvidia:stable` was never created (e.g.,
-nvidia `:testing` didn't exist during the first promotion that set `:latest`),
+nvidia `:testing` didn't exist during the first promotion that set `:stable`),
 it will silently never get set on subsequent runs where the default image hasn't
 changed.
 
 **How it breaks:**
 
 1. First promotion: NVIDIA `:testing` not found → `has_nvidia=false` → nvidia skipped
-2. Next promotion: NVIDIA `:testing` now exists, but `dakota:testing == dakota:latest`
+2. Next promotion: NVIDIA `:testing` now exists, but `dakota:testing == dakota:stable`
    → `has_diff=false` → entire promote job skipped → `dakota-nvidia:stable` never set
 
 **Fix (manual):** Copy from the matching `:testing` digest directly:

--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -45,7 +45,7 @@ Use when you need product/repo context before planning work, when someone asks w
 - CI green is not sufficient. Hardware confirmation is.
 
 **Production image = `ghcr.io/projectbluefin/dakota:stable`.**
-- Streams: `:testing` (nightly, e2e-gated), `:latest` + `:stable` (weekly promotion)
+- Streams: `:testing` (nightly, e2e-gated), `:stable` (weekly promotion)
 - Rolling nightly stream: `:next` / `:btw` (GNOME 51 master — see below)
 - When someone says "is X in the image", check the GHCR image via `skopeo inspect` or `podman run --rm` — not a local machine unless explicitly asked.
 
@@ -60,14 +60,14 @@ freedesktop-sdk provides glibc/systemd/kernel, gnome-build-meta provides GNOME S
 
 **Key positioning:** Dakota is a **curated subset** of production Bluefin, not a 1:1 clone. It intentionally includes things production Bluefin doesn't have (sudo-rs, uutils-coreutils, GNOME nightly) and intentionally omits things that don't make sense for a from-source build (Nvidia drivers, ZFS, enterprise AD/Kerberos).
 
-Published image: `ghcr.io/projectbluefin/dakota:{testing,latest,stable,:next,:btw}`
+Published image: `ghcr.io/projectbluefin/dakota:{testing,stable,next,btw}`
 
 ## Image Streams
 
 | Tag | Branch | GNOME | Cadence | Stability |
 |-----|--------|-------|---------|-----------|
 | `:testing` | `main` | GNOME 50 (stable) | Every merged PR | e2e-gated |
-| `:latest` / `:stable` | `main` | GNOME 50 (stable) | Weekly promotion | Production |
+| `:stable` | `main` | GNOME 50 (stable) | Weekly promotion | Production |
 | `:next` | `next` | GNOME 51 (master) | On junction bump (~nightly) | Experimental |
 | `:btw` | `next` | GNOME 51 (master) | Same as `:next`, nvidia variant | Experimental |
 

--- a/docs/skills/quickstart.md
+++ b/docs/skills/quickstart.md
@@ -130,6 +130,6 @@ factory restart sequence is:
 4. `publish.yml` auto-triggers via `workflow_run`. If not, dispatch manually.
 5. After `:testing` lands, dispatch `weekly-testing-promotion.yml` and get
    2 human approvals at https://github.com/projectbluefin/dakota/deployments
-   to promote `:testing` → `:latest` + `:stable`.
+   to promote `:testing` → `:stable`.
 
 Full details: `release-promotion.md` and `ci-tooling.md`.

--- a/docs/skills/release-promotion.md
+++ b/docs/skills/release-promotion.md
@@ -11,7 +11,7 @@ metadata:
 
 ## Overview
 
-Promotion from `testing` to `:stable`/`:latest` is **fully automated and daily** — no human approval required at any stage.
+Promotion from `testing` to `:stable` is **fully automated and daily** — no human approval required at any stage.
 
 ```text
 testing (trunk) → build.yml → publish.yml → :testing tag
@@ -19,7 +19,7 @@ testing (trunk) → build.yml → publish.yml → :testing tag
                                          execute-release.yml (workflow_run from publish)
                                          SHA freshness check → cosign verify → boot-check
                                                   │
-                                         :stable / :latest + fast-forward main bookmark
+                                         :stable + fast-forward main bookmark
 ```
 
 `main` is a release bookmark only. It is fast-forwarded by `execute-release.yml` after each successful promotion. Do not open PRs against `main`.
@@ -34,7 +34,7 @@ Use when the task mentions:
 - SHA-based freshness check or `workflow_run` from `publish.yml`
 - `main-bookmark-protection` ruleset
 - cosign verify in the release path
-- stable release, `:latest`, `:stable`, or daily promotion flow
+- stable release, `:stable`, or daily promotion flow
 - `testing-merge-queue-no-review` ruleset
 
 ## When NOT to Use
@@ -52,7 +52,7 @@ Use when the task mentions:
    - `execute-release.yml` SHA freshness check
    - cosign verify `:testing`
    - boot-check gate
-   - skopeo copy `:testing` → `:stable`/`:latest`
+   - skopeo copy `:testing` → `:stable`
    - fast-forward `main` bookmark
 3. **`execute-release.yml` fires via `workflow_run` from `publish.yml` on the `testing` branch.**
    It checks whether the SHA published as `:testing` differs from the current `:stable`. If
@@ -79,7 +79,7 @@ push to testing (BST-affecting paths)
           → skip if equal (already up to date)
           → cosign verify :testing
           → boot-check gate
-          → skopeo copy :testing → :stable / :latest
+          → skopeo copy :testing → :stable
           → fast-forward main bookmark
           → create GitHub Release
 ```

--- a/docs/skills/release-promotion.md
+++ b/docs/skills/release-promotion.md
@@ -278,3 +278,84 @@ flow (issue 1073). The key differences:
 - **ARM trigger change:** `build-aarch64.yml` now fires via `workflow_run` from
   `publish.yml` — not a Tuesday cron. This serializes ARM after x86 CAS writes
   complete, preventing CAS contention.
+
+## Rollback
+
+When a promoted `:stable` image regresses behaviour or ships a security issue
+that cannot wait for the next promotion cycle, use the
+[`rollback-stable.yml`](../../.github/workflows/rollback-stable.yml) workflow
+instead of running `skopeo copy` from a laptop. The workflow re-uses the same
+cosign identity gate that gates promotion, so a rollback cannot smuggle in an
+image that was never legitimately published.
+
+### When to use it
+
+- A bug or regression escaped the testing → stable promotion and is hitting
+  users on `:stable` / `:stable-multiarch`.
+- A supply-chain incident requires reverting to a known-good digest fast.
+- **Not** for cosmetic / "I'd rather have yesterday's build" preferences —
+  rollback breaks the linear `main`-bookmark history users expect.
+
+### How to invoke
+
+1. Find a target SHA that previously held `:stable`. Successful
+   `execute-release.yml` runs are the canonical source:
+
+   ```bash
+   gh run list \
+     --repo projectbluefin/dakota \
+     --workflow execute-release.yml \
+     --status success \
+     --json headSha,createdAt,displayTitle \
+     --limit 10
+   ```
+
+   Pick the `headSha` of the run *before* the regression landed.
+
+2. Dispatch the workflow:
+
+   ```bash
+   gh workflow run rollback-stable.yml \
+     --repo projectbluefin/dakota \
+     --ref main \
+     -f target_sha=<sha> \
+     -f reason="<short reason — appears in audit release notes>" \
+     -f include_multiarch=true \
+     -f dry_run=true
+   ```
+
+3. Read the `verify` job step summary. If digests resolve and cosign verify
+   passes, re-dispatch with `dry_run=false` to actually move the tags.
+
+### Defaults that matter
+
+- **`dry_run` defaults to `true`.** Humans must explicitly pass `dry_run=false`
+  to live-rollback. This is intentional — a one-button live rollback under
+  pressure is exactly when foot-guns fire.
+- **`include_multiarch` defaults to `true`.** Leave it on unless ARM is
+  intentionally being held back; otherwise `:stable-multiarch` will continue
+  to advertise the bad image to `aarch64` users.
+- **Concurrency group is `dakota-execute-release`**, identical to the
+  promotion workflow. A rollback cannot race with a promotion in flight, and
+  vice versa.
+
+### What the workflow guarantees
+
+- `dakota:${target_sha}` and `dakota-nvidia:${target_sha}` both exist (pair
+  invariant — refuses to roll back a partial set).
+- Both images cosign-verify against the anchored
+  `publish.yml@refs/heads/(testing|gh-readonly-queue/testing/.+)` identity.
+- Tags are moved with `skopeo copy --preserve-digests --all`, so the digest
+  served by `:stable` is exactly the digest cosign signed.
+- A GitHub Release (`rollback-<sha>-<unix_ts>`, marked prerelease) is created
+  to keep an audit trail of the operator, reason, timestamp, and digests.
+
+### What it does *not* do
+
+- It does **not** rewind the `main` bookmark. `main` continues to point at the
+  most recent promoted SHA. The image stream and the git bookmark are
+  intentionally decoupled in this flow — if the regression also needs a code
+  revert, open a normal PR against `testing` and let the promotion pipeline
+  re-promote.
+- It does **not** delete the bad image. The previously-stable digest stays in
+  GHCR (under its SHA tag) for forensics.

--- a/docs/skills/release-promotion.md
+++ b/docs/skills/release-promotion.md
@@ -93,11 +93,16 @@ Ruleset: `testing-merge-queue-no-review`
 | Rule | Value |
 |---|---|
 | Required reviews | 0 (fully automated) |
-| Required status checks | `validate` + `e2e` |
+| Required status checks | `validate` (single context, integration_id 15368) |
 | Merge queue | enabled |
 | Force push | blocked |
 | Deletion | blocked |
 | Default branch | Yes — `testing` is the GitHub default branch |
+
+**Ground truth (verified via `gh api repos/projectbluefin/dakota/rulesets/18053489`):**
+- The only required status check context on `testing` is `validate`.
+- `e2e` and `Boot check — gate` from `publish.yml` are **not** ruleset-enforced gates. They run as part of `publish.yml` post-merge and gate stream-tag movement / promotion, not merge-queue entry.
+- If you want `Boot check — gate` to block merge-queue entry, that is a Design Gate change to the ruleset — do not modify in passing.
 
 ### main (release bookmark)
 

--- a/docs/skills/workflow-map.md
+++ b/docs/skills/workflow-map.md
@@ -67,7 +67,7 @@ Successful publish.yml on testing
        │    └─ skip if equal (already up to date)
        ├─ cosign verify :testing
        ├─ boot-check gate
-       ├─ skopeo copy :testing → :stable / :latest
+       ├─ skopeo copy :testing → :stable
        ├─ fast-forward main bookmark
        └─ create GitHub Release
 
@@ -100,7 +100,7 @@ Successful publish.yml on testing   ← PARALLEL, DECOUPLED
 | Branch | Trigger | Published tag(s) | Notes |
 |---|---|---|---|
 | `testing` | `push` (BST-affecting paths only) or `schedule: 13:00 UTC` | `:testing` | **Development trunk. Primary `:testing` publish path.** Every BST-affecting push builds → publishes → promotes. Doc/workflow-only pushes are ignored (paths-ignore). |
-| `main` | fast-forward from `execute-release.yml` | `:latest`, `:stable` | **Release bookmark only.** Only `execute-release.yml` writes here after a successful SHA freshness check + cosign verify + boot-check. No PRs target `main`. |
+| `main` | fast-forward from `execute-release.yml` | `:stable` | **Release bookmark only.** Only `execute-release.yml` writes here after a successful SHA freshness check + cosign verify + boot-check. No PRs target `main`. |
 | `next` | `push` or `sync-next-from-main` dispatch | `:next`, `:btw` | Rolling GNOME master; never stable. No PR requirement on branch protection. |
 | `gh-readonly-queue/testing/*` | merge-queue | (build only, no tag) | Gate before merge to `testing`. |
 | `gh-readonly-queue/next/*` | merge-queue | (build only, no tag) | Gate before merge to `next`. |
@@ -114,7 +114,7 @@ push to testing (BST-affecting) or daily 13:00 UTC schedule
       → :testing tag published to GHCR
   → execute-release.yml (workflow_run from publish on testing)
       → SHA freshness check → cosign verify → boot-check
-      → skopeo copy :testing → :stable / :latest
+      → skopeo copy :testing → :stable
       → fast-forward main bookmark
   → build-aarch64.yml (workflow_run from publish on testing)
       → :aarch64 / :aarch64-<sha> published (decoupled, never blocks release)

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -176,7 +176,6 @@ testing (development trunk — all PRs land here)
                               (workflow_run from publish, daily if :testing != :stable)
                               SHA-based freshness check → cosign verify → boot-check gate
                                        │
-                                       ├─► :latest  (+ fast-forwards main bookmark)
                                        └─► :stable  (+ fast-forwards main bookmark)
 ```
 
@@ -184,8 +183,7 @@ testing (development trunk — all PRs land here)
 |---|---|---|---|
 | Development | `:sha` | Every merge to `testing` | None |
 | Testing | `:testing` | Daily (13:00 UTC build) | boot-check |
-| Latest | `:latest` | Daily (if :testing != :stable) | SHA freshness check + cosign verify + boot-check |
-| Stable | `:stable` | Daily (if :testing != :stable) | Same as `:latest` |
+| Stable | `:stable` | Daily (if :testing != :stable) | SHA freshness check + cosign verify + boot-check |
 
 **All PRs target `testing`.** This includes contributor PRs, Renovate PRs, and BST source bump PRs. The `main` git branch is a release bookmark only — it is fast-forwarded by `execute-release.yml` after each successful promotion and must not be used as a PR base.
 


### PR DESCRIPTION
## Summary

Brutal-review hardening of the OCI-native daily promotion flow. Repo was paused for this pitstop; ready to fire after merge.

## Critical (supply-chain)

- **C1 — Anchored cosign identity regex** (3 places: `execute-release.yml` cosign step, release-notes cert verify, multiarch consumer). Was unanchored and accepted signatures from any workflow in dakota/actions. Now restricted to `publish.yml@refs/heads/(testing|gh-readonly-queue/testing/.+)$`.
- **C2 — Signed aarch64**: build-aarch64.yml now publishes via `projectbluefin/actions/bootc-build/sign-and-publish@v1` with cosign + build provenance attestation. `create-multiarch-stable` cosign-verifies both x86 and ARM by digest before assembling the manifest list; SHA-pinned aarch64 digest used (no floating `:aarch64` tag); `continue-on-error: true` removed.
- **C3 covered upstream** in projectbluefin/actions reusable PR — transactional variant promotion eliminates partial-failure stale `:stable` on dakota-nvidia.

## High

- **H1 (--preserve-digests)** in actions reusable PR.
- **H2 (fast_forward_sha)** wired here, declared in actions reusable PR.
- **H3 (ruleset reconciliation)** — confirmed via `gh api repos/projectbluefin/dakota/rulesets`: only `validate` is required on testing; no `e2e` check. Docs updated to match reality.
- **H4 (default-branch gate)** — `verify-default-branch` job in `build.yml` fails fast if repo settings drift off `testing`.
- **H5 (CAS-global concurrency)** — shared `dakota-bst-build-global` group across `build.yml`'s BST job and `nightly-next-build.yml`, honoring the single-build CAS rate limit. Publish/validate paths intentionally left out.
- **H6 (dead main paths)** — `publish.yml` and `build.yml` no longer accept main as a publish source.

## Medium / cleanup

- **M4** — freshness-check uses `:${BUILD_SHA}` digest, not floating `:testing`.
- **M6** — release-notes pinned to `${{ github.event.workflow_run.id }}`.
- **M1** — stale `auto/promote-testing-to-main` filter removed from `pr-autoupdate.yml`.
- **M2** — `ci-reference.md` retired with HISTORICAL banner.
- **`:latest` scrubbed** — canonical dakota stream tags are `:testing`, `:stable`, `:next`, `:btw`. 24 references corrected across docs + `vulnerability-scan.yml` default.

## New: post-release verification + rollback

- **`post-release-verify` job** in `execute-release.yml`: confirms `main` HEAD = promoted SHA, `:stable` digest = promoted digest, `:stable-multiarch` present, no stale `auto/*` branches, prunes untagged GHCR versions > 30 days (continue-on-error). Skipped on `dry_run`.
- **`rollback-stable.yml`** workflow_dispatch: one-button revert with cosign verify + `--preserve-digests`. Defaults `dry_run: true`. Shares concurrency group with `execute-release` so they serialize.

## Re-enable recipe

```bash
# First cycle: dry-run before live
gh workflow run execute-release.yml --repo projectbluefin/dakota --ref testing -f dry_run=true
# Inspect step summary; if clean:
gh workflow run execute-release.yml --repo projectbluefin/dakota --ref testing -f dry_run=false
```

Or just let the daily 13:00 UTC cron fire.

## Dependencies

This PR depends on projectbluefin/actions PR landing first so `fast_forward_sha` is recognized on the reusable. Backward-compat fallback in actions means dakota merging first only causes a deprecation warning, not a failure.

Assisted-by: Claude Opus 4.7 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated image stream documentation to reflect `:testing` (nightly) and `:stable` (weekly) as primary streams; removed `:latest` tag references.

* **New Features**
  * Added rollback capability for `:stable` releases.

* **Chores**
  * Enhanced CI/CD pipeline with improved build verification, concurrency controls, and multi-arch manifest handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->