### PR TITLE
fix(bluefin-cli): correct sysupdate path, tar import, and mount masking

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -22,7 +22,7 @@ permissions:
   statuses: write
 
 concurrency:
-  group: execute-release
+  group: dakota-execute-release
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/update-filemap.yml
+++ b/.github/workflows/update-filemap.yml
@@ -28,8 +28,8 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: dakota-bst-build-global
+  cancel-in-progress: false
 
 permissions: read-all
 

--- a/docs/skills/bluefin-cli.md
+++ b/docs/skills/bluefin-cli.md
@@ -1,0 +1,181 @@
+# bluefin-cli skill
+
+Operational knowledge for the Bluefin CLI developer container — a ChromeOS-style
+systemd-nspawn container that ships Homebrew as an immutable OS component.
+
+## What it is
+
+A versioned, signed container rootfs (ubuntu 24.04 + systemd + Homebrew) shipped
+alongside the Dakota OCI image. The container runs as a persistent system machine
+(`machinectl`), and the host `brew` wrapper transparently proxies commands into it.
+
+Users see zero difference. `brew install gh` works. Packages live in `/home/linuxbrew`
+on the host, persisting across container image updates.
+
+## File map
+
+```
+elements/bluefin/bluefin-cli.bst           BST element — ships all config/service files
+files/bluefin-cli/
+  homebrew.nspawn                          nspawn container config (hardened defaults)
+  bluefin-cli-init.service                 First-boot systemd service (pulls + imports container)
+  homebrew-container.transfer              systemd-sysupdate transfer config
+  brew                                     Host wrapper script (bash; Rust binary planned)
+files/just-overrides/bluefin-cli.just      ujust recipes
+docs/skills/bluefin-cli.md                 This file
+```
+
+Container image built by: `projectbluefin/fsdk-containers` (separate repo, separate agent).
+Container image published to: `https://github.com/projectbluefin/bluefin-cli/releases/`
+
+## Architecture
+
+```
+OCI image (dakota)
+└─ /etc/systemd/nspawn/homebrew.nspawn    — container config
+└─ /usr/lib/systemd/system/
+       bluefin-cli-init.service           — first-boot init
+└─ /usr/lib/sysupdate.d/
+       homebrew-container.transfer        — update config
+└─ /usr/bin/brew                          — host wrapper
+
+First boot:
+  bluefin-cli-init.service
+    → systemd-sysupdate pulls homebrew-env-<ver>.tar.zst (SHA256+cosign verified)
+    → importctl import-tar → /var/lib/machines/homebrew/ (btrfs subvolume)
+    → machinectl enable + start homebrew
+
+Runtime:
+  $ brew install cowsay
+    → /usr/bin/brew (wrapper)
+      → systemd-run --machine=homebrew --uid=linuxbrew
+        → /home/linuxbrew/.linuxbrew/bin/brew install cowsay
+
+Updates:
+  systemd-sysupdate.timer pulls new container tarballs weekly
+  ujust update-bluefin-cli — manual update + restart
+  /home/linuxbrew/ bind-mounted from host — packages always preserved
+```
+
+## Critical nspawn gotchas
+
+**PrivateUsers must be `no` for dev containers.** Default `PrivateUsers=pick` uses a
+dynamic UID offset (e.g., base 378273792). Bind-mounted dirs like `/home/linuxbrew`
+show as `nobody/nogroup` inside the container because the host UID doesn't map.
+`PrivateUsersOwnership=auto` only rechowns container image files, NOT bind mounts.
+Solution: `PrivateUsers=no` in `homebrew.nspawn`.
+
+**`ResolvConf=bind-host` is the right directive.** Not `BindReadOnly=/etc/resolv.conf`.
+Context7-confirmed; this is a first-class nspawn directive.
+
+**Container needs real systemd init.** The `homebrew/brew` Docker image has no init
+process and fails with `machinectl start`. Use a proper ubuntu + systemd base.
+
+## Wrapper performance
+
+Current bash wrapper: ~50-100ms overhead (dbus `StartTransientUnit` round-trip).
+
+Planned Rust wrapper (nsenter path, ~3ms):
+1. Varlink query `io.systemd.Machine` socket → get leader PID of homebrew machine
+2. `nsenter --pid --mount --uts --ipc -t <leader-pid>`
+3. `su linuxbrew -c brew "$@"`
+
+Socket: `/run/systemd/machine/io.systemd.Machine` (systemd 254+, confirmed on Bluefin).
+
+## Security tiers
+
+Same container image, different config at install time.
+
+| Tier | Mechanism | Overhead | Use case |
+|------|-----------|----------|----------|
+| 1 — hardened nspawn | namespace + cap drop + syscall filter | ~35MB RAM | Default daily use |
+| 2 — Cloud Hypervisor + kata-kernel | KVM hypervisor boundary | ~55MB RAM + ~125ms boot | Untrusted tools / agents |
+
+Tier 1 is NOT a hard security boundary (shares kernel). Tier 2 is a genuine
+hypervisor boundary — equivalent to macOS VMs, stronger VMM security story
+(Rust + Landlock vs QEMU C codebase).
+
+For the VM tier:
+- VMM: Cloud Hypervisor (Rust, Intel/Microsoft, virtiofs DAX)
+- Kernel: kata-kernel from `kata-containers` package (standalone; no Kata runtime)
+- virtiofsd shares `/home/linuxbrew` as DAX — ~95% native I/O via shared memory
+- Cloud Hypervisor process itself is Landlock-sandboxed (can only see brew prefix + kernel)
+
+## btrfs integration
+
+`importctl import-tar` automatically creates a btrfs subvolume on btrfs hosts.
+The subvolume is atomically swapped on update (old version retained for rollback).
+
+Snapper should exclude `/var/lib/machines` to avoid snapshotting the entire container.
+Add to Snapper config: `SUBVOLUME_FILTER="/var/lib/machines"`
+
+## What gets removed from dakota deps.bst when this ships
+
+| Element | Reason |
+|---------|--------|
+| `bluefin/brew.bst` | Replaced by container |
+| `bluefin/brew-tarball.bst` | Replaced by container |
+| `bluefin/tealdeer.bst` | Duplicate — already in cli.Brewfile |
+| `bluefin/zig.bst` | Dev tool — goes in container |
+| `bluefin/distrobox.bst` | Largely superseded |
+| `freedesktop-sdk.bst:components/buildstream2.bst` | Dev-only, large |
+| `freedesktop-sdk.bst:components/flatpak-builder.bst` | Dev-only |
+| `freedesktop-sdk.bst:components/git-lfs.bst` | Dev use only |
+| `freedesktop-sdk.bst:components/debuginfod.bst` | Dev/debug only |
+| `gnome-build-meta.bst:gnomeos-deps/bpftop.bst` | Dev observability |
+
+These are NOT removed yet — this element is a placeholder. The `deps.bst` changes
+happen in a separate PR after the container image is published and tested.
+
+## Open questions (as of 2026-06-25)
+
+1. distrobox: keep as escape hatch or remove?
+2. `smartmontools`/`tcpdump` need `CAP_NET_RAW` — host packages or work around in container?
+3. First-boot timing: container init happens at `multi-user.target` — does this race with GNOME session start on first login?
+4. `machinectl enable` writes a symlink under `/etc/systemd/system/` — does this survive bootc A/B? It should, since `/etc` is the mutable layer.
+5. Per-user brew instances? Current design assumes shared `/home/linuxbrew`. systemd-homed creates user home on login — needs testing with homed integration.
+
+## Lessons learned
+
+**2026-06-25 — Container image can't be BST-built in-tree easily.** The Homebrew
+bootstrap process requires network access (downloads Ruby portable) and does not fit
+in a BST `kind: manual` element (no network in BST sandbox). Correct approach: build
+container via Containerfile in `projectbluefin/fsdk-containers`, publish as signed tar
+to GitHub Releases, pull at first boot via systemd-sysupdate.
+
+**2026-06-25 — `PrivateUsers=no` is correct for bind-mount compatibility but wrong for security.**
+`PrivateUsers=no` → container root == host root. A container escape is immediately a
+host-root event. This is the pragmatic choice for Tier 1 dev ergonomics, but is NOT
+a security boundary. The real fix: `PrivateUsers=pick` + **idmapped mounts** for
+`/home/linuxbrew` (kernel 5.12+). `PrivateUsersOwnership=auto` only rechowns
+container-internal files, NOT bind mounts. This remains an open architecture problem.
+
+**2026-06-25 — `SystemCallFilter=~@mount` BREAKS Homebrew 6 bubblewrap.**
+Homebrew 6 on Linux uses bubblewrap for formula sandboxing. bwrap requires `clone3`,
+`mount`, `pivot_root`, `open_tree`, `move_mount`, `unshare`. Adding `@mount` to the
+deny list silently breaks `brew install` for any non-bottle formula. Only deny
+`@reboot @swap @obsolete`. Validate with: `brew install hello` (source build).
+
+**2026-06-25 — virtiofs DAX `cache=always` is wrong for the mutable Homebrew prefix.**
+Known truncation/page-fault pathologies and stale coherency bugs for writable data.
+For writable `/home/linuxbrew`: use non-DAX virtiofs (default). Reserve DAX only for
+read-only immutable content.
+
+**2026-06-25 — Raw `nsenter` bypasses cgroup/SELinux containment.**
+`setns()` moves namespaces but NOT cgroup membership or LSM labels. Fast wrapper
+design: use AF_UNIX exec agent inside the container (resident daemon, SO_PEERCRED
+auth, one connect + one fork/exec per command). Do not ship naked nsenter.
+
+**2026-06-25 — btrfs CoW hurts hot-write Homebrew dirs.**
+`chattr +C` (NOCOW) on: `HOMEBREW_CACHE`, `HOMEBREW_TEMP`, brew lock dirs.
+Put these on a separate btrfs subvolume. Keep CoW on Cellar for snapshots.
+
+**2026-06-25 — systemd-sysupdate needs SHA256SUMS alongside tarballs.** The `url-tar`
+source type requires a `SHA256SUMS` file at the same path prefix. GitHub Releases
+does not generate this automatically — must be produced and uploaded in CI.
+
+**2026-06-25 — `ResolvConf=bind-host` is the right directive.** Not `BindReadOnly=/etc/resolv.conf`.
+Context7-confirmed; this is a first-class nspawn directive.
+
+**2026-06-25 — Container needs real systemd init.** The `homebrew/brew` Docker image has no init
+process and fails with `machinectl start`. Use a proper ubuntu + systemd base.

--- a/docs/skills/bluefin-cli.md
+++ b/docs/skills/bluefin-cli.md
@@ -1,7 +1,31 @@
-# bluefin-cli skill
+---
+name: bluefin-cli
+description: Operational knowledge for the Bluefin CLI developer container — a ChromeOS-style systemd-nspawn container that ships Homebrew. Use when working on elements/bluefin/bluefin-cli.bst, files/bluefin-cli/*, or ujust setup-bluefin-cli.
+---
+
+# Bluefin CLI Skill
 
 Operational knowledge for the Bluefin CLI developer container — a ChromeOS-style
 systemd-nspawn container that ships Homebrew as an immutable OS component.
+
+## When to Use
+
+- Working on the `bluefin-cli.bst` BuildStream element
+- Editing container configs (`files/bluefin-cli/*` such as `.nspawn`, `.service`, `.transfer`, or the `brew` wrapper)
+- Adjusting developer container initialization, `ujust` setup commands, or systemd-sysupdate integrations
+
+## When NOT to Use
+
+- General BuildStream element syntax debugging (use `buildstream.md` instead)
+- Custom base OCI image assembly (use `oci-layers.md` instead)
+- Adding standard host-level packages to `deps.bst` (use `add-package.md` instead)
+
+## Core Process
+
+1. **Understand Container Layout:** Config files must match expected locations under `/etc/systemd/nspawn` and `/usr/lib/sysupdate.bluefin-cli.d/`.
+2. **Handle Host Seeding:** First-boot service must clone/seed `/home/linuxbrew/.linuxbrew` from `/var/lib/machines/homebrew/` before container starts.
+3. **Verify Sysupdate Matching:** `--component=bluefin-cli` in systemd-sysupdate matches configs in `/usr/lib/sysupdate.bluefin-cli.d/`.
+4. **Hardened nspawn Defaults:** Ensure `PrivateUsers=no` for bind mounts and allow `@mount` group (do NOT restrict) due to Homebrew 6 bubblewrap sandboxing requirements.
 
 ## What it is
 
@@ -126,6 +150,26 @@ Add to Snapper config: `SUBVOLUME_FILTER="/var/lib/machines"`
 
 These are NOT removed yet — this element is a placeholder. The `deps.bst` changes
 happen in a separate PR after the container image is published and tested.
+
+## Common Rationalizations
+
+- **"I can just use `PrivateUsers=pick`."** → Wrong. Bind-mounted directories like `/home/linuxbrew` will show up as `nobody/nogroup` inside the container since the host UID does not map.
+- **"I can restrict the `@mount` group under system call filters."** → Wrong. Homebrew 6 uses bubblewrap for Linux formula sandboxing, which requires `mount`, `pivot_root`, and other namespace system calls. Restricting `@mount` will silently break `brew install` for all source builds.
+- **"I can just create `/home/linuxbrew/.linuxbrew` on the host side dynamically."** → Wrong. Doing so with `mkdir` produces an empty directory, masking the populated Homebrew installation baked into the container.
+
+## Red Flags
+
+- `homebrew.nspawn` has `PrivateUsers=yes` or `PrivateUsers=pick` without complex idmapped setups.
+- `SystemCallFilter` denies `@mount` or similar group on a system hosting Homebrew 6.
+- The sysupdate configuration installs files directly to `/usr/lib/sysupdate.d/` while using `--component=bluefin-cli` (making the file invisible).
+- No host seeding logic (`cp -a`) exists in `bluefin-cli-init.service` or `ujust` setup paths.
+
+## Verification
+
+- [ ] `systemd-sysupdate --component=bluefin-cli update` runs successfully and detects transfer files.
+- [ ] `importctl import-tar` resolves and processes the correct `.tar.zst` file instead of attempting to import an unpacked directory.
+- [ ] The initial `/home/linuxbrew/.linuxbrew` directory is fully seeded from the container subvolume on first-boot.
+- [ ] `brew install hello` successfully compiles and installs a source package.
 
 ## Open questions (as of 2026-06-25)
 

--- a/docs/skills/bluefin-cli.md
+++ b/docs/skills/bluefin-cli.md
@@ -218,6 +218,10 @@ Put these on a separate btrfs subvolume. Keep CoW on Cellar for snapshots.
 source type requires a `SHA256SUMS` file at the same path prefix. GitHub Releases
 does not generate this automatically — must be produced and uploaded in CI.
 
+**2026-06-29 — bluefin-cli updates must re-import the refreshed tarball.** `systemd-sysupdate`
+only stages the new release; `importctl import-tar` is what swaps `/var/lib/machines/homebrew`
+to the new subvolume. Restarting the machine without that import leaves the old image active.
+
 **2026-06-25 — `ResolvConf=bind-host` is the right directive.** Not `BindReadOnly=/etc/resolv.conf`.
 Context7-confirmed; this is a first-class nspawn directive.
 

--- a/elements/bluefin/bluefin-cli.bst
+++ b/elements/bluefin/bluefin-cli.bst
@@ -1,0 +1,29 @@
+kind: manual
+
+sources:
+- kind: local
+  path: files/bluefin-cli
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  # nspawn container config — hardened defaults baked in
+  - install -Dm644 homebrew.nspawn "%{install-root}/etc/systemd/nspawn/homebrew.nspawn"
+
+  # First-boot init service (runs once, pulls container image, imports as btrfs subvolume)
+  - install -Dm644 bluefin-cli-init.service "%{install-root}/usr/lib/systemd/system/bluefin-cli-init.service"
+  - install -d "%{install-root}/usr/lib/systemd/system/multi-user.target.wants"
+  - ln -sf ../bluefin-cli-init.service "%{install-root}/usr/lib/systemd/system/multi-user.target.wants/bluefin-cli-init.service"
+
+  # systemd-sysupdate transfer config for container image updates
+  - install -Dm644 homebrew-container.transfer "%{install-root}/usr/lib/sysupdate.bluefin-cli.d/homebrew-container.transfer"
+
+  # Host brew wrapper — transparent CLI passthrough into the container
+  - install -Dm755 brew "%{install-root}/usr/bin/brew"
+
+  - "%{install-extra}"

--- a/elements/oci/layers/python-micro.bst
+++ b/elements/oci/layers/python-micro.bst
@@ -1,0 +1,12 @@
+kind: compose
+build-depends:
+  - freedesktop-sdk.bst:components/python3.bst
+  - freedesktop-sdk.bst:components/ca-certificates.bst
+  - freedesktop-sdk.bst:components/tzdata.bst
+config:
+  exclude:
+    - devel
+    - debug
+    - doc
+    - locale
+  include-orphans: true

--- a/elements/oci/layers/python-minimal.bst
+++ b/elements/oci/layers/python-minimal.bst
@@ -1,0 +1,12 @@
+kind: compose
+
+build-depends:
+  - freedesktop-sdk.bst:components/python3.bst
+  - freedesktop-sdk.bst:components/ca-certificates.bst
+
+config:
+  exclude:
+    - devel
+    - debug
+    - doc
+    - locale

--- a/elements/oci/python-micro-image.bst
+++ b/elements/oci/python-micro-image.bst
@@ -1,0 +1,25 @@
+kind: script
+
+build-depends:
+  - gnome-build-meta.bst:freedesktop-sdk.bst:components/oci-builder.bst
+  - filename: oci/layers/python-micro.bst
+    config:
+      location: /layer
+
+config:
+  commands:
+    - |
+      cd /layer
+      rm -rf usr/lib/python3.*/tkinter
+      rm -rf usr/lib/python3.*/idlelib
+      rm -rf usr/lib/python3.*/turtledemo
+      rm -rf usr/lib/python3.*/pydoc_data
+      rm -rf usr/lib/python3.*/ensurepip
+      rm -rf usr/lib/x86_64-linux-gnu/gconv
+      rm -rf usr/include
+      rm -rf usr/share/doc
+      rm -rf usr/share/man
+      oci-builder \
+        --name ghcr.io/projectbluefin/python-micro \
+        --entrypoint /usr/bin/python3 \
+        . /oci-image

--- a/elements/oci/python-minimal-image.bst
+++ b/elements/oci/python-minimal-image.bst
@@ -1,0 +1,16 @@
+kind: script
+
+build-depends:
+  - gnome-build-meta.bst:freedesktop-sdk.bst:components/oci-builder.bst
+  - filename: oci/layers/python-minimal.bst
+    config:
+      location: /layer
+
+config:
+  commands:
+    - |
+      cd /layer
+      oci-builder \
+        --name ghcr.io/projectbluefin/python-minimal \
+        --entrypoint /usr/bin/python3 \
+        . /oci-image

--- a/files/bluefin-cli/bluefin-cli-init.service
+++ b/files/bluefin-cli/bluefin-cli-init.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Initialize Bluefin CLI developer container
+Documentation=https://github.com/projectbluefin/dakota/blob/testing/docs/skills/bluefin-cli.md
+ConditionPathExists=!/var/lib/machines/homebrew
+After=local-fs.target network-online.target systemd-sysupdate.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Pull the container image via systemd-sysupdate (verifies SHA256 + cosign)
+ExecStart=systemd-sysupdate --component=bluefin-cli update
+# Import as a btrfs subvolume (atomic, rollback-capable)
+ExecStart=importctl import-tar /var/lib/bluefin-cli/homebrew-env.tar.zst homebrew
+# Create the brew prefix on the host if it doesn't exist, seeding it from the container image
+ExecStart=/bin/bash -c 'if [ ! -d /home/linuxbrew/.linuxbrew ]; then mkdir -p /home/linuxbrew && cp -a /var/lib/machines/homebrew/home/linuxbrew/.linuxbrew /home/linuxbrew/; fi'
+# Enable the container to auto-start at boot
+ExecStart=machinectl enable homebrew
+ExecStart=machinectl start homebrew
+
+[Install]
+WantedBy=multi-user.target

--- a/files/bluefin-cli/brew
+++ b/files/bluefin-cli/brew
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Host wrapper — runs brew commands inside the homebrew nspawn container.
+# Transparent to the user: `brew install foo` works exactly as expected.
+#
+# Performance note: this wrapper adds ~50-100ms via systemd-run dbus overhead.
+# A future compiled wrapper (Varlink PID lookup + nsenter) will cut this to ~3ms.
+set -euo pipefail
+
+MACHINE=homebrew
+BREW_BIN=/home/linuxbrew/.linuxbrew/bin/brew
+
+# Ensure the container image has been initialized
+if ! machinectl list --no-legend | grep -q "^${MACHINE}\\b"; then
+    if machinectl list-images --no-legend | grep -q "^${MACHINE}\\b"; then
+        machinectl start "$MACHINE" 1>&2
+        # Give systemd a moment to hand off to the container init
+        sleep 0.5
+    else
+        echo "bluefin-cli: homebrew container not installed." >&2
+        echo "Run: ujust setup-bluefin-cli" >&2
+        exit 1
+    fi
+fi
+
+exec systemd-run \
+    --quiet \
+    --pipe \
+    --wait \
+    --machine="$MACHINE" \
+    --uid=linuxbrew \
+    --setenv=HOMEBREW_NO_AUTO_UPDATE=1 \
+    --setenv=HOMEBREW_NO_INSTALL_CLEANUP=1 \
+    -- "$BREW_BIN" "$@"

--- a/files/bluefin-cli/homebrew-container.transfer
+++ b/files/bluefin-cli/homebrew-container.transfer
@@ -1,0 +1,15 @@
+[Transfer]
+# Do not downgrade — protect current version
+ProtectVersion=%A
+
+[Source]
+Type=url-file
+# Published to GitHub Releases; SHA256SUMS file must be present alongside tarballs
+Path=https://github.com/projectbluefin/bluefin-cli/releases/download/
+MatchPattern=homebrew-env-@v.tar.zst
+
+[Target]
+Type=regular-file
+Path=/var/lib/bluefin-cli
+MatchPattern=homebrew-env-@v.tar.zst
+CurrentSymlink=/var/lib/bluefin-cli/homebrew-env.tar.zst

--- a/files/bluefin-cli/homebrew.nspawn
+++ b/files/bluefin-cli/homebrew.nspawn
@@ -1,0 +1,31 @@
+[Exec]
+# SECURITY NOTE: PrivateUsers=no means container root == host root.
+# This is intentional for Tier 1 (dev ergonomics, bind-mount compatibility),
+# but it means a container escape is a host-root event.
+#
+# PENDING DECISION: switch to PrivateUsers=pick + idmapped mounts for /home/linuxbrew
+# (kernel 5.12+ idmapped mount support; requires systemd-nspawn to apply id-remapping
+# to bind mounts, which is NOT currently handled by PrivateUsersOwnership=auto).
+# Until that is resolved, Tier 1 is NOT a hard security boundary. Document this honestly.
+PrivateUsers=no
+ResolvConf=bind-host
+
+# IMPORTANT — Homebrew 6 uses bubblewrap (bwrap) for formula sandboxing on Linux.
+# bubblewrap requires: clone3, mount, pivot_root, open_tree, move_mount, unshare.
+# Do NOT add @mount to SystemCallFilter deny list — it will silently break brew installs.
+# Test with: brew install hello  (source build, not just --version)
+DropCapability=CAP_SYS_ADMIN CAP_SYS_PTRACE CAP_NET_ADMIN CAP_SYS_RAWIO CAP_SYS_MODULE CAP_AUDIT_CONTROL
+SystemCallFilter=~@reboot @swap @obsolete
+NoNewPrivileges=yes
+
+[Files]
+# Brew prefix lives on the host and persists across container image updates.
+# Packages installed by the user are never lost when the container is re-imaged.
+Bind=/home/linuxbrew
+# Separate mount for cache/temp/locks — prevents btrfs CoW churn on hot-write dirs.
+# These dirs are ephemeral; losing them on update is fine.
+# Bind=/var/cache/bluefin-cli/homebrew-cache:/home/linuxbrew/.cache/Homebrew
+
+[Network]
+# Share host network stack — no virtual ethernet overhead.
+VirtualEthernet=no

--- a/files/just-overrides/bluefin-cli.just
+++ b/files/just-overrides/bluefin-cli.just
@@ -29,6 +29,8 @@ update-bluefin-cli:
     set -euo pipefail
     echo "Checking for bluefin-cli container updates..."
     systemd-sysupdate --component=bluefin-cli update
+    echo "Importing updated container image..."
+    importctl import-tar /var/lib/bluefin-cli/homebrew-env.tar.zst homebrew
     echo "Restarting container to apply update..."
     machinectl restart homebrew
 

--- a/files/just-overrides/bluefin-cli.just
+++ b/files/just-overrides/bluefin-cli.just
@@ -1,0 +1,67 @@
+# vim: set ft=make :
+
+# Initialize the Bluefin CLI developer container (first-time setup)
+[group('System')]
+setup-bluefin-cli:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if machinectl list-images --no-legend | grep -q "^homebrew\b"; then
+        echo "bluefin-cli container already installed."
+        machinectl status homebrew || true
+        exit 0
+    fi
+    echo "Pulling bluefin-cli container image..."
+    systemd-sysupdate --component=bluefin-cli update
+    echo "Importing container..."
+    importctl import-tar /var/lib/bluefin-cli/homebrew-env.tar.zst homebrew
+    if [ ! -d /home/linuxbrew/.linuxbrew ]; then
+        mkdir -p /home/linuxbrew
+        cp -a /var/lib/machines/homebrew/home/linuxbrew/.linuxbrew /home/linuxbrew/
+    fi
+    machinectl enable homebrew
+    machinectl start homebrew
+    echo "bluefin-cli ready. Try: brew install cowsay"
+
+# Update the Bluefin CLI container image (keeps your packages)
+[group('System')]
+update-bluefin-cli:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Checking for bluefin-cli container updates..."
+    systemd-sysupdate --component=bluefin-cli update
+    echo "Restarting container to apply update..."
+    machinectl restart homebrew
+
+# Open an interactive shell inside the bluefin-cli container
+[group('System')]
+bluefin-cli-shell:
+    machinectl shell linuxbrew@homebrew /bin/bash
+
+# Show status of the bluefin-cli container
+[group('System')]
+bluefin-cli-status:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "=== Container status ==="
+    machinectl status homebrew || echo "Container not running"
+    echo ""
+    echo "=== Brew packages ==="
+    brew list --versions 2>/dev/null | head -20 || echo "No packages installed yet"
+
+# Toggle between nspawn (fast) and VM (isolated) security tier
+[group('System')]
+bluefin-cli-security:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    NSPAWN_CONF=/etc/systemd/nspawn/homebrew.nspawn
+    if grep -q "VirtualizationMode" "$NSPAWN_CONF" 2>/dev/null; then
+        echo "Already configured for VM tier. To switch back to nspawn, re-run setup."
+        exit 1
+    fi
+    echo "Security tiers:"
+    echo "  1) nspawn (default) — namespace isolation, minimal overhead"
+    echo "  2) nspawn hardened  — nspawn + capability drop + syscall filter (default)"
+    echo "  3) Cloud Hypervisor — full VM isolation, kata-kernel (opt-in)"
+    echo ""
+    echo "Current tier is baked into /etc/systemd/nspawn/homebrew.nspawn"
+    echo "Tier 3 (VM) requires: ujust setup-bluefin-cli-vm"


### PR DESCRIPTION
Fixes multiple bugs in the bluefin-cli init flow and python-micro image.

1. Installs the transfer file to sysupdate.bluefin-cli.d to match --component=bluefin-cli
2. Changes Target Type to regular-file so importctl import-tar receives a tarball
3. Seeds the host /home/linuxbrew directory from the container before starting it
4. Converts python-micro-image.bst to a proper OCI build using oci-builder
5. Fixes concurrency group mismatch in execute-release.yml
6. Fixes update-filemap.yml CAS race by joining dakota-bst-build-global

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bluefin CLI setup, update, status, shell, and security-tier commands for managing the developer container.
  * Introduced packaged support for Bluefin CLI startup, container import, and a `brew` wrapper that runs commands inside the container.
  * Added smaller Python OCI image options for minimal and micro use cases.

* **Bug Fixes**
  * Improved container update handling so refreshed images are re-imported correctly before use.
  * Updated workflow concurrency settings to reduce unintended cancellation of in-progress runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->