### PR TITLE
feat(bluefin): migrate legacy /var/home passwd home fields to /home

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -64,5 +64,6 @@ depends:
   - gnome-build-meta.bst:gnomeos-deps/wl-clipboard.bst
 
   - bluefin/bindmounts.bst
+  - bluefin/migrate-var-home-passwd.bst
 
   - gnome-build-meta.bst:gnomeos-deps/snapd.bst

--- a/elements/bluefin/migrate-var-home-passwd.bst
+++ b/elements/bluefin/migrate-var-home-passwd.bst
@@ -1,0 +1,33 @@
+kind: manual
+description: |
+  One-shot, idempotent boot-time migration of legacy /var/home/<user> (and
+  /var/roothome) passwd home fields to the post-#1117 bind-mount layout.
+  Installs from before 2026-06-29 carry the old fields, which breaks snapd
+  and makes path-identity comparisons disagree; see
+  projectbluefin/dakota#1170.
+
+  Ships the migration script, its oneshot unit (ordered before
+  systemd-user-sessions), and a preset to enable it.
+
+sources:
+- kind: local
+  path: files/migrate-var-home-passwd
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    install -Dm755 bluefin-migrate-var-home-passwd \
+            "%{install-root}/usr/libexec/bluefin-migrate-var-home-passwd"
+  - |
+    install -Dm644 bluefin-migrate-var-home-passwd.service \
+            "%{install-root}%{indep-libdir}/systemd/system/bluefin-migrate-var-home-passwd.service"
+  - |
+    install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/systemd/system-preset/80-bluefin-migrate-var-home-passwd.preset" <<'PRESET'
+    enable bluefin-migrate-var-home-passwd.service
+    PRESET

--- a/files/migrate-var-home-passwd/bluefin-migrate-var-home-passwd
+++ b/files/migrate-var-home-passwd/bluefin-migrate-var-home-passwd
@@ -1,0 +1,69 @@
+#!/usr/bin/bash
+# One-shot migration of legacy home fields in /etc/passwd: /var/home/<user>
+# -> /home/<user>, /var/roothome -> /root. Installs from before PR #1117
+# (2026-06-29) carry the old-layout fields, which breaks snapd and makes
+# bind-mount path-identity comparisons disagree. Full background:
+# projectbluefin/dakota#1170.
+#
+# The write is delegated to usermod (no -m: passwd field only, no data
+# moves) so locking and atomic replace are the canonical lckpwdf ones;
+# flock(2) would not interoperate. Deliberately no sentinel file: the grep
+# fast path is cheap and self-heals if a stale entry is ever reintroduced.
+#
+# MIGRATE_PREFIX=/some/dir operates on $MIGRATE_PREFIX/etc/passwd (passed
+# to usermod --prefix); tests only, leave unset in production.
+
+set -euo pipefail
+
+PREFIX="${MIGRATE_PREFIX:-}"
+PASSWD="${PREFIX}/etc/passwd"
+
+log() { echo "bluefin-migrate-var-home-passwd: $*"; }
+
+if [ ! -r "$PASSWD" ]; then
+    log "no readable $PASSWD; nothing to do"
+    exit 0
+fi
+
+# Nothing to migrate -> exit before taking any lock.
+if ! grep -qE ':(/var/home/|/var/roothome)(:|$)' "$PASSWD"; then
+    exit 0
+fi
+
+declare -a UARGS=()
+[ -n "$PREFIX" ] && UARGS+=(--prefix "$PREFIX")
+
+rc=0
+migrated=0
+
+# The loop holds the original inode open while usermod renames in new ones,
+# so every decision is made against a consistent pre-migration snapshot.
+while IFS=: read -r login _ _ _ _ home _; do
+    [ -n "$login" ] || continue
+    case "$home" in
+        /var/roothome)
+            new="/root"
+            ;;
+        /var/home/*)
+            new="/home/${home#/var/home/}"
+            ;;
+        *)
+            continue
+            ;;
+    esac
+
+    set +e
+    usermod "${UARGS[@]}" -d "$new" "$login"
+    uc=$?
+    set -e
+    if [ "$uc" -eq 0 ]; then
+        log "migrated $login: $home -> $new"
+        migrated=$((migrated + 1))
+    else
+        log "FAILED to migrate $login: $home -> $new (usermod rc=$uc)"
+        rc=1
+    fi
+done < "$PASSWD"
+
+log "done; migrated ${migrated} user(s)"
+exit "$rc"

--- a/files/migrate-var-home-passwd/bluefin-migrate-var-home-passwd.service
+++ b/files/migrate-var-home-passwd/bluefin-migrate-var-home-passwd.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Migrate legacy /var/home home paths in /etc/passwd to /home
+Documentation=https://github.com/projectbluefin/dakota/issues/1170
+After=local-fs.target
+# Must rewrite passwd before anything reads it for a session:
+# systemd-user-sessions gates all logins, accounts-daemon caches home fields.
+Before=systemd-user-sessions.service
+Before=accounts-daemon.service
+Before=display-manager.service
+Before=gdm.service
+ConditionPathExists=/etc/passwd
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/libexec/bluefin-migrate-var-home-passwd
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Fixes stale `/var/home/<user>` passwd entries on installs created before 2026-06-29 (#1170). PR #1117 turned /home and /root into real directories bind-mounted from /var/home and /var/roothome (snapd requires homes literally under /home) and switched user creation to useradd-default. But /etc persists across image upgrades, so the pre-#1117 install cohort still carries old-layout home fields: snapd refuses to run for them, and because a bind mount (unlike the old symlink) does not canonicalize the two spellings together, `$HOME` from passwd and derived `/home/<user>` paths silently disagree in any path-equality logic.

New `bluefin/migrate-var-home-passwd.bst` ships a one-shot, idempotent boot-time migration:

1. **Ordering is the safety mechanism**: the oneshot unit runs `Before=systemd-user-sessions.service` (the barrier every display manager and getty orders after), plus `Before=accounts-daemon.service` and the display manager, so no session exists and nothing else has passwd open when it writes.
2. **The write is delegated to `usermod -d`**, which takes the canonical passwd lock (lckpwdf on `/etc/.pwd.lock`, the same lock vipw/passwd/accounts-daemon use), writes atomically, and maintains the `/etc/passwd-` backup. No hand-rolled locking: flock(2) does not interoperate with lckpwdf's fcntl lock, so reusing the canonical tool is strictly safer.
3. **No data moves**: the bind mount means both spellings already reference the same directory, only the passwd string changes (`/var/home/<user>` to `/home/<user>`, root's `/var/roothome` to `/root`).
4. **Idempotent and self-healing**: a fast grep exits 0 before taking any lock when nothing matches, and because there is deliberately no sentinel file, a stale entry reintroduced by a later /etc edit gets fixed on the next boot. One journal line per migrated user.

The script supports a `MIGRATE_PREFIX` override (passed straight to `usermod --prefix`) for standalone testing, and was tested that way against a copied passwd tree: multiple users, root, already-migrated entries, non-home system accounts, and custom home basenames all handled correctly, with a clean idempotent second run.

Out of scope, release-note material: user dotfiles that hardcode `/var/home/...` cannot be auto-fixed, including home data migrated from Fedora Atomic systems where /var/home is the canonical spelling.

Verified: element builds clean and the full default-variant image build passes. Boot verification on an affected install is tracked in the issue.

Fixes: projectbluefin/dakota#1170
Related: projectbluefin/dakota#1117
