### PR TITLE
fix(ci): align standard builds with upstream caches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Pull prebuilt artifacts from remote CAS
         env:
-          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
+          BST_FLAGS: -o x86_64_v3 false --no-interactive --config /src/buildstream-ci.conf
         run: |
           just bst artifact pull --deps all ${{ matrix.element }}
         timeout-minutes: 15
@@ -100,7 +100,7 @@ jobs:
       - name: Count elements for progress tracking
         id: count
         env:
-          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
+          BST_FLAGS: -o x86_64_v3 false --no-interactive --config /src/buildstream-ci.conf
         run: |
           set +e
           BST_SHOW_OUT=$(just bst show --deps all --format "%{name}" \
@@ -119,7 +119,7 @@ jobs:
 
       - name: Build OCI image with BuildStream
         env:
-          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
+          BST_FLAGS: -o x86_64_v3 false --no-interactive --config /src/buildstream-ci.conf
           ELEMENT_TOTAL: ${{ steps.count.outputs.total }}
         run: |
           set -o pipefail
@@ -129,7 +129,7 @@ jobs:
 
       - name: Push OCI artifact to remote CAS
         env:
-          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-push.conf
+          BST_FLAGS: -o x86_64_v3 false --no-interactive --config /src/buildstream-push.conf
         run: |
           just bst artifact push --deps run ${{ matrix.element }}
         timeout-minutes: 30

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Export OCI image from BuildStream
         id: export
         env:
-          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
+          BST_FLAGS: -o x86_64_v3 false --no-interactive --config /src/buildstream-ci.conf
           BUILD_IMAGE_NAME: ${{ env.IMAGE_NAME }}
           OCI_IMAGE_CREATED: ${{ steps.timestamp.outputs.created }}
           OCI_IMAGE_REVISION: ${{ needs.setup.outputs.sha }}
@@ -277,7 +277,7 @@ jobs:
 
       - name: Generate SBOM
         env:
-          BST_FLAGS: -o x86_64_v3 true --no-interactive --config /src/buildstream-ci.conf
+          BST_FLAGS: -o x86_64_v3 false --no-interactive --config /src/buildstream-ci.conf
         run: just sbom ${{ matrix.variant }}
 
       - name: Upload SBOM artifact for release workflow

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -50,10 +50,10 @@ jobs:
 
       - name: Validate BST element graph (default)
         env:
-          BST_FLAGS: -o x86_64_v3 true --no-interactive
+          BST_FLAGS: -o x86_64_v3 false --no-interactive
         run: just bst show --deps all oci/bluefin.bst
 
       - name: Validate BST element graph (nvidia)
         env:
-          BST_FLAGS: -o x86_64_v3 true --no-interactive
+          BST_FLAGS: -o x86_64_v3 false --no-interactive
         run: just bst show --deps all oci/bluefin-nvidia.bst

--- a/Justfile
+++ b/Justfile
@@ -24,7 +24,8 @@ export OCI_IMAGE_VERSION := env("OCI_IMAGE_VERSION", "latest")
 
 # ── BuildStream wrapper ──────────────────────────────────────────────
 # Runs any bst command inside the bst2 container via podman.
-# Defaults to `-o x86_64_v3 true --no-interactive` so local runs match CI.
+# Defaults to baseline x86_64 (`-o x86_64_v3 false`) so local runs match CI
+# and reuse artifacts published by gnome-build-meta and freedesktop-sdk.
 # Set BST_FLAGS to append flags (e.g. --config ...).
 # Set BST_FLAGS_OVERRIDE to replace all default/appended flags.
 # Usage: just bst build oci/bluefin.bst
@@ -35,12 +36,12 @@ bst *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p "${HOME}/.cache/buildstream"
-    DEFAULT_BST_FLAGS="-o x86_64_v3 true --no-interactive"
+    DEFAULT_BST_FLAGS="-o x86_64_v3 false --no-interactive"
     if [ -n "${BST_FLAGS_OVERRIDE:-}" ]; then
         EFFECTIVE_BST_FLAGS="${BST_FLAGS_OVERRIDE}"
     else
         EFFECTIVE_BST_FLAGS="${BST_FLAGS:-}"
-        if [[ ! " ${EFFECTIVE_BST_FLAGS} " =~ [[:space:]]-o[[:space:]]+x86_64_v3[[:space:]]+true([[:space:]]|$) ]]; then
+        if [[ ! " ${EFFECTIVE_BST_FLAGS} " =~ [[:space:]]-o[[:space:]]+x86_64_v3[[:space:]]+(true|false)([[:space:]]|$) ]]; then
             EFFECTIVE_BST_FLAGS="${DEFAULT_BST_FLAGS} ${EFFECTIVE_BST_FLAGS}"
         fi
         if [[ ! " ${EFFECTIVE_BST_FLAGS} " =~ [[:space:]]--no-interactive([[:space:]]|$) ]]; then

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -305,6 +305,24 @@ gh run list --repo projectbluefin/dakota --limit 5
 
 > **Note:** Lessons are ordered newest-first. Deleted CI paths are historical evidence only; do not recreate them.
 
+### Architecture options must match upstream artifact producers (2026-07-13)
+
+BuildStream project options participate in artifact cache keys. Passing
+`-o x86_64_v3 true` to an otherwise upstream-aligned graph therefore cannot
+reuse baseline x86-64 artifacts published by GNOME Build Meta or
+freedesktop-sdk. Historical Dakota v3 successes depended on warm artifacts in
+`cache.projectbluefin.io`, not the upstream caches: the June 30 default build
+pulled 810 artifacts from the project cache, while identical sampled v3 keys
+were absent from every remote by July 13. Direct probes of `gettext`, `expat`,
+and `startup-notification` found each v3 key missing and each baseline key
+available. A full baseline pull produced 978 cached elements out of the 1,077
+element default graph, compared with 73 remote hits in the failed v3 CI run.
+
+Keep the standard local, build, validation, export, push, and SBOM paths on
+`-o x86_64_v3 false`. The project option remains available for an explicit
+local opt-in, but an opt-in v3 build must expect to compile and maintain its own
+architecture-specific artifacts rather than relying on upstream cache reuse.
+
 ### Breaking Cold-Cache Starvation Loops via Temporary Timeout Extension (2026-07-13)
 
 **The Failure Pattern (Cold-Cache Starvation):** When local patches or junction modifications (such as necessary changes to `freedesktop-sdk.bst`) intentionally alter build configuration or bootstrap elements, they inevitably change the cache keys for downstream elements. On the next CI run, a massive cache miss is triggered. Because strict protective step/job timeouts (like 30m/45m) are in place, the GHA runner begins compiling the uncached elements from source but gets aborted before completion. Because the step is cancelled, the `Push OCI artifact to remote CAS` step is never reached. Consequently, the remote CAS remains cold, and every subsequent CI run is doomed to hit the exact same timeout, resulting in a permanent cold-cache starvation loop.


### PR DESCRIPTION
## What problem are you solving?

Dakota's standard x86_64 build selected x86-64-v3, producing artifact keys that are absent from the GNOME Build Meta and freedesktop-sdk caches. This left normal builds dependent on a fragile private cache and forced large source rebuilds when those artifacts disappeared.

- [x] I am using an agent and I take responsibility for this PR

---

## Changes

- Use baseline x86-64 for standard local and CI BuildStream operations.
- Keep x86-64-v3 available through an explicit `-o x86_64_v3 true` override.
- Keep build, validation, artifact push, export, and SBOM options consistent.
- Document the architecture-specific cache-key behavior and measured cache coverage.

## Testing

- [x] `just validate` passes
- [ ] `just boot-test` passes (automated boot smoke test)
- [ ] `just lint` passes on a built image — local invocation requires interactive sudo and no built `dakota:latest` image was available
- [ ] `just boot-fast` or `just boot-vm` — desktop comes up, no regressions

Additional evidence:

- `just check-publish-workflow` passes.
- Both default and NVIDIA BuildStream graphs resolve.
- Baseline artifact pull completed successfully: 676 newly pulled; 978/1,077 elements cached locally after the pull.
- The failed v3 CI run found only 73/1,077 dependencies remotely available.
- `git diff --check` passes.

## Checklist

- [x] New BST elements wired into `deps.bst` — not applicable; no elements added
- [x] Patches in `patches/` regenerated if junction refs changed — not applicable; no junction or patch changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build and Release Improvements**
  * Updated automated build, validation, publishing, and image workflows to use the standard x86-64 configuration by default.
  * Improved reuse of existing build artifacts, helping reduce cache misses, cold builds, and timeout risk.
  * Advanced x86-64-v3 builds remain available as an explicit opt-in configuration.

* **Documentation**
  * Added guidance explaining architecture-specific cache behavior and requirements for maintaining optimized build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->