### PR TITLE
ci(next): sync CI fixes from testing — push config, exclude merge_group, aarch64 paths

### DIFF
--- a/.github/actions/generate-bst-ci-config/action.yml
+++ b/.github/actions/generate-bst-ci-config/action.yml
@@ -140,3 +140,42 @@ runs:
 
         echo "=== BuildStream CI config ==="
         cat buildstream-ci.conf
+
+        # Always generate a push-only config for the post-build artifact push step.
+        # push: true so bst artifact push can write; no storage-service so casd
+        # stays local and there is no sustained gRPC stream during the push phase.
+        if [[ -n "${CASD_CLIENT_CERT:-}" ]] && [[ -n "${CASD_CLIENT_KEY:-}" ]]; then
+          cat > buildstream-push.conf <<'BSTCONFPUSH'
+        scheduler:
+          on-error: continue
+          fetchers: 32
+          builders: 4
+          network-retries: 3
+
+        logging:
+          message-format: '[%{wallclock}][%{elapsed}][%{key}][%{element}] %{action} %{message}'
+          error-lines: 80
+
+        cachedir: /root/.cache/buildstream
+        logdir: /src/logs
+
+        build:
+          retry-failed: True
+
+        artifacts:
+          servers:
+          - url: https://cache.projectbluefin.io:11002
+            push: true
+            connection-config:
+              keepalive-time: 180
+              retry-limit: 5
+              retry-delay: 1000
+              request-timeout: 180
+            auth:
+              client-key: /src/client.key
+              client-cert: /src/client.crt
+
+        BSTCONFPUSH
+          echo "=== BuildStream push config ==="
+          cat buildstream-push.conf
+        fi

--- a/.github/workflows/build-aarch64.yml
+++ b/.github/workflows/build-aarch64.yml
@@ -25,6 +25,7 @@ on:
     branches: [main, testing]
     paths-ignore:
       - '.github/workflows/**'
+      - '.github/actions/**'
       - 'docs/**'
       - '**.md'
       - 'AGENTS.md'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
   # default branch is not 'testing', the daily build silently targets the
   # wrong ref. Fail fast and loudly when that invariant is violated.
   verify-default-branch:
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -109,12 +109,14 @@ jobs:
         run: just bst show --deps all oci/bluefin-nvidia.bst
 
   # ── Full OCI build ────────────────────────────────────────────────────────
-  # Fires on merge_group, schedule, and workflow_dispatch — NOT on pull_request.
-  # PRs are validated by the validate job above; the full build is the
-  # merge-queue gate. This keeps cache.projectbluefin.io free from PR traffic.
+  # Fires on schedule (daily 13:00 UTC) and workflow_dispatch only.
+  # merge_group is intentionally excluded: the merge queue requires only
+  # `validate` to pass; a full BST build triggered by merge_group is always
+  # cancelled when the PR merges (before the 5h build can finish), which
+  # wastes the CAS slot and starves the scheduled build.
   build:
     needs: [verify-default-branch]
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     timeout-minutes: 360
     # Global BST concurrency: only one BuildStream build may run across
@@ -242,15 +244,16 @@ jobs:
             | python3 files/scripts/bst-progress.py
         timeout-minutes: 330
 
-      # Push the built artifact to the remote CAS so the export job can pull it.
-      # Remote execution may populate the artifact cache implicitly, but an
-      # explicit push guarantees the artifact is there regardless of BST internals.
-      # Push both variants so publish.yml can fetch each from CAS.
+      # Push all locally-built artifacts to remote CAS so publish.yml can export
+      # and the next scheduled build starts warm. Uses buildstream-push.conf
+      # (push: true, no storage-service) so bst artifact push can write without
+      # a sustained gRPC stream during the build phase. --deps all ensures every
+      # element rebuilt locally during a cold start is cached for future builds.
       - name: Push OCI artifact to remote CAS
         env:
-          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
+          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-push.conf
         run: |
-          just bst artifact push --deps none ${{ matrix.element }}
+          just bst artifact push --deps all ${{ matrix.element }}
 
       # ── Upload build logs ─────────────────────────────────────────────
       # Always upload, even on failure, so build failures can be diagnosed.

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -92,6 +92,7 @@ Use this file when:
 | Issue lifecycle / Actionadon / data donation | `actionadon.md` |
 | Installer work | `installer.md` |
 | VM stack context | `vm-stack.md` |
+| Bluefin CLI nspawn developer container | `bluefin-cli.md` |
 | Repo and product overview | `overview.md` |
 | PR review workflow | `pr-review.md` |
 | ujust recipes in `files/just-overrides/` | `.github/skills/ujust-recipes.md` |

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -137,13 +137,15 @@ The rationalizations that have caused real production failures:
 **This is the primary BST caching strategy for Dakota. Everything else is a variation or a failure mode.**
 
 ```
-build phase:   runner local disk  ←── reads from cache.projectbluefin.io:11001 (read-only)
+build phase:   runner local disk  ←── reads from cache.projectbluefin.io:11002 (push: false)
                                   ←── reads from gbm.gnome.org:11003 (upstream elements)
                                        builds missing elements locally
                                        stores finished artifacts on runner disk
+               config: buildstream-ci.conf  (artifacts push: false, no storage-service)
 
-push phase:    runner local disk  ──► cache.projectbluefin.io:11002 (one targeted push)
-               bst artifact push --deps none <element>
+push phase:    runner local disk  ──► cache.projectbluefin.io:11002 (push: true, one-shot)
+               bst artifact push --deps all <element>
+               config: buildstream-push.conf  (artifacts push: true, no storage-service)
                (runs after build completes successfully)
 ```
 
@@ -169,14 +171,25 @@ When `enable-push: false` (local-first mode):
 ```yaml
 - name: Push OCI artifact to remote CAS
   env:
-    BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
+    BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-push.conf
   run: |
-    just bst artifact push --deps none ${{ matrix.element }}
+    just bst artifact push --deps all ${{ matrix.element }}
 ```
 
-`--deps none` pushes only the top-level OCI element. BST artifact push is idempotent —
-already-cached elements are skipped. This step runs after a successful build and populates
-the cache with exactly what the next build needs to start warm.
+`generate-bst-ci-config` writes TWO configs:
+- `buildstream-ci.conf` — used during the build phase: `push: false`, no `storage-service`. BST reads from CAS but never writes during the build.
+- `buildstream-push.conf` — used for the post-build push only: `push: true`, no `storage-service`, no `source-caches`. Only the artifacts server block — `bst artifact push` does not use source-caches.
+
+`--deps all` pushes the entire locally-built artifact tree, not just the top-level OCI element.
+This is critical for cold starts: after a build that rebuilt many elements (e.g. after the cache
+went cold), `--deps none` would leave all intermediate artifacts un-pushed and the next build
+would be cold again. BST artifact push is idempotent — elements already in the remote CAS are
+skipped, so `--deps all` is safe and fast on a warm cache.
+
+**Why `push: false` in buildstream-ci.conf does NOT mean the push step is a noop:**
+They use different config files. The build phase uses `buildstream-ci.conf` (`push: false`) so
+BST never streams writes during a 4-6 hour build. The push step uses `buildstream-push.conf`
+(`push: true`) so `bst artifact push` can actually write to the server.
 
 **What "warm cache" means in practice:** A warm build skips the element graph entirely for
 unchanged upstream refs and only rebuilds elements whose inputs changed since the last push.
@@ -194,7 +207,7 @@ during the build phase. Reads are fine. Streaming writes during the build phase 
 | `CASD_CLIENT_CERT` | Repository **variable** | PEM-encoded client certificate (public) |
 | `CASD_CLIENT_KEY` | Repository **secret** | PEM-encoded private key |
 
-**Push is conditional:** Remote cache section is only added to `buildstream-ci.conf` if **both** are set. Without credentials, BST builds from source using local disk cache only — slower but functional. This is normal for external contributors' forks.
+**Push is conditional:** Both `buildstream-ci.conf` and `buildstream-push.conf` are only written if **both** `CASD_CLIENT_CERT` and `CASD_CLIENT_KEY` are set. Without credentials, BST builds from source using local disk cache only — slower but functional. This is normal for external contributors' forks.
 
 ### CAS drops connections mid-build — disable remote-execution + push
 
@@ -2377,9 +2390,10 @@ green light. Agents read these comments and re-enable `enable-remote-execution` 
 corruption. This has happened multiple times.
 
 **Rule:** `enable-remote-execution: 'false'` and `enable-push: 'false'` are the permanent
-correct values. The explicit `bst artifact push --deps none` step after the build handles
-cache writes atomically. Do not change these flags. The comment in build.yml must never
-suggest it is safe to re-enable them — if such a comment exists, delete it.
+correct values. The explicit `bst artifact push --deps all` step after the build (using
+`buildstream-push.conf` with `push: true`) handles cache writes atomically. Do not change
+these flags. The comment in build.yml must never suggest it is safe to re-enable them —
+if such a comment exists, delete it.
 
 **What happened:** Commit `d59a04a` added "Re-enabled 2026-06-24 after
 cache.projectbluefin.io:11002 confirmed back up" as justification. An agent read it,

--- a/docs/skills/workflow-map.md
+++ b/docs/skills/workflow-map.md
@@ -46,12 +46,9 @@ PR touching image paths
   └─ e2e (testsuite wrapper; change-detected)
 
 Merge queue → testing or next
-  └─ build.yml
-       └─ publish.yml (workflow_run from build)
-            ├─ publish-image
-            ├─ boot-check   [hard gate]
-            ├─ publish-sbom [parallel]
-            └─ promote to :testing / :next / :btw
+  └─ validate only (full build excluded — merge queue only requires validate;
+     merge_group builds were always cancelled by PR merge before completion,
+     wasting the CAS slot and starving the scheduled build)
 
 Daily 13:00 UTC / manual
   └─ build.yml (schedule trigger)
@@ -82,7 +79,7 @@ Successful publish.yml on testing   ← PARALLEL, DECOUPLED
 
 | Workflow | Owns | Normal trigger |
 |---|---|---|
-| `.github/workflows/build.yml` | BST build into remote CAS | `merge_group`, `workflow_dispatch`, `schedule: daily 13:00 UTC`. `validate` job runs on `pull_request` only; `build` job skips `pull_request`. Note: `push:` triggers were removed to avoid CAS contention; we rely entirely on the daily schedule to publish streams. |
+| `.github/workflows/build.yml` | BST build into remote CAS | `schedule: daily 13:00 UTC`, `workflow_dispatch`. `validate` job runs on `pull_request` and `merge_group`; `build` job runs on `schedule` and `workflow_dispatch` only — merge_group builds were always cancelled by PR merge before completion. |
 | `.github/workflows/build-aarch64.yml` | aarch64 OCI build + GHCR push | `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch`. Fully decoupled — never in `needs:` of publish/promote/release. |
 | `.github/workflows/publish.yml` | export, sign, boot-check, promote tags | `workflow_run` from build |
 | `.github/workflows/publish-smoke.yml` | observational smoke only | `workflow_run` from publish |
@@ -98,7 +95,7 @@ Successful publish.yml on testing   ← PARALLEL, DECOUPLED
 
 | Branch | Trigger | Published tag(s) | Notes |
 |---|---|---|---|
-| `testing` | `schedule: 13:00 UTC` | `:testing` | **Development trunk. Primary `:testing` publish path.** Builds on schedule using CAS warmed by merge queue. |
+| `testing` | `schedule: 13:00 UTC` | `:testing` | **Development trunk. Primary `:testing` publish path.** Builds daily; `bst artifact push --deps all` after each successful build warms the CAS for the next run. |
 | `main` | fast-forward from `execute-release.yml` | `:stable` | **Release bookmark only.** Only `execute-release.yml` writes here after a successful SHA freshness check + cosign verify + boot-check. No PRs target `main`. |
 | `next` | `schedule: 03:00 UTC` (via `nightly-next-build.yml`) | `:next`, `:btw` | Rolling GNOME master; never stable. No PR requirement on branch protection. |
 | `gh-readonly-queue/testing/*` | merge-queue | (build only, no tag) | Gate before merge to `testing`. |


### PR DESCRIPTION
Brings next branch in sync with testing-branch CI fixes (PRs #1102, #1103):

1. generate-bst-ci-config: write buildstream-push.conf (push: true) for post-build step
2. build.yml: exclude merge_group from full build — schedule/dispatch only
3. build.yml: push step uses buildstream-push.conf and --deps all
4. build-aarch64.yml: exclude .github/actions/** from push trigger

These are CI-only changes. The next branch junction refs (gnome-build-meta.bst,
freedesktop-sdk.bst) are unchanged. When sync-next-from-main.yml next runs,
these changes will already be present and won't conflict.

- [ ] I am using an agent and I take responsibility for this PR