### PR TITLE
chore(workflow): pin bonedigger lifecycle to clanker-queue rollout

### DIFF
--- a/.github/workflows/bonedigger.yml
+++ b/.github/workflows/bonedigger.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   lifecycle:
-    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@d53076732c23203efd7856eaee7c502742897603 # v1
+    uses: projectbluefin/bonedigger/.github/workflows/lifecycle.yml@aa3185566171de43106976cd5a0ac72ee3106868 # clanker-queue-rollout
     with:
       brand_name: "Dakota"
     secrets: inherit


### PR DESCRIPTION
Pins dakota's bonedigger caller to the new bonedigger rollout SHA so it can consume the clanker-queue migration workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated lifecycle workflow to use a newer workflow revision.
  * No changes to workflow triggers, permissions, or job configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->