### PR TITLE
fix(bluefin): ship VTE typelibs for GTK3 GI consumers

### DIFF
--- a/docs/skills/add-package.md
+++ b/docs/skills/add-package.md
@@ -158,3 +158,18 @@ variables:
 ```
 
 External dep: `freedesktop-sdk.bst:components/sndfile.bst`. No external LV2 headers needed — bundled.
+
+### Dropping upstream apps silently drops their transitive libs/typelibs (2026-07-19)
+
+`core/meta-gnome-core-apps.bst` is overridden to a short allow-list, so any library
+pulled *only* by a dropped app never enters the image. This is invisible until a GI
+consumer fails to bind it. Example: dakota#1022 — gnome-console/builder/foundry were
+the only pullers of gnome-build-meta's `core-deps/vte.bst`, so the image shipped **zero**
+VTE typelibs and the user-installed ddterm extension (GTK3 ABI, `Vte-2.91`) could not load.
+
+Fix pattern: add a dedicated `bluefin/<lib>.bst` that rebuilds the *same source/ref as
+the junction element* (keep them in lockstep — bump together) rather than overriding the
+junction. If a Shell extension needs the GTK3 introspection ABI, build with `-Dgtk3=true`
+(depends on `gnome-build-meta.bst:sdk/gtk+-3.bst`); upstream's VTE is GTK4-only. Push demo
+binaries and unversioned `.so` linker symlinks to the `devel` split so `bluefin-runtime`'s
+compose (which excludes `devel`) keeps only the `.typelib` + versioned `.so.N`.

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -38,6 +38,8 @@ depends:
   - bluefin/xdg-terminal-exec.bst
   - bluefin/nautilus-python.bst
   - bluefin/gnome-ponytail-daemon.bst
+  # Restores the VTE typelibs the app-drop strips out (dakota#1022)
+  - bluefin/vte.bst
   - bluefin/network.bst
   - bluefin/countme.bst
   # - bluefin/lsp-plugins-lv2.bst

--- a/elements/bluefin/vte.bst
+++ b/elements/bluefin/vte.bst
@@ -1,0 +1,71 @@
+# Dakota ships no VTE at all: the only things in the upstream stack that pull
+# gnome-build-meta's core-deps/vte.bst -- gnome-console, gnome-builder, foundry
+# -- are all dropped from this image (see core/meta-gnome-core-apps.bst), so
+# the widget and, critically, its GObject-introspection typelib never reach the
+# tree. GI consumers then fail to bind VTE; the ddterm Shell extension needs the
+# GTK3 ABI (Vte-2.91) and cannot load. See projectbluefin/dakota#1022.
+#
+# Upstream core-deps/vte.bst builds GTK4-only (-Dgtk3=false). ddterm binds the
+# GTK3 typelib, so this element rebuilds the identical 0.84.0 source with BOTH
+# ABIs and stages the pair the image otherwise lacks:
+#   Vte-2.91 + libvte-2.91.so.0        (GTK3, what ddterm needs)
+#   Vte-3.91 + libvte-2.91-gtk4.so.0   (GTK4, for parity with upstream)
+# The 0.84.0 source/ref MUST stay in lockstep with the gnome-build-meta
+# junction's core-deps/vte.bst -- bump both together to avoid two VTE ABIs.
+kind: meson
+
+sources:
+- kind: tar
+  url: gnome_downloads:vte/0.84/vte-0.84.0.tar.xz
+  ref: 0414e31583836aeb7878da25f67c515f7e8879917ecc37c92e26b83e8d8fc3e3
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+- gnome-build-meta.bst:sdk/gobject-introspection.bst
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+- freedesktop-sdk.bst:components/fmtlib.bst
+- freedesktop-sdk.bst:components/fribidi.bst
+- freedesktop-sdk.bst:components/gnutls.bst
+- freedesktop-sdk.bst:components/icu.bst
+- freedesktop-sdk.bst:components/systemd-libs.bst
+- gnome-build-meta.bst:sdk/glib.bst
+- gnome-build-meta.bst:sdk/gtk.bst
+# GTK3 stack is the reason this element exists: gtk3=true needs gtk+-3.0.
+- gnome-build-meta.bst:sdk/gtk+-3.bst
+- gnome-build-meta.bst:core-deps/fast-float.bst
+- gnome-build-meta.bst:core-deps/simdutf.bst
+
+variables:
+  # docs/vapi/glade produce only devel artifacts the compose already drops, so
+  # disable them to avoid pulling gi-docgen/vala just to throw the output away.
+  meson-local: >-
+    -Dgtk3=true
+    -Dgtk4=true
+    -Ddocs=false
+    -Dvapi=false
+    -Dglade=false
+
+public:
+  bst:
+    split-rules:
+      # Demo apps default to the runtime split; push them and the unversioned
+      # linker symlinks (both ABIs) to devel so bluefin-runtime's compose
+      # excludes them, leaving only the typelibs + versioned .so.N in the image.
+      devel:
+        (>):
+        - '%{bindir}/vte-2.91'
+        - '%{bindir}/vte-2.91-gtk4'
+        - '%{datadir}/applications/org.gnome.Vte.App.Gtk3.desktop'
+        - '%{datadir}/applications/org.gnome.Vte.App.Gtk4.desktop'
+        # The demo apps ALSO register as xdg-terminal-exec candidates; with the
+        # binaries excluded these entries would dangle, so exclude them too.
+        - '%{datadir}/xdg-terminals/org.gnome.Vte.App.Gtk3.desktop'
+        - '%{datadir}/xdg-terminals/org.gnome.Vte.App.Gtk4.desktop'
+        # GIR XML is devel metadata; the runtime consumers load the compiled
+        # typelibs. Nothing else in the image ships .gir to the standard dir.
+        - '%{datadir}/gir-1.0/Vte-2.91.gir'
+        - '%{datadir}/gir-1.0/Vte-3.91.gir'
+        - '%{libdir}/libvte-2.91.so'
+        - '%{libdir}/libvte-2.91-gtk4.so'


### PR DESCRIPTION
## Summary

Fixes the ddterm GNOME Shell extension failing to load because the image ships no VTE typelibs at all (#1022). Dakota's `meta-gnome-core-apps` override drops gnome-console, gnome-builder, and foundry, the only things in the upstream stack that pull vte in, and upstream's `core-deps/vte.bst` builds GTK4-only anyway while ddterm binds the GTK3 ABI.

New `bluefin/vte.bst` rebuilds the identical vte 0.84.0 source with `-Dgtk3=true -Dgtk4=true`, staging both ABIs:

1. **`Vte-2.91.typelib` + `libvte-2.91.so.0`** (GTK3, what ddterm needs)
2. **`Vte-3.91.typelib` + `libvte-2.91-gtk4.so.0`** (GTK4, parity with upstream)

The source ref is pinned in lockstep with the gnome-build-meta junction's vte and commented as a bump-together constraint, so we never ship two VTE ABI generations. Split rules push the demo apps, both sets of demo `.desktop` registrations (including the `xdg-terminals/` entries that would otherwise dangle), the unversioned linker symlinks, and the `.gir` XML to devel, so only the typelibs and versioned libraries reach the composed image. docs/vapi/glade are disabled to avoid pulling gi-docgen/vala for artifacts the compose discards.

Verified: element and full default-variant image builds pass, and the composed `bluefin-runtime` layer contains exactly the two typelibs plus versioned libs with no demo/desktop/gir leakage.

Fixes: projectbluefin/dakota#1022


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored VTE runtime libraries and introspection data needed by applications and desktop extensions.
  * Improved compatibility for terminal-related functionality, including GTK3 and GTK4 environments.
  * Ensured required runtime components are included without unnecessarily packaging development files.

* **Documentation**
  * Added guidance for preserving transitive libraries and introspection files when customizing application contents.
  * Documented recommended patterns for supporting GTK3 introspection and runtime packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->