### PR TITLE
feat(bluefin): enable fingerprint auth for sudo and polkit

### DIFF
--- a/docs/skills/bst-overrides.md
+++ b/docs/skills/bst-overrides.md
@@ -290,3 +290,44 @@ Applying any local patch queue (`patch_queue` source) to a junction (like `gnome
 
 - **Consequence:** Carrying local patches (like `disable-lorry-mirrors.patch`) on a junction silently forces local compiles for massive components (like WebKit) by preventing cache reuse against the official public upstream cache (`gbm.gnome.org:11003`).
 - **Fix:** Keep junctions 100% clean of downstream patch queues. If a patch is required, submit it upstream first or bump the junction ref. Removing the patch queue on `gnome-build-meta` immediately restored 1053 out of 1090 cached elements (96% cache hit rate).
+
+### Overriding a single file a junction ships into /etc (overlap-whitelist pattern) (2026-07-19)
+
+To replace one file that an upstream junction component installs (not patch the
+junction, not shadow the whole element), ship a Dakota `bluefin/*.bst` element
+that installs the replacement to the same path, and use `overlap-whitelist` to
+win the compose overlap. This is the same mechanism `bluefin/sudo-rs.bst` uses
+to take over `/usr/bin/sudo` from fdsdk's `components/sudo.bst`.
+
+```yaml
+public:
+  bst:
+    overlap-whitelist:
+    - /etc/pam.d/system-auth   # literal path, not a %{var}
+depends:
+- freedesktop-sdk.bst:components/linux-pam.bst   # forces staging AFTER the stock file
+```
+
+Two facts that make this safe and deterministic:
+
+- **Staging order = overlap winner.** Whitelisting only silences the warning; the
+  element staged *later* wins. A runtime `depends:` on the component that ships
+  the original guarantees the override stages after it. (`sudo-rs.bst` gets away
+  without the explicit dep, but declaring it removes the ambiguity.)
+- **/etc vs /usr/etc matters.** fdsdk `sysconfdir=/etc`, so config like
+  `linux-pam`'s pam.d lands in real `/etc`, and the compose includes `/etc`.
+  `oci/bluefin.bst` only merges `/usr/etc -> /etc` (`cp -a`, `/usr/etc` wins) —
+  it never touches files already in `/etc`. So an `/etc` override is NOT
+  clobbered by that merge. If you instead need to override something a component
+  ships to `/usr/etc`, your override must also go to `/usr/etc` (mine would lose
+  to the merge otherwise) and the whitelist path must be the `/usr/etc` one.
+
+Case study — issue #953, fingerprint for sudo/polkit: `bluefin/fprintd-system-auth.bst`
+ships a full `/etc/pam.d/system-auth` with `auth sufficient pam_fprintd.so` above
+`pam_unix`. PAM has no drop-in for the aggregate `system-auth` stack and there is
+no authselect on this image, so a whole-file override is the only option. sudo
+(`/etc/pam.d/sudo`) and polkit (`/usr/lib/pam.d/polkit-1`) both reach it via
+`auth include system-auth`. Note Dakota builds sudo-rs without the `pam-login`
+cargo feature (`default = []`), so sudo-rs opens the `sudo` PAM service (not
+`sudo-i`) for `sudo -i` too — both paths include `system-auth`. Re-sync the
+copied stock stack at every fdsdk bump.

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -34,6 +34,7 @@ depends:
 
   - bluefin/uutils-coreutils.bst
   - bluefin/sudo-rs.bst
+  - bluefin/fprintd-system-auth.bst
   - bluefin/efibootmgr.bst
   - bluefin/xdg-terminal-exec.bst
   - bluefin/nautilus-python.bst

--- a/elements/bluefin/fprintd-system-auth.bst
+++ b/elements/bluefin/fprintd-system-auth.bst
@@ -1,0 +1,93 @@
+kind: manual
+
+# Dakota override of freedesktop-sdk's /etc/pam.d/system-auth (issue #953).
+#
+# WHY A FULL-FILE OVERRIDE:
+# PAM has no drop-in / .d mechanism for the aggregate `system-auth` stack, so
+# the only way to add fingerprint auth to everything that `include`s it is to
+# ship a complete replacement file. fdsdk's `components/linux-pam.bst` installs
+# the stock file to %{sysconfdir}/pam.d/system-auth (sysconfdir=/etc), with no
+# fingerprint line. There is NO authselect on this image — `authselect
+# select ... with-fingerprint` is not available — so the file must be edited
+# statically at build time.
+#
+# WHAT THIS FIXES:
+# sudo (/etc/pam.d/sudo), polkit (/usr/lib/pam.d/polkit-1) and su all reach
+# their auth stack via `auth include system-auth`. Enrollment and GDM already
+# work because gdm-fingerprint / fingerprint-auth reference pam_fprintd
+# directly; system-auth never did, so sudo and polkit never offered a finger.
+# Adding one line here lights up fingerprint for every system-auth consumer at
+# once.
+#
+# ORDERING CONTRACT (do not reorder):
+#   * pam_fprintd.so sits ABOVE pam_unix.so — the reader is offered first.
+#   * It is `sufficient`, not `required`: a fingerprint match short-circuits to
+#     success, but ANY failure (no match, no reader, no enrolled prints) falls
+#     through to pam_unix so the password remains a full fallback. It can never
+#     lock anyone out.
+#   * It sits directly after pam_env, mirroring fdsdk's own fingerprint-auth
+#     file, and before the systemd-homed line — homed users still get their
+#     password path via the `-auth sufficient pam_systemd_home.so` below.
+#
+# NO-READER LATENCY:
+# pam_fprintd asks fprintd (net.reactivated.Fprint) for devices over D-Bus. On
+# a machine with NO reader, GetDevices() returns empty and the module returns
+# PAM_AUTHINFO_UNAVAIL immediately — it does NOT block. The ~30s wait only
+# occurs when a reader IS present and the module is waiting for a swipe (and
+# even then it times out and falls through to the password). So this line adds
+# no perceptible delay to sudo/polkit on reader-less hardware. (Verify on real
+# no-reader hardware — see PR notes; the dev machine has no reader.)
+#
+# OVERRIDE MECHANICS:
+# This element depends on components/linux-pam.bst so it stages AFTER the stock
+# file and wins the compose overlap; overlap-whitelist silences the (expected)
+# overlap warning. The file lands in /etc (not /usr/etc), so the OCI
+# `/usr/etc -> /etc` merge in oci/bluefin.bst never touches or clobbers it.
+#
+# Exit condition: drop if fdsdk/gnome-build-meta ship a fingerprint-enabled
+# system-auth, or if the image gains authselect. Re-check at every fdsdk bump
+# that the stock auth/account/password/session stack below still matches
+# upstream (diff against files/linux-pam-config/system-auth in the fdsdk ref) —
+# if upstream changes system-auth, this copy must be re-synced.
+
+public:
+  bst:
+    overlap-whitelist:
+    - /etc/pam.d/system-auth
+
+# No external sources — the file is inline.
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+# Stage after the stock file so this override wins the overlap deterministically.
+depends:
+- freedesktop-sdk.bst:components/linux-pam.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    install -Dm644 /dev/stdin "%{install-root}%{sysconfdir}/pam.d/system-auth" <<'EOF'
+    auth        required      pam_env.so
+    auth        sufficient    pam_fprintd.so
+    -auth       sufficient    pam_systemd_home.so
+    auth        sufficient    pam_unix.so try_first_pass nullok_secure
+    auth        required      pam_deny.so
+
+    -account    sufficient    pam_systemd_home.so
+    account     required      pam_unix.so
+
+    -password   sufficient    pam_systemd_home.so
+    password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+    password    sufficient    pam_unix.so try_first_pass use_authtok nullok_secure sha512 shadow
+    password    required      pam_deny.so
+
+    -session    optional      pam_systemd_home.so
+    session     optional      pam_keyinit.so revoke
+    session     required      pam_limits.so
+    -session     optional      pam_systemd.so
+    session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+    session     required      pam_unix.so
+    EOF


### PR DESCRIPTION
## Summary

Fixes fingerprint auth never being offered by sudo or polkit despite working enrollment and GDM login (#953). Enrollment and GDM work because `fingerprint-auth`/`gdm-fingerprint` reference `pam_fprintd` directly, but sudo and polkit reach auth through `auth include system-auth`, and fdsdk's `system-auth` has no fingerprint line. There is no authselect on this image, so nothing ever added one.

New `bluefin/fprintd-system-auth.bst` ships a full `/etc/pam.d/system-auth` override (PAM has no drop-in mechanism for the aggregate stack) with one added line: `auth sufficient pam_fprintd.so` above `pam_unix`.

1. **Ordering contract documented in the element**: fingerprint is offered first, and any failure (no match, no reader, nothing enrolled) falls through to password, so it can never lock anyone out.
2. **sudo-rs compatible**: the in-flight sudo-rs (built without the `pam-login` feature) opens the `sudo` PAM service for both `sudo` and `sudo -i`, and libpam expands the `include`, so the fix covers classic sudo, sudo-rs, and polkit (`/usr/lib/pam.d/polkit-1` also includes system-auth) through one file. The latent `pam-login`/`sudo-i` trap is documented in the commit and in `docs/skills/bst-overrides.md`.
3. **No reader, no delay**: pam_fprintd returns `PAM_AUTHINFO_UNAVAIL` immediately when fprintd reports no devices, so reader-less machines see no added latency.
4. **Zero drift at introduction**: the override is a verified one-line diff against the stock file, and the element documents the re-sync obligation at every fdsdk bump plus the exit condition (drop when upstream ships a fingerprint-enabled system-auth or the image gains authselect).

Verified: full default-variant image build passes, and the composed layer's `/etc/pam.d/system-auth` contains the fingerprint line, proving the override wins the overlap (element depends on `components/linux-pam.bst` to stage after the stock file, with the expected overlap whitelisted). Needs verification on fingerprint-reader hardware once published, tracked in the issue.

Fixes: projectbluefin/dakota#953
