### PR TITLE
fix(ci): replace !inputs.dry_run with inputs.dry_run != true to avoid startup_failure

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -95,6 +95,7 @@ jobs:
     permissions:
       actions: read
       contents: write
+      id-token: write
       issues: write
       packages: write
       pull-requests: write
@@ -299,7 +300,7 @@ jobs:
 
   post-release-verify:
     name: Post-release verification + cleanup
-    if: ${{ !inputs.dry_run && needs.execute.result == 'success' && needs.create-multiarch-stable.result == 'success' }}
+    if: ${{ inputs.dry_run != true && needs.execute.result == 'success' && needs.create-multiarch-stable.result == 'success' }}
     needs: [freshness-check, execute, create-multiarch-stable]
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
## Problem

`execute-release.yml` has been `startup_failure`-ing on every run since pitstop PR #1086 merged. All three post-pitstop runs (11:39, 12:16, 12:18 UTC) failed before any job started.

## Root cause

The pitstop added a `post-release-verify` job with this condition:

```yaml
if: ${{ !inputs.dry_run && ... }}
```

The `!` operator applied to `inputs.dry_run` causes `startup_failure` when the workflow is triggered via `workflow_run`. The `inputs` context does not exist for non-dispatch triggers — GHA errors at expression evaluation time before any job runs.

The pre-pitstop pattern `inputs.dry_run != true` is safe because null comparisons resolve correctly (`null != true` = true). The pitstop introduced the incompatible `!` form.

## Fix

- Replace `!${inputs.dry_run}` with `inputs.dry_run != true` in the `post-release-verify` job condition (line 302)
- Add `id-token: write` to the `execute` job permissions block — the reusable `reusable-execute-release.yml` needs OIDC for cosign; job-level permissions override top-level so it must be explicit

## Verification

Pattern matches the working pre-pitstop line 92 which has operated correctly under `workflow_run` trigger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow gating so verification and cleanup steps run only when the release is successful and not a dry run.
  * Expanded release job permissions to support secure automated handoff during release execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->