### PR TITLE
fix(ci): remove undeclared build_run_id input causing execute-release startup_failure

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -129,10 +129,6 @@ jobs:
       # Inline syft with rpm cataloger returns 0 packages on BST images.
       build_workflow: publish.yml
       build_branch: testing
-      # Pin SBOM lookup to the specific publish run that produced the promoted
-      # image — eliminates drift between "latest publish on testing" and the
-      # exact workflow_run.id whose digests we just promoted.
-      build_run_id: ${{ github.event.workflow_run.id }}
       sbom_artifact: sbom-dakota
       checkout_ref: testing
       project_name: Dakota

--- a/docs/skills/ci-tooling.md
+++ b/docs/skills/ci-tooling.md
@@ -398,3 +398,32 @@ if: inputs.dry_run != true && github.event_name == 'workflow_run'
 - [ ] `renovate-automerge.yml` does NOT have `workflows: write` (invalid scope — actionlint rejects it; use Mergeraptor app token instead)
 - [ ] CI-only changes that must survive sync are either landed on main directly or promoted before the next unrelated main push
 - [ ] All job `if:` conditions in dual-trigger workflows (`workflow_run` + `workflow_dispatch`) use bare expressions, not `${{ }}` wrappers
+
+### 15b) Undeclared input passed to reusable workflow — startup_failure (2026-06-24)
+
+**Root cause of execute-release startup_failure since PR #1086.**
+
+When a caller workflow passes an input via `with:` to a `uses:` (reusable workflow call)
+that the reusable workflow does NOT declare in its `on.workflow_call.inputs:`, GitHub
+validates this at dispatch time and returns `startup_failure` with zero jobs and no log output.
+
+**Pattern that causes startup_failure:**
+```yaml
+# caller (execute-release.yml)
+uses: org/actions/.github/workflows/reusable-release.yml@v1
+with:
+  build_run_id: ${{ github.event.workflow_run.id }}   # ← NOT declared in reusable-release.yml
+  build_workflow: publish.yml
+```
+
+**Fix:** Remove the undeclared input. If the reusable workflow needs run-ID pinning,
+add the input to the reusable workflow's `on.workflow_call.inputs:` first.
+
+**Why PR #1089 and #1091 didn't fix it:** Those PRs fixed `if:` expression syntax issues
+(real but secondary bugs). The undeclared input was the startup_failure root cause —
+no `if:` fix can prevent validation failure on the workflow graph before jobs start.
+
+**Actionlint does not catch this.** YAML parses cleanly. The error only manifests at runtime.
+
+**Verification after fix:** Run `workflow_dispatch` on the fixed workflow and confirm
+`freshness-check` job appears in the run (not `startup_failure` with 0 jobs).


### PR DESCRIPTION
Root cause of every execute-release startup_failure since PR #1086.

## Problem

`execute-release.yml` passes `build_run_id: ${{ github.event.workflow_run.id }}` to
`reusable-release.yml@v1` in the `release-notes` job. The reusable workflow does not
declare `build_run_id` as an accepted input.

GitHub validates the workflow graph at dispatch time. Passing an undeclared input
to a reusable workflow call causes `startup_failure` before any jobs run — zero log output.

## Why previous fixes did not work

PR #1089 fixed `!inputs.dry_run` syntax.
PR #1091 removed the `${{ }}` wrapper from `if:` conditions.
Both were real fixes for secondary issues but did not address the undeclared input.

## Fix

Remove `build_run_id` from the `release-notes` job `with:` block.
The `reusable-release.yml` workflow uses `build_workflow` + `build_branch` to locate
the SBOM artifact without requiring a specific run ID.

## Verification

- actionlint: clean
- All known `startup_failure` causes removed
- `build_run_id` no longer referenced in the file

Closes the execute-release startup_failure regression introduced by #1086.

- [ ] I am using an agent and I take responsibility for this PR