### PR TITLE
ci(build): disable CAS push/remote-exec — server still unstable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,16 +206,18 @@ jobs:
           CASD_CLIENT_KEY: ${{ secrets.CASD_CLIENT_KEY }}
         uses: ./.github/actions/generate-bst-ci-config
         with:
-          # Disable remote execution and push: cache.projectbluefin.io:11002
-          # drops connections during src-push after ~3.5 hours (grpc
-          # StatusCode.UNAVAILABLE, Connection refused), killing builds at 68%.
-          # BST requires storage-service when remote-execution is configured,
-          # and storage-service routes local casd through :11002 — so disabling
-          # remote-execution removes that dependency entirely. Local casd uses
-          # runner disk. Pulls still read from gbm.gnome.org:11003 and :11001.
-          # TODO: re-enable both once cache.projectbluefin.io:11002 is stable.
-          enable-remote-execution: 'true'
-          enable-push: 'true'
+          # HARD RULE — DO NOT RE-ENABLE EITHER FLAG.
+          # cache.projectbluefin.io:11002 drops connections mid-build after
+          # ~3.5 hours (grpc StatusCode.UNAVAILABLE). When enable-push is true,
+          # storage-service routes local casd through :11002 and the build dies
+          # at ~68% completion. When enable-remote-execution is true, BST adds
+          # a remote-execution block that also routes through :11002.
+          # Result: 3-6 hour wasted builds, hot cache destroyed.
+          # Pulls still read from gbm.gnome.org:11003 and :11001 (unaffected).
+          # Both flags stay false until cache.projectbluefin.io:11002 is confirmed
+          # stable under sustained load. Changing these flags is a human decision.
+          enable-remote-execution: 'false'
+          enable-push: 'false'
 
       # ── BuildStream build ─────────────────────────────────────────────
       # Uses the Justfile's `bst` wrapper to run BuildStream inside the


### PR DESCRIPTION
## What

Reverts the accidental re-enable of CAS push/remote-execution from 7d2a82d.

Both `enable-remote-execution` and `enable-push` are set back to `false`.

## Why

cache.projectbluefin.io:11002 drops connections after ~3.5 hours. When
`enable-push: true`, the storage-service block routes local casd through
:11002, killing builds at ~68% and destroying hot cache. Same for remote-execution.

This is the same issue fixed by #1093 (`2826799`). An agent re-enabled
both flags despite the comment explaining why they must stay off.

## Prevention

The comment no longer contains a TODO. It now explicitly states both flags
are a human decision to change, not a pending task for agents.

## Validation

- Cancelled the active poisoned build (run 28117186832)
- CI pre-flight confirmed field clear
- Build.yml validated: both flags are 'false'