### PR TITLE
fix(ujust): harden confirm and verify issue recipes

### DIFF
--- a/.github/skills/ujust-recipes.md
+++ b/.github/skills/ujust-recipes.md
@@ -140,7 +140,7 @@ The digest lives under `.image`, not on the boot entry (the old
 `.status.booted.imageDigest` path never existed — it always rendered
 "unknown" through jq's `// "unknown"` fallback):
 
-```
+```text
 .status.booted.image.image.image    # image ref
 .status.booted.image.version        # version (may be null)
 .status.booted.image.imageDigest    # digest

--- a/.github/skills/ujust-recipes.md
+++ b/.github/skills/ujust-recipes.md
@@ -101,6 +101,75 @@ spinner messages and flavor text.
 
 ---
 
+## Recipe arguments must go through quote()
+
+just interpolates `{{param}}` textually into the recipe's script source, so
+`ISSUE="{{param}}"` lets an argument containing `"` break out of the quoting
+and execute before any shell validation runs. Always interpolate with the
+builtin `quote()`, then validate in bash:
+
+```bash
+ISSUE={{ quote(issue_number) }}
+if [[ ! "$ISSUE" =~ ^[1-9][0-9]*$ ]]; then
+    echo "usage..." >&2; exit 1
+fi
+```
+
+Do NOT use `set positional-arguments` for this — the file is merged into the
+system-wide ublue justfile and the setting would change every recipe.
+
+---
+
+## $(printf ...) strips trailing newlines — markdown tables collapse
+
+Command substitution strips trailing newlines, so building multi-line strings
+with `VAR+=$(printf '...\n')` silently glues rows together: a GitHub comment
+table posts as one mangled line. Append the newline outside the substitution
+(or use a `$'...'` literal for constant lines):
+
+```bash
+COMMENT+=$'| Field | Value |\n|-------|-------|\n'      # constant rows
+COMMENT+=$(printf '| Image | `%s` |' "$IMG")$'\n'       # substituted rows
+```
+
+---
+
+## bootc status --json field paths
+
+The digest lives under `.image`, not on the boot entry (the old
+`.status.booted.imageDigest` path never existed — it always rendered
+"unknown" through jq's `// "unknown"` fallback):
+
+```
+.status.booted.image.image.image    # image ref
+.status.booted.image.version        # version (may be null)
+.status.booted.image.imageDigest    # digest
+```
+
+`bootc status` requires root. In anything that may run without a tty, use
+`sudo -n ... || fallback` so it can never hang on a password prompt.
+
+---
+
+## Recipes that post publicly must fail closed without a tty
+
+`gum confirm` fails when stdin is not a tty; under `set -e` patterns that can
+either abort the recipe or (worse) be "handled" into auto-posting. Detect the
+tty once and require explicit opt-in for scripted use instead of silently
+publishing:
+
+```bash
+INTERACTIVE=0
+[[ -t 0 ]] && INTERACTIVE=1
+# non-tty: post only when the caller passed an explicit "yes" argument
+```
+
+Related: `wl-copy` forks and lingers to serve the clipboard — a scripted
+caller capturing the recipe's output hangs on the open pipe. Only invoke
+clipboard tools when interactive.
+
+---
+
 ## jq -n for JSON file generation in just recipes
 
 When a just recipe needs to write a JSON file, use `jq -n` instead of a

--- a/files/just-overrides/default.just
+++ b/files/just-overrides/default.just
@@ -258,6 +258,13 @@ verify issue_number:
         exit 1
     fi
 
+    # Verify asks for a verdict, so it cannot run scripted; fail fast instead
+    # of dying at the gum prompt or hanging on a sudo password read.
+    if [[ ! -t 0 ]]; then
+        echo "❌ ujust verify is interactive and requires a terminal." >&2
+        exit 1
+    fi
+
     echo "🔍 Verifying fix for issue #${ISSUE}..."
     echo ""
 
@@ -302,7 +309,8 @@ verify issue_number:
     # Collect system context
     BOOTC_JSON=$(sudo bootc status --json 2>/dev/null || echo '{}')
     BOOTED_IMAGE=$(echo "$BOOTC_JSON" | jq -r '.status.booted.image.image.image // "unknown"')
-    BOOTED_DIGEST=$(echo "$BOOTC_JSON" | jq -r '.status.booted.imageDigest // "unknown"')
+    BOOTED_VERSION=$(echo "$BOOTC_JSON" | jq -r '.status.booted.image.version // "unknown"')
+    BOOTED_DIGEST=$(echo "$BOOTC_JSON" | jq -r '.status.booted.image.imageDigest // "unknown"')
     KERNEL_VER=$(uname -r)
     ARCH=$(uname -m)
 
@@ -322,18 +330,21 @@ verify issue_number:
         fi
     fi
 
-    # Build the verification comment
-    COMMENT=$(printf '### %s Verification: **%s**\n\n' "$EMOJI" "$RESULT")
-    COMMENT+=$(printf '| Field | Value |\n|-------|-------|\n')
-    COMMENT+=$(printf '| Image | `%s` |\n' "$BOOTED_IMAGE")
-    COMMENT+=$(printf '| Digest | `%s` |\n' "$BOOTED_DIGEST")
-    COMMENT+=$(printf '| Kernel | `%s` |\n' "$KERNEL_VER")
-    COMMENT+=$(printf '| Arch | `%s` |\n' "$ARCH")
-    COMMENT+=$(printf '| Device ID | `%s` |\n' "$HOST_ID")
+    # Build the verification comment. $(...) strips trailing newlines, so
+    # each row's newline is appended outside the substitution or the table
+    # collapses.
+    COMMENT=$(printf '### %s Verification: **%s**' "$EMOJI" "$RESULT")$'\n\n'
+    COMMENT+=$'| Field | Value |\n|-------|-------|\n'
+    COMMENT+=$(printf '| Image | `%s` |' "$BOOTED_IMAGE")$'\n'
+    COMMENT+=$(printf '| Version | `%s` |' "$BOOTED_VERSION")$'\n'
+    COMMENT+=$(printf '| Digest | `%s` |' "$BOOTED_DIGEST")$'\n'
+    COMMENT+=$(printf '| Kernel | `%s` |' "$KERNEL_VER")$'\n'
+    COMMENT+=$(printf '| Arch | `%s` |' "$ARCH")$'\n'
+    COMMENT+=$(printf '| Device ID | `%s` |' "$HOST_ID")$'\n'
     if [[ -n "$JOURNAL_SNIPPET" ]]; then
-        COMMENT+=$(printf '\n<details><summary>Journal (errors, last 50 lines)</summary>\n\n```\n%s\n```\n</details>\n' "$JOURNAL_SNIPPET")
+        COMMENT+=$(printf '\n<details><summary>Journal (errors, last 50 lines)</summary>\n\n```\n%s\n```\n</details>' "$JOURNAL_SNIPPET")$'\n'
     fi
-    COMMENT+=$(printf '\n_Submitted via `ujust verify %s`_\n' "$ISSUE")
+    COMMENT+=$(printf '\n_Submitted via `ujust verify %s`_' "$ISSUE")$'\n'
 
     # Show user what will be posted
     echo ""
@@ -346,11 +357,17 @@ verify issue_number:
     fi
 
     if gh auth status --active &>/dev/null; then
-        gh issue comment "$ISSUE" --repo "$REPO" --body "$COMMENT"
-        echo ""
-        echo "✅ Verification posted on issue #${ISSUE}"
-        echo ""
-        echo "Thank you for helping confirm whether this fix works!"
+        if COMMENT_URL=$(gh issue comment "$ISSUE" --repo "$REPO" --body "$COMMENT"); then
+            echo ""
+            echo "✅ Verification posted: ${COMMENT_URL:-https://github.com/${REPO}/issues/${ISSUE}}"
+            echo ""
+            echo "Thank you for helping confirm whether this fix works!"
+        else
+            echo "" >&2
+            echo "❌ Posting failed. Copy the text above and paste it as a comment on:" >&2
+            echo "  https://github.com/${REPO}/issues/${ISSUE}" >&2
+            exit 1
+        fi
     else
         echo ""
         if command -v wl-copy &>/dev/null; then

--- a/files/just-overrides/default.just
+++ b/files/just-overrides/default.just
@@ -154,17 +154,24 @@ file-issue:
     xdg-open "$URL" 2>/dev/null || echo "Could not open browser. Visit: $URL"
 
 # Confirm you also experience an issue ("me too" with system context).
-# Usage: ujust confirm 531
-confirm issue_number:
+# Usage: ujust confirm 531        (prompts before posting)
+#        ujust confirm 531 yes    (scripted use: posts without prompting)
+confirm issue_number yes="":
     #!/usr/bin/bash
     set -euo pipefail
 
     ISSUE={{ quote(issue_number) }}
+    ASSUME_YES={{ quote(yes) }}
     REPO="projectbluefin/dakota"
 
     if [[ ! "$ISSUE" =~ ^[1-9][0-9]*$ ]]; then
         echo "❌ '${ISSUE}' is not a valid issue number (expected a positive integer)." >&2
-        echo "Usage: ujust confirm <issue-number>   e.g. ujust confirm 531" >&2
+        echo "Usage: ujust confirm <issue-number> [yes]   e.g. ujust confirm 531" >&2
+        exit 1
+    fi
+    if [[ -n "$ASSUME_YES" && "$ASSUME_YES" != "yes" ]]; then
+        echo "❌ Unrecognized argument '${ASSUME_YES}' (only 'yes' is accepted)." >&2
+        echo "Usage: ujust confirm <issue-number> [yes]   e.g. ujust confirm 531 yes" >&2
         exit 1
     fi
 
@@ -215,19 +222,30 @@ confirm issue_number:
     echo "$COMMENT"
     echo ""
 
-    if (( INTERACTIVE )); then
-        if ! gum confirm "Post this as a comment on issue #${ISSUE}?"; then
-            echo "Cancelled."
-            exit 0
+    if [[ "$ASSUME_YES" != "yes" ]]; then
+        if (( INTERACTIVE )); then
+            if ! gum confirm "Post this as a comment on issue #${ISSUE}?"; then
+                echo "Cancelled."
+                exit 0
+            fi
+        else
+            # Fail closed: never publish without explicit consent.
+            echo "ℹ️  Not posting: stdin is not a terminal and 'yes' was not passed." >&2
+            echo "    To post from a script: ujust confirm ${ISSUE} yes" >&2
+            exit 1
         fi
-    else
-        echo "ℹ️  Non-interactive session — posting without confirmation prompt."
     fi
 
     if gh auth status --active &>/dev/null; then
-        COMMENT_URL=$(gh issue comment "$ISSUE" --repo "$REPO" --body "$COMMENT")
-        echo ""
-        echo "✅ Confirmation posted: ${COMMENT_URL:-https://github.com/${REPO}/issues/${ISSUE}}"
+        if COMMENT_URL=$(gh issue comment "$ISSUE" --repo "$REPO" --body "$COMMENT"); then
+            echo ""
+            echo "✅ Confirmation posted: ${COMMENT_URL:-https://github.com/${REPO}/issues/${ISSUE}}"
+        else
+            echo "" >&2
+            echo "❌ Posting failed. Copy the text above and paste it as a comment on:" >&2
+            echo "  https://github.com/${REPO}/issues/${ISSUE}" >&2
+            exit 1
+        fi
     else
         echo ""
         # Clipboard only makes sense interactively; wl-copy also lingers to
@@ -241,6 +259,8 @@ confirm issue_number:
         echo "  https://github.com/${REPO}/issues/${ISSUE}"
         echo ""
         echo "Or authenticate gh first: gh auth login"
+        # Scripted callers must be able to detect that nothing was posted.
+        (( INTERACTIVE )) || exit 1
     fi
 
 # Verify that a fix works on your hardware after upgrading.

--- a/files/just-overrides/default.just
+++ b/files/just-overrides/default.just
@@ -159,20 +159,35 @@ confirm issue_number:
     #!/usr/bin/bash
     set -euo pipefail
 
-    ISSUE="{{issue_number}}"
+    ISSUE={{ quote(issue_number) }}
     REPO="projectbluefin/dakota"
+
+    if [[ ! "$ISSUE" =~ ^[1-9][0-9]*$ ]]; then
+        echo "❌ '${ISSUE}' is not a valid issue number (expected a positive integer)." >&2
+        echo "Usage: ujust confirm <issue-number>   e.g. ujust confirm 531" >&2
+        exit 1
+    fi
+
+    INTERACTIVE=0
+    [[ -t 0 ]] && INTERACTIVE=1
 
     echo "📋 Confirming you also experience issue #${ISSUE}..."
     echo ""
 
     # Collect lightweight system fingerprint
-    BOOTC_JSON=$(sudo bootc status --json 2>/dev/null || echo '{}')
+    if (( INTERACTIVE )); then
+        BOOTC_JSON=$(sudo bootc status --json 2>/dev/null || echo '{}')
+    else
+        # Never hang on a sudo password prompt when scripted
+        BOOTC_JSON=$(sudo -n bootc status --json 2>/dev/null || bootc status --json 2>/dev/null || echo '{}')
+    fi
     BOOTED_IMAGE=$(echo "$BOOTC_JSON" | jq -r '.status.booted.image.image.image // "unknown"')
-    BOOTED_DIGEST=$(echo "$BOOTC_JSON" | jq -r '.status.booted.imageDigest // "unknown"')
+    BOOTED_VERSION=$(echo "$BOOTC_JSON" | jq -r '.status.booted.image.version // "unknown"')
+    BOOTED_DIGEST=$(echo "$BOOTC_JSON" | jq -r '.status.booted.image.imageDigest // "unknown"')
     KERNEL_VER=$(uname -r)
     ARCH=$(uname -m)
     FAILED_UNITS=$(systemctl list-units --state=failed --no-legend --plain 2>/dev/null \
-                   | awk '{print $1}' | head -10 || echo "")
+                   | awk 'NR<=10 {print $1}' || echo "")
 
     if [[ -r /etc/machine-id ]]; then
         HOST_ID=$(printf 'ujust-confirm:%s' "$(cat /etc/machine-id)" | sha256sum | cut -c1-8)
@@ -180,37 +195,44 @@ confirm issue_number:
         HOST_ID="unknown"
     fi
 
-    # Build the comment
-    COMMENT=$(printf '### ✋ I also experience this issue\n\n')
-    COMMENT+=$(printf '| Field | Value |\n|-------|-------|\n')
-    COMMENT+=$(printf '| Image | `%s` |\n' "$BOOTED_IMAGE")
-    COMMENT+=$(printf '| Digest | `%s` |\n' "$BOOTED_DIGEST")
-    COMMENT+=$(printf '| Kernel | `%s` |\n' "$KERNEL_VER")
-    COMMENT+=$(printf '| Arch | `%s` |\n' "$ARCH")
-    COMMENT+=$(printf '| Device ID | `%s` |\n' "$HOST_ID")
+    # Build the comment. $(...) strips trailing newlines, so each row's
+    # newline is appended outside the substitution or the table collapses.
+    COMMENT=$'### ✋ I also experience this issue\n\n'
+    COMMENT+=$'| Field | Value |\n|-------|-------|\n'
+    COMMENT+=$(printf '| Image | `%s` |' "$BOOTED_IMAGE")$'\n'
+    COMMENT+=$(printf '| Version | `%s` |' "$BOOTED_VERSION")$'\n'
+    COMMENT+=$(printf '| Digest | `%s` |' "$BOOTED_DIGEST")$'\n'
+    COMMENT+=$(printf '| Kernel | `%s` |' "$KERNEL_VER")$'\n'
+    COMMENT+=$(printf '| Arch | `%s` |' "$ARCH")$'\n'
+    COMMENT+=$(printf '| Device ID | `%s` |' "$HOST_ID")$'\n'
     if [[ -n "$FAILED_UNITS" ]]; then
-        COMMENT+=$(printf '\n**Failed units:** ')
-        COMMENT+=$(echo "$FAILED_UNITS" | tr '\n' ',' | sed 's/,$//')
-        COMMENT+=$(printf '\n')
+        COMMENT+=$'\n**Failed units:** '
+        COMMENT+=$(echo "$FAILED_UNITS" | tr '\n' ',' | sed 's/,$//')$'\n'
     fi
-    COMMENT+=$(printf '\n_Submitted via `ujust confirm %s`_\n' "$ISSUE")
+    COMMENT+=$(printf '\n_Submitted via `ujust confirm %s`_' "$ISSUE")$'\n'
 
-    # Show user what will be posted
+    # Show user what will be posted (always — no silent uploads)
     echo "$COMMENT"
     echo ""
 
-    if ! gum confirm "Post this as a comment on issue #${ISSUE}?"; then
-        echo "Cancelled."
-        exit 0
+    if (( INTERACTIVE )); then
+        if ! gum confirm "Post this as a comment on issue #${ISSUE}?"; then
+            echo "Cancelled."
+            exit 0
+        fi
+    else
+        echo "ℹ️  Non-interactive session — posting without confirmation prompt."
     fi
 
     if gh auth status --active &>/dev/null; then
-        gh issue comment "$ISSUE" --repo "$REPO" --body "$COMMENT"
+        COMMENT_URL=$(gh issue comment "$ISSUE" --repo "$REPO" --body "$COMMENT")
         echo ""
-        echo "✅ Confirmation posted on issue #${ISSUE}"
+        echo "✅ Confirmation posted: ${COMMENT_URL:-https://github.com/${REPO}/issues/${ISSUE}}"
     else
         echo ""
-        if command -v wl-copy &>/dev/null; then
+        # Clipboard only makes sense interactively; wl-copy also lingers to
+        # serve the clipboard, which would hang scripted callers.
+        if (( INTERACTIVE )) && command -v wl-copy &>/dev/null; then
             printf '%s' "$COMMENT" | wl-copy
             echo "📋 Copied to clipboard! Paste it as a comment on:"
         else
@@ -227,8 +249,14 @@ verify issue_number:
     #!/usr/bin/bash
     set -euo pipefail
 
-    ISSUE="{{issue_number}}"
+    ISSUE={{ quote(issue_number) }}
     REPO="projectbluefin/dakota"
+
+    if [[ ! "$ISSUE" =~ ^[1-9][0-9]*$ ]]; then
+        echo "❌ '${ISSUE}' is not a valid issue number (expected a positive integer)." >&2
+        echo "Usage: ujust verify <issue-number>   e.g. ujust verify 531" >&2
+        exit 1
+    fi
 
     echo "🔍 Verifying fix for issue #${ISSUE}..."
     echo ""


### PR DESCRIPTION
Closes #579.

The `report --confirm` mode #579 specified was superseded: the `report` recipe moved to projectbluefin/common in #845, and dakota's `ujust confirm` already implements the me-too flow. This brings `confirm` (and its sibling `verify`) up to #579's acceptance criteria and fixes latent bugs found on the way.

- **Input validation**: issue number validated as a positive integer; arguments interpolated via just's `quote()` so hostile values cannot break out of the recipe source or inject gh flags (both recipes)
- **Scripted use**: `ujust confirm 531 yes` posts without a tty; without `yes` it fails closed — prints the comment and exits 1, never silently publishes. `sudo -n` with fallbacks so it cannot hang on a password prompt; wl-copy only runs interactively (it lingers to serve the clipboard and hangs scripted callers)
- **verify** fails fast without a terminal (it needs a verdict prompt) instead of dying at the gum prompt
- **Fingerprint**: adds the image Version row; fixes the digest jq path — `.status.booted.imageDigest` does not exist in the bootc schema (`.status.booted.image.imageDigest` does), so Digest always rendered "unknown"
- **Comment rendering**: `$(printf)` strips trailing newlines, so posted markdown tables collapsed onto one garbled line; rows now get their newline outside the substitution
- **Posting**: success prints the comment URL; a failed gh post falls back to paste instructions and exits non-zero instead of aborting with raw stderr
- **docs**: recorded the discovered pitfalls in `.github/skills/ujust-recipes.md` per the skill mandate

## Verification

- `just validate` passes; recipes parse (`just -f files/just-overrides/default.just --list`)
- Exercised the recipes on a Bluefin system with a stub `gh` on PATH (no real posts): injection payloads arrive single-quoted and inert; `abc`, `0`, `007`, `$(...)`, and stray flags all exit 1; non-tty without `yes` exits 1 and does not post; with `yes` it posts and prints the URL; a locked-issue gh failure falls back with exit 1; the unauthenticated path suggests `gh auth login`; `verify` without a tty fails fast
- Note: the confirm comment gains a Version row. docs/workflow.md says confirms are counted by the `ujust confirm` substring, which is unchanged — flagging in case the external counter matches on table shape instead

**Question for maintainers**: report/confirm/verify salt the anonymous device ID differently (`ujust-report:` / `ujust-confirm:` / `ujust-verify:`), so one machine gets three uncorrelatable IDs. Deliberate unlinkability, or worth unifying in a follow-up?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2Trae2Hqpuc436f4T1Chj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `ujust confirm`/`ujust verify` with an optional explicit approval for non-interactive runs.
* **Bug Fixes**
  * Added stricter `issue_number` validation and terminal detection (fails closed when required).
  * Reduced risks of scripted hangs by querying system status more safely.
  * Hardened GitHub commenting with clearer success/failure messaging, captured comment URLs, and non-zero exits on failure.
* **Documentation**
  * Expanded “ujust Recipe Authoring — Lessons Learned” with safer quoting/interpolation patterns, newline/command-substitution guidance, and corrected `bootc status --json` field usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->