### PR TITLE
fix(bluefin): declare libgtop explicitly for GTop-2.0 typelib

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -45,6 +45,10 @@ depends:
   # Include things missing from the gnomeos base image
   - gnome-build-meta.bst:core-deps/fwupd.bst
 
+  # system-monitor shell extension needs GTop-2.0.typelib; only reaches the image
+  # transitively via gnome-control-center otherwise (projectbluefin/dakota#1163)
+  - gnome-build-meta.bst:core-deps/libgtop.bst
+
   - freedesktop-sdk.bst:components/buildstream2.bst
   - freedesktop-sdk.bst:components/containers-common.bst
   - freedesktop-sdk.bst:components/debuginfod.bst


### PR DESCRIPTION
## Summary

Hardens against the system-monitor Shell extension losing its `GTop-2.0.typelib` (#1163). The typelib currently reaches the image only transitively: `gnomeos-deps/deps.bst -> meta-gnome-core-shell -> gnome-control-center -> core-deps/libgtop`. Nothing in Dakota's own element graph declares it, so any upstream refactor that drops libgtop from gnome-control-center's dependencies (or drops gnome-control-center from the core-shell meta) would silently remove the typelib and break the extension.

Adds `gnome-build-meta.bst:core-deps/libgtop.bst` explicitly to `bluefin/deps.bst` with a comment stating the constraint. The full transitive chain is documented in the commit body.

Verified: `bst show` resolves the junction element and the full default-variant image build passes. The typelib already ships today via the transitive chain; this change only pins it, so it cannot regress anything. This is preventive hardening rather than a repair, the issue itself is pending reporter info (likely a stale image), hence Related rather than Fixes.

Related: projectbluefin/dakota#1163
