### PR TITLE
ci(build): switch to strict daily build model, drop push triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,19 +11,6 @@ on:
     branches: [testing, next]
   merge_group:
     branches: [testing, next]
-  push:
-    # main is a release bookmark — pushes to main after promotion should not
-    # trigger a full BST build. Only testing (trunk) and next (rolling) build.
-    branches: [next, testing]
-    paths-ignore:
-      # Workflow files and docs don't affect the built image.
-      # .github/actions/** is intentionally NOT ignored — local composite
-      # actions (check-bst2-pin, generate-bst-ci-config) are used in the build.
-      - '.github/workflows/**'
-      - 'docs/**'
-      - '**.md'
-      - 'AGENTS.md'
-      - 'files/scripts/**'
   workflow_dispatch:
     # WARNING: Do not manually dispatch immediately after auto/track-* ref bumps
     # (e.g. Renovate PRs updating gnome-build-meta.bst). Cold builds of GNOME

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
           # Only trunk branches (direct pushes / schedule) advance stream tags.
           # Merge-queue builds (gh-readonly-queue/**) publish an immutable :SHA
           # tag only — they must NOT move public stream tags before the commit lands.
-          # testing  → :testing  (every merge to testing publishes immediately)
+          # testing  → :testing  (published daily on schedule)
           # next     → :next     (rolling GNOME master / bleeding edge)
           # queue/** → (empty)   :SHA only, no stream tag
           if [[ "$BRANCH" == "next" ]]; then

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -6,7 +6,7 @@
 |---|---|---|
 | `validate` | `pull_request` | `bst show` — graph + patch check (~15 min) |
 | `e2e` | `pull_request` when `elements/`, `files/`, `patches/`, `Justfile`, or `project.conf` changed | Smoke test in QEMU via projectbluefin/testsuite |
-| `build` | `push: main/next/testing` (paths-ignore: `.github/workflows/**`, `docs/**`, `**.md`, `AGENTS.md`), `merge_group`, `workflow_dispatch` — skips on `pull_request` | Full OCI build (~60–90 min) |
+| `build` | `merge_group`, `workflow_dispatch`, `schedule` — skips on `pull_request` | Full OCI build (~60–90 min) |
 | `build-aarch64` | disabled | ARM64 — pending investigation |
 
 ## Publish pipeline (publish.yml)
@@ -51,7 +51,7 @@ Schedule: `promote-testing-to-main.yml` runs `cron: '0 4 * * 2'` (Tuesday 04:00 
 
 ## Schedule
 
-No daily build schedule. Builds fire on push, merge_group, or workflow_dispatch only.
+Builds fire on schedule (13:00 UTC for testing, 03:00 UTC for next), merge_group, or workflow_dispatch.
 
 ## Remote cache
 

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -94,7 +94,7 @@ The rationalizations that have caused real production failures:
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| `build.yml` | `push: testing/next` (paths-ignore: docs/workflows/md), `merge_group`, `workflow_dispatch`, `schedule: daily 13:00 UTC` — NOT `pull_request` | BST build → artifacts into remote CAS. Does NOT push to GHCR. `validate` job runs on `pull_request` only; `build` job runs on everything else. |
+| `build.yml` | `merge_group`, `workflow_dispatch`, `schedule: daily 13:00 UTC` — NOT `pull_request` | BST build → artifacts into remote CAS. Does NOT push to GHCR. `validate` job runs on `pull_request` only; `build` job runs on everything else. |
 | `publish.yml` | `workflow_run` from `build.yml` (branches: testing, next, + their gh-readonly-queue/* paths) | Export from CAS → push `:$sha` → sign/attest → promote to `:testing`/`:next`. No build happens here. |
 | `execute-release.yml` | `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch` | SHA freshness check (:testing vs :stable). If different: cosign verify → boot-check → skopeo copy `:testing` → `:stable` → fast-forward main → create GitHub Release. Skips if equal. |
 | ~~`promote-testing-to-main.yml`~~ | DELETED | Was: `push: testing`, schedule Tue 04:00 UTC, manual. |

--- a/docs/skills/workflow-map.md
+++ b/docs/skills/workflow-map.md
@@ -54,8 +54,8 @@ Merge queue → testing or next
             ├─ publish-sbom [parallel]
             └─ promote to :testing / :next / :btw
 
-Daily 13:00 UTC / push: testing (BST-affecting paths) / manual
-  └─ build.yml (schedule or push trigger)
+Daily 13:00 UTC / manual
+  └─ build.yml (schedule trigger)
        └─ publish.yml (workflow_run from build)
             └─ promote to :testing
 
@@ -83,7 +83,7 @@ Successful publish.yml on testing   ← PARALLEL, DECOUPLED
 
 | Workflow | Owns | Normal trigger |
 |---|---|---|
-| `.github/workflows/build.yml` | BST build into remote CAS | `push: testing/next` (paths-ignore: docs, workflows, md, `files/scripts/**`), `merge_group`, `workflow_dispatch`, `schedule: daily 13:00 UTC`. `validate` job runs on `pull_request` only; `build` job skips `pull_request`. |
+| `.github/workflows/build.yml` | BST build into remote CAS | `merge_group`, `workflow_dispatch`, `schedule: daily 13:00 UTC`. `validate` job runs on `pull_request` only; `build` job skips `pull_request`. Note: `push:` triggers were removed to avoid CAS contention; we rely entirely on the daily schedule to publish streams. |
 | `.github/workflows/build-aarch64.yml` | aarch64 OCI build + GHCR push | `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch`. Fully decoupled — never in `needs:` of publish/promote/release. |
 | `.github/workflows/publish.yml` | export, sign, boot-check, promote tags | `workflow_run` from build |
 | `.github/workflows/publish-smoke.yml` | observational smoke only | `workflow_run` from publish |
@@ -99,17 +99,17 @@ Successful publish.yml on testing   ← PARALLEL, DECOUPLED
 
 | Branch | Trigger | Published tag(s) | Notes |
 |---|---|---|---|
-| `testing` | `push` (BST-affecting paths only) or `schedule: 13:00 UTC` | `:testing` | **Development trunk. Primary `:testing` publish path.** Every BST-affecting push builds → publishes → promotes. Doc/workflow-only pushes are ignored (paths-ignore). |
+| `testing` | `schedule: 13:00 UTC` | `:testing` | **Development trunk. Primary `:testing` publish path.** Builds on schedule using CAS warmed by merge queue. |
 | `main` | fast-forward from `execute-release.yml` | `:stable` | **Release bookmark only.** Only `execute-release.yml` writes here after a successful SHA freshness check + cosign verify + boot-check. No PRs target `main`. |
-| `next` | `push` or `sync-next-from-main` dispatch | `:next`, `:btw` | Rolling GNOME master; never stable. No PR requirement on branch protection. |
+| `next` | `schedule: 03:00 UTC` (via `nightly-next-build.yml`) | `:next`, `:btw` | Rolling GNOME master; never stable. No PR requirement on branch protection. |
 | `gh-readonly-queue/testing/*` | merge-queue | (build only, no tag) | Gate before merge to `testing`. |
 | `gh-readonly-queue/next/*` | merge-queue | (build only, no tag) | Gate before merge to `next`. |
 | `testing` (BST paths) | `workflow_run` from publish | `:aarch64`, `:aarch64-<sha>` | Published by `build-aarch64.yml`. Completely decoupled from x86_64 flow. Never blocks release. |
 
 **What testing does (not just PRs):**
 ```
-push to testing (BST-affecting) or daily 13:00 UTC schedule
-  → build.yml (build job)
+daily 13:00 UTC schedule
+  → build.yml (build job using CAS warmed by merge queue)
   → publish.yml (workflow_run)
       → :testing tag published to GHCR
   → execute-release.yml (workflow_run from publish on testing)
@@ -126,7 +126,7 @@ push to testing (BST-affecting) or daily 13:00 UTC schedule
 |---|---|
 | "Publish failed, so build must be broken." | Often false. Build, publish, boot, smoke, and promotion are separate stages. |
 | "Nothing ran, so GitHub is flaky." | Usually the trigger or branch filter is wrong. |
-| "The schedule still owns :testing." | Not anymore. Every successful merge publishes immediately. |
+| "The schedule still owns :testing." | This is correct. The daily schedule is the only way `:testing` updates (as of 2026-06-25) to avoid global CAS locks. |
 
 ## Red Flags
 


### PR DESCRIPTION
## Objective
Moves Dakota to a strict daily release schedule to prevent the permanent CAS starvation caused by global concurrency limits.

By dropping the `push:` trigger in `build.yml`, we stop every PR merge to `testing` from queuing a full 4-hour build and killing subsequent builds.

### Time Spacing
- **`next`**: 03:00 UTC (via `nightly-next-build.yml`)
- **`testing`**: 13:00 UTC (via `build.yml` schedule)
- **`stable`**: Immediately after `testing` publish completes (via `execute-release.yml`)

### Workflow
1. PRs use the merge-queue to build and warm the CAS.
2. The merge commit lands on the branch, but **does not trigger a build**.
3. At the scheduled time, the build uses the pre-warmed CAS.
4. The daily build completes fast and publishes the public stream tags.

**Note:** The `workflow-map.md` documentation was updated to officially revoke the 'Hard Rule' that `push: testing` is required.

[x] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated CI workflow triggers so the build workflow no longer runs on pushes, and instead relies on scheduled, merge-queue, pull request, and manual events.

- **Documentation**
  - Updated CI and CI router/skills documentation to match the new trigger behavior and scheduling times.
  - Refreshed the workflow map and testing/tagging descriptions to reflect that the testing path is now schedule-driven.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Maintainer-approved no-issue exception.