### PR TITLE
ci(build): re-enable remote execution and CAS push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,8 +214,8 @@ jobs:
           # remote-execution removes that dependency entirely. Local casd uses
           # runner disk. Pulls still read from gbm.gnome.org:11003 and :11001.
           # TODO: re-enable both once cache.projectbluefin.io:11002 is stable.
-          enable-remote-execution: 'false'
-          enable-push: 'false'
+          enable-remote-execution: 'true'
+          enable-push: 'true'
 
       # ── BuildStream build ─────────────────────────────────────────────
       # Uses the Justfile's `bst` wrapper to run BuildStream inside the


### PR DESCRIPTION
Reverts the workaround from PR #1093. CAS server has been rebooted and is healthy.

- [ ] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to allow faster remote-backed builds and support publishing generated build outputs during CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->