### PR TITLE
Add snapd

### DIFF
--- a/elements/bluefin/bindmounts.bst
+++ b/elements/bluefin/bindmounts.bst
@@ -1,0 +1,24 @@
+kind: manual
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+sources:
+- kind: local
+  path: files/bindmounts/home.mount
+- kind: local
+  path: files/bindmounts/root.mount
+- kind: local
+  path: files/bindmounts/snap.mount
+
+config:
+  install-commands:
+  - |
+    install -Dm644 -t '%{install-root}%{indep-libdir}/systemd/system' {home,root,snap}.mount
+  - |
+    install -Dm755 -d '%{install-root}%{indep-libdir}/systemd/system/local-fs.target.wants'
+  - |
+    ln -s ../{home,root,snap}.mount '%{install-root}%{indep-libdir}/systemd/system/local-fs.target.wants/'

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -62,3 +62,7 @@ depends:
   - bluefin/distrobox.bst
   - gnome-build-meta.bst:gnomeos-deps/just.bst
   - gnome-build-meta.bst:gnomeos-deps/wl-clipboard.bst
+
+  - bluefin/bindmounts.bst
+
+  - gnome-build-meta.bst:gnomeos-deps/snapd.bst

--- a/elements/oci/layers/bluefin-stack.bst
+++ b/elements/oci/layers/bluefin-stack.bst
@@ -10,7 +10,7 @@ depends:
 
   - gnome-build-meta.bst:gnomeos-deps/bootc.bst
   - gnome-build-meta.bst:oci/integration/bootc-config.bst
-  - freedesktop-sdk.bst:vm/config/useradd-ostree.bst
+  - freedesktop-sdk.bst:vm/config/useradd-default.bst
   - freedesktop-sdk.bst:vm/config/sudo.bst
 
 public:
@@ -30,9 +30,9 @@ public:
       # Relative symlinks (var/home not /var/home) match zirconium-hawaii and
       # are safer in chroot/deploy tooling flows.
       - rm -rfv /home /root /opt /mnt /srv /var
+      # Mount points for bind mounts
+      - mkdir /home /root /snap
       - mkdir -p /var/home /var/roothome /var/opt /var/mnt /var/srv /var/tmp
-      - ln -s var/home /home
-      - ln -s var/roothome /root
       - ln -s var/opt /opt
       - ln -s var/mnt /mnt
       - ln -s var/srv /srv

--- a/files/bindmounts/home.mount
+++ b/files/bindmounts/home.mount
@@ -1,0 +1,8 @@
+[Unit]
+Description=Bind mount of /home
+
+[Mount]
+What=/var/home
+Where=/home
+Type=none
+Options=bind

--- a/files/bindmounts/root.mount
+++ b/files/bindmounts/root.mount
@@ -1,0 +1,8 @@
+[Unit]
+Description=Bind mount of /root
+
+[Mount]
+What=/var/roothome
+Where=/root
+Type=none
+Options=bind

--- a/files/bindmounts/snap.mount
+++ b/files/bindmounts/snap.mount
@@ -1,0 +1,8 @@
+[Unit]
+Description=Bind mount of /snap
+
+[Mount]
+What=/var/lib/snapd/snap
+Where=/snap
+Type=none
+Options=bind


### PR DESCRIPTION
## What problem are you solving?

I am adding snapd. Also moving /var/roothome and /var/home to /root and /home.

## Testing

- [*] `just validate` passes
- [ ] `just boot-test` passes (automated boot smoke test)
- [*] `just lint` passes on a built image
- [ ] `just boot-fast` or `just boot-vm` — desktop comes up, no regressions

I used qemu manually.

## Checklist

- [ ] New BST elements wired into `deps.bst`
- [ ] Patches in `patches/` regenerated if junction refs changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added systemd-driven bind mounts for `/home`, `/root`, and `/snap`, enabled for `local-fs.target` at startup.
* **Bug Fixes**
  * Improved early-boot filesystem initialization by creating the `/home`, `/root`, and `/snap` mount points before recreating the corresponding `/var/*` directories.
  * Removed the previous `/home` and `/root` symlink mapping so the bind mounts apply consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->