### PR TITLE
fix(ci): align scorecard push trigger with default branch

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,7 +9,7 @@ on:
   schedule:
     - cron: '17 9 * * 1'
   push:
-    branches: ["main"]
+    branches: ["testing"]
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/docs/skills/ci-tooling.md
+++ b/docs/skills/ci-tooling.md
@@ -377,6 +377,19 @@ If a reusable automerge workflow matches PRs by `head_sha`, it must listen to th
 
 **Symptom:** open dependency PRs stay mergeable and green but never get `autoMergeRequest` set.
 
+## Lessons Learned
+
+### Scorecard push trigger must target the actual default branch (2026-07-03)
+
+`ossf/scorecard-action` validates default-branch-only behavior for checks like
+`Branch-Protection` and fails with `validating options: only default branch is
+supported` if the workflow's `push.branches` points at a non-default branch.
+Dakota's GitHub default branch is `testing`, not `main`, so
+`.github/workflows/scorecard.yml` must use `push.branches: [testing]`.
+
+Keep the weekly `schedule` trigger (`17 9 * * 1`) intact for the `Maintained`
+check; only retarget the push branch filter to the actual default branch.
+
 ## Red Flags
 
 - `permissions: {}` on a reusable workflow caller


### PR DESCRIPTION
## Problem

`Scorecard supply-chain security` has been failing on every `push` to `main`:

```
2026/06/30 03:37:30 validating options: only default branch is supported
```

`ossf/scorecard-action` requires its checks (e.g. Branch-Protection) to run only against the repository's actual GitHub default branch. Dakota's default branch is `testing`, not `main`, so the workflow's `push: branches: ["main"]` trigger never validates.

## Fix

Retarget the push trigger to the real default branch:

```diff
   push:
-    branches: ["main"]
+    branches: ["testing"]
```

The weekly `schedule` trigger (`cron: '17 9 * * 1'`, Mondays 09:17 UTC) is unchanged and already runs successfully — this PR does not affect the weekly cadence, it only fixes the broken push-triggered runs.

## Verification

- Confirmed via `gh run list` that recent `push` runs (main) failed with the validation error above, while `schedule` runs succeeded.
- Confirmed `gh repo view projectbluefin/dakota --json defaultBranchRef` returns `testing`.
- Added a skill note to `docs/skills/ci-tooling.md` documenting this constraint for future workflows using default-branch-only GitHub Actions.
- CI pre-flight checked before push: no BST-competing workflow is triggered by this PR (`build.yml` only fires on `schedule`/`workflow_dispatch`; this PR only runs the lightweight `Validate` workflow).

## Checklist

- [ ] I am using an agent and I take responsibility for this PR

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a CI/security workflow trigger to use the repository’s current default branch.
* **Documentation**
  * Added guidance on a known Scorecard setup requirement and noted the correct branch to use for maintaining the check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->