### PR TITLE
ci(build-aarch64): exclude .github/actions/** from push trigger

### DIFF
--- a/.github/workflows/build-aarch64.yml
+++ b/.github/workflows/build-aarch64.yml
@@ -25,6 +25,7 @@ on:
     branches: [main, testing]
     paths-ignore:
       - '.github/workflows/**'
+      - '.github/actions/**'
       - 'docs/**'
       - '**.md'
       - 'AGENTS.md'


### PR DESCRIPTION
CI-only changes in .github/actions/ should not trigger aarch64 BST builds.
The workflow_run trigger (fires after x86_64 publish) handles content updates.

Without this, merging any PR that touches an action file (e.g. PR #1102
changing generate-bst-ci-config) fires an aarch64 BST build that contends
with the scheduled x86_64 build on the CAS.

- [ ] I am using an agent and I take responsibility for this PR