### PR TITLE
ci(build-aarch64): remove push trigger — workflow_run and dispatch only

### DIFF
--- a/.github/workflows/build-aarch64.yml
+++ b/.github/workflows/build-aarch64.yml
@@ -11,7 +11,6 @@ name: Build Bluefin dakota (aarch64)
 #     land in the remote CAS for subsequent builds and warm-cache runs.
 #
 # Triggers:
-#   - push: testing / main (BST-affecting paths only; docs/workflow-only changes ignored)
 #   - workflow_run: fires after x86_64 publish completes on testing — ARM builds
 #     after x86 CAS writes are done, avoiding CAS write contention
 #   - workflow_dispatch: manual recovery / on-demand
@@ -21,15 +20,6 @@ name: Build Bluefin dakota (aarch64)
 #   :aarch64-<sha>    — immutable per-commit tag
 
 on:
-  push:
-    branches: [main, testing]
-    paths-ignore:
-      - '.github/workflows/**'
-      - '.github/actions/**'
-      - 'docs/**'
-      - '**.md'
-      - 'AGENTS.md'
-      - 'files/scripts/**'
   # Triggered after x86_64 publish completes — ARM builds after x86 CAS writes
   # are done, avoiding CAS write contention.
   workflow_run:


### PR DESCRIPTION
Checkins to testing no longer fire aarch64 builds.

workflow_run (after x86_64 publish) is enough. Push-triggered aarch64 builds contend with the scheduled x86_64 build for CAS bandwidth and produce cancelled runs.

- [ ] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ARM build workflow so it no longer runs directly on code pushes.
  * The build now runs only after the related publishing workflow completes or when started manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->