### PR TITLE
ci(build): disable remote CAS push to unblock builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,6 +207,14 @@ jobs:
         uses: ./.github/actions/generate-bst-ci-config
         with:
           enable-remote-execution: 'true'
+          # Disable remote push so local casd uses runner disk instead of routing
+          # through cache.projectbluefin.io:11002 as storage-service. The remote
+          # CAS drops connections mid-build (src-push: Connection refused) after
+          # ~3.5 hours, killing the build at 68% even though all pulls succeed.
+          # Pulls still read from gbm.gnome.org:11003 and :11001 (read-only).
+          # Re-enable once the CAS server connectivity is stable.
+          # TODO: re-enable push once cache.projectbluefin.io:11002 is fixed.
+          enable-push: 'false'
 
       # ── BuildStream build ─────────────────────────────────────────────
       # Uses the Justfile's `bst` wrapper to run BuildStream inside the


### PR DESCRIPTION
## Summary

Workaround for `cache.projectbluefin.io:11002` dropping connections mid-build.

Builds have been failing for 4 days. Root cause: the remote CAS drops
connections during `src-push` after ~3.5 hours (grpc StatusCode.UNAVAILABLE,
Connection refused). 792 elements pull cleanly, then 5 OCI elements fail
before they can be built because `cache.storage-service` routes the local
casd daemon through the remote server.

Setting `enable-push: false` removes the `cache.storage-service` block
so local casd uses runner disk. Pulls still read from:
- `gbm.gnome.org:11003` (GNOME public CAS, primary)
- `cache.projectbluefin.io:11001` (read-only)

Missing elements build from source locally. Build completes. Publish fires.

## Impact

:testing publishing resumes. :stable promotion resumes.

Future builds will rebuild the 5 missing OCI elements from source until
the CAS server is fixed and push is re-enabled.

## Follow-up

Re-enable push once `cache.projectbluefin.io:11002` src-push connectivity
is stable. One-line revert of this change.

Evidence from failed run 28075299045:
```
Build Queue:     processed 0,   failed 5
Src-push Queue:  processed 0,   failed 5
grpc StatusCode.UNAVAILABLE: ipv4:77.42.112.172:11002: Connection refused
```

Closes #0
[ ] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability by avoiding remote cache uploads during CI BuildStream configuration generation when connectivity is unstable.
  * CI builds now use local storage for cache writes, helping prevent mid-build connection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->