### PR TITLE
feat(zswap): transition from zram to optimized zswap configuration

### DIFF
--- a/docs/skills/buildstream.md
+++ b/docs/skills/buildstream.md
@@ -156,3 +156,19 @@ Do not cancel a build under 120 min just because it "seems slow." Historical ran
 ### Avoid /dev/stdin redirection in remote sandboxes (2026-07-25)
 
 BuildStream elements that write inline configuration files using `install -Dm644 /dev/stdin ... <<'EOF'` fail in remote execution sandboxes (like BuildBarn) where `/dev/stdin` is not available as a standard character device. Write inline files using a two-step pattern: create the destination file with `install -Dm644 /dev/null target`, then populate it with `cat > target <<'EOF'`.
+
+### overlap-whitelist required for base system file replacement
+
+When an element provides files that are also provided by an upstream junction component (for example, `/etc/subuid` and `/etc/subgid` provided by `freedesktop-sdk.bst:components/shadow.bst`), BuildStream will throw an overlap error during composition (e.g. in `bluefin-runtime.bst`).
+
+To explicitly overwrite these files, you must declare an overlap whitelist in the `public` block of the authoring element:
+
+```yaml
+public:
+  bst:
+    overlap-whitelist:
+    - '%{sysconfdir}/subuid'
+    - '%{sysconfdir}/subgid'
+```
+
+*Note: Replacing base system files destroys the base mappings. Whenever possible, prefer injecting changes dynamically via a hook (e.g., in `common.bst`) rather than completely replacing junction files.*

--- a/docs/skills/oci-layers.md
+++ b/docs/skills/oci-layers.md
@@ -185,3 +185,10 @@ Running `ldconfig` after `build-oci` has no effect. Running `build-oci` before `
 ### Force a new OCI layer digest via a tiny layer marker element (2026-07-05)
 
 When a remote CAS/object cache reuses the wrong content for a layer digest/size tuple, the safest fix is to change the layer contents in a targeted way instead of only changing workflow timeouts or element keys. A small manual element that installs a versioned marker file into the compose layer keeps the fix in the layer boundary and avoids turning the final OCI script into a broad rebuild path.
+
+### Stateless bootc configurations must reside in /usr (like /usr/lib/systemd/ and /usr/lib/bootc/kargs.d/) rather than /etc (2026-07-01)
+
+In a bootc/OSTree-based immutable OS like Dakota, `/etc` is mutable, user-owned, and must remain completely stateless. Baking default system configs into `/etc` at build time is an anti-pattern. Instead:
+1. **Disable ZRAM**: Override `zram-generator` by copying an empty `zram-generator.conf` to `/usr/lib/systemd/zram-generator.conf` (via `just-overrides.bst`) and whitelist it. Since this is in `/usr/lib`, it cleanly preempts the generator from creating devices without cluttering `/etc`.
+2. **Inject Bootc Kernel Arguments**: Install kargs TOML files directly under `/usr/lib/bootc/kargs.d/` (e.g. `/usr/lib/bootc/kargs.d/20-zswap.toml`). Bootc automatically reads these on switch/upgrade and applies them.
+3. **Vendor Sysctl parameters**: Store system defaults under `/usr/lib/sysctl.d/*.conf` (e.g. `60-swappiness.conf`) instead of `/etc/sysctl.conf`.

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -23,6 +23,7 @@ depends:
 
   - bluefin/common.bst
   - bluefin/just-overrides.bst
+  - bluefin/zswap-config.bst
   - bluefin/firstboot-date.bst
   - bluefin/firstboot-services.bst
   - bluefin/wallpaper-month.bst

--- a/elements/bluefin/just-overrides.bst
+++ b/elements/bluefin/just-overrides.bst
@@ -16,6 +16,7 @@ public:
     - /usr/share/ublue-os/just/default.just
     - /usr/share/ublue-os/just/changelog.just
     - /usr/share/ublue-os/just/system.just
+    - /usr/lib/systemd/zram-generator.conf
 
 config:
   install-commands:
@@ -23,4 +24,5 @@ config:
   - install -Dm644 changelog.just "%{install-root}/usr/share/ublue-os/just/changelog.just"
   - install -Dm644 system.just "%{install-root}/usr/share/ublue-os/just/system.just"
   - install -Dm644 flutter.just "%{install-root}/usr/share/ublue-os/just/flutter.just"
+  - install -Dm644 zram-generator.conf "%{install-root}%{prefix}/lib/systemd/zram-generator.conf"
   - "%{install-extra}"

--- a/elements/bluefin/zswap-config.bst
+++ b/elements/bluefin/zswap-config.bst
@@ -1,0 +1,33 @@
+kind: manual
+description: |
+  Declarative kernel arguments and sysctl parameters to enable and optimize zswap.
+
+  bootc applies the kernel arguments from /usr/lib/bootc/kargs.d/ on switch/upgrade.
+  The vm.swappiness=100 sysctl instructs the kernel to treat anonymous and file-backed
+  memory with parity, routing swap I/O through high-speed zswap cache.
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ''
+
+config:
+  install-commands:
+  - |
+    install -d "%{install-root}/usr/lib/bootc/kargs.d"
+    cat > "%{install-root}/usr/lib/bootc/kargs.d/20-zswap.toml" <<'EOF'
+    kargs = [
+        "zswap.enabled=1",
+        "zswap.compressor=zstd",
+        "zswap.zpool=zsmalloc",
+        "zswap.max_pool_percent=20",
+        "zswap.shrinker_enabled=1",
+    ]
+    EOF
+
+  - |
+    install -d "%{install-root}/usr/lib/sysctl.d"
+    cat > "%{install-root}/usr/lib/sysctl.d/60-swappiness.conf" <<'EOF'
+    vm.swappiness = 100
+    EOF

--- a/files/just-overrides/zram-generator.conf
+++ b/files/just-overrides/zram-generator.conf
@@ -1,0 +1,1 @@
+# Empty zram-generator config to disable automatic zram generation.


### PR DESCRIPTION
Transition Dakota from the inherited GNOME OS zram default to an optimized zswap architecture:

- **Stateless ZRAM Neutralization**: Deposited an empty `zram-generator.conf` into `/usr/lib/systemd/zram-generator.conf` (via `just-overrides.bst` with BuildStream overlap whitelist) to cleanly disable automatic zram generation while keeping `/etc` completely clean and stateless.
- **Bootc Kernel Arguments**: Created `elements/bluefin/zswap-config.bst` to write `/usr/lib/bootc/kargs.d/20-zswap.toml` containing optimized zswap parameters (`zswap.enabled=1`, `zswap.compressor=zstd`, `zswap.zpool=zsmalloc`, etc.) which bootc automatically reads and applies.
- **Sysctl Override**: Set `vm.swappiness = 100` under `/usr/lib/sysctl.d/60-swappiness.conf` to treat anonymous and file-backed memory with parity and route swap I/O through high-speed zswap.
- **Pipeline Integration**: Integrated `bluefin/zswap-config.bst` into `elements/bluefin/deps.bst`.
- **Lessons Learned**: Updated `docs/skills/oci-layers.md` with stateless bootc configuration conventions.

Verified with `just validate` which completed successfully with zero graph or junction errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added zswap tuning support via a new Bluefin element that installs boot-time kernel argument drop-ins and sysctl defaults.
* **Bug Fixes**
  * Disabled automatic zram generation by providing an intentionally empty zram-generator override and whitelisting the overlap overwrite.
* **Documentation**
  * Expanded lessons-learned guidance on BuildStream overlap handling (including overlap whitelists) and clarified stateless configuration placement rules under `/usr` for bootc kargs, zram, and sysctl.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->