### PR TITLE
fix(ci): remove ${{ }} wrapper from post-release-verify if condition

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -300,7 +300,7 @@ jobs:
 
   post-release-verify:
     name: Post-release verification + cleanup
-    if: ${{ inputs.dry_run != true && needs.execute.result == 'success' && needs.create-multiarch-stable.result == 'success' }}
+    if: inputs.dry_run != true && needs.execute.result == 'success' && needs.create-multiarch-stable.result == 'success'
     needs: [freshness-check, execute, create-multiarch-stable]
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
Fixes startup_failure on all execute-release.yml runs since PR #1086.

## Root cause

`post-release-verify` used `${{ inputs.dry_run != true && ... }}` with
the expression wrapper in its `if:` condition. When triggered via
`workflow_run` (not `workflow_dispatch`), the `inputs` context is absent.
With the `${{ }}` wrapper, GitHub evaluates the expression at startup and
errors on the absent context, producing `startup_failure` before any job
is created.

PR #1089 correctly changed `!inputs.dry_run` to `inputs.dry_run != true`
but left the `${{ }}` wrapper — wrong fix for the wrong diagnosis. The
actual issue is the wrapper, not the operator.

## Fix

Remove the `${{ }}` wrapper. Bare `if:` expressions handle the absent
`inputs` context safely: `inputs` resolves to an empty object, `.dry_run`
is `null`, and `null != true` is `true` — the job runs normally.

This aligns `post-release-verify` with every other job-level `if:` in
this file (`execute`, `release-notes`, `create-multiarch-stable` all use
bare expressions without `${{ }}`).

## Verification

actionlint reports zero errors. The change is a 1-line edit with no
behavioral change — the expression evaluates identically, but now without
causing startup_failure on workflow_run triggers.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the release workflow’s verification step so it evaluates its conditions more directly and reliably.
  * Improved when the post-release check runs after a successful release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->