### PR TITLE
fix(build): set GOROOT for remote Go builds

### DIFF
--- a/docs/skills/buildstream.md
+++ b/docs/skills/buildstream.md
@@ -152,3 +152,7 @@ Do not cancel a build under 120 min just because it "seems slow." Historical ran
 ### 32 fetchers is the right setting for cache.projectbluefin.io (2026-06-23)
 
 `buildstream-ci.conf` uses `fetchers: 32` (BST default is 10). With default + nvidia running simultaneously = 64 concurrent gRPC streams. The CAS server is a Hetzner AX102-U (1 Gbit/s uplink, NVMe Gen4) and can serve 64 streams comfortably. The bottleneck is network bandwidth (~125 MB/s total), not server capacity. Do not reduce fetchers without evidence of server-side saturation.
+
+### Avoid /dev/stdin redirection in remote sandboxes (2026-07-25)
+
+BuildStream elements that write inline configuration files using `install -Dm644 /dev/stdin ... <<'EOF'` fail in remote execution sandboxes (like BuildBarn) where `/dev/stdin` is not available as a standard character device. Write inline files using a two-step pattern: create the destination file with `install -Dm644 /dev/null target`, then populate it with `cat > target <<'EOF'`.

--- a/docs/skills/packaging-go.md
+++ b/docs/skills/packaging-go.md
@@ -191,3 +191,7 @@ reads from the source), the Go vendor tarball must be generated offline and uplo
 separately. Factor in this extra maintenance step when deciding between Pattern 1 and
 Pattern 2 — Pattern 1 (go_module sources) is more maintainable long-term because refs
 can be updated in-place.
+### Dependent Go elements need an explicit GOROOT in remote sandboxes
+
+The freedesktop-sdk Go toolchain installs its standard library under `%{libdir}/go`, but dependent elements do not inherit the toolchain element’s `GOROOT_BOOTSTRAP`. Set `GOROOT: "%{libdir}/go"` in every Dakota element that invokes `go build`; otherwise BuildBarn remote actions can fail with `go: cannot find GOROOT directory` even though the Go binary is present.
+

--- a/elements/bluefin-nvidia/nvidia-container-toolkit-preset.bst
+++ b/elements/bluefin-nvidia/nvidia-container-toolkit-preset.bst
@@ -15,7 +15,7 @@ config:
   install-commands:
   - |
     install -Dm644 /dev/null "%{install-root}%{indep-libdir}/systemd/system-preset/80-nvidia-container-toolkit.preset"
-  cat > "%{install-root}%{indep-libdir}/systemd/system-preset/80-nvidia-container-toolkit.preset" <<'PRESET'
+    cat > "%{install-root}%{indep-libdir}/systemd/system-preset/80-nvidia-container-toolkit.preset" <<'PRESET'
     enable nvidia-cdi-refresh.path
     enable nvidia-cdi-refresh.service
     PRESET

--- a/elements/bluefin-nvidia/nvidia-container-toolkit-preset.bst
+++ b/elements/bluefin-nvidia/nvidia-container-toolkit-preset.bst
@@ -14,7 +14,8 @@ variables:
 config:
   install-commands:
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/systemd/system-preset/80-nvidia-container-toolkit.preset" <<'PRESET'
+    install -Dm644 /dev/null "%{install-root}%{indep-libdir}/systemd/system-preset/80-nvidia-container-toolkit.preset"
+  cat > "%{install-root}%{indep-libdir}/systemd/system-preset/80-nvidia-container-toolkit.preset" <<'PRESET'
     enable nvidia-cdi-refresh.path
     enable nvidia-cdi-refresh.service
     PRESET

--- a/elements/bluefin-nvidia/nvidia-container-toolkit.bst
+++ b/elements/bluefin-nvidia/nvidia-container-toolkit.bst
@@ -26,6 +26,9 @@ build-depends:
 depends:
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
+environment:
+  GOROOT: "%{libdir}/go"
+
 variables:
   local_ldflags: -Wl,-z,lazy
 

--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -43,7 +43,8 @@ config:
     cp -r bluefin-branding/system_files/etc/./ "%{install-root}%{sysconfdir}/"
 
     # Default Bluefin shell MOTD to disabled, while allowing user overrides.
-    install -Dm644 /dev/stdin "%{install-root}%{sysconfdir}/profile.d/bluefin-shell-defaults.sh" <<'EOF'
+    install -Dm644 /dev/null "%{install-root}%{sysconfdir}/profile.d/bluefin-shell-defaults.sh"
+    cat > "%{install-root}%{sysconfdir}/profile.d/bluefin-shell-defaults.sh" <<'EOF'
     : "${BLUEFIN_SHELL_ENABLE_MOTD:=0}"
     export BLUEFIN_SHELL_ENABLE_MOTD
     EOF

--- a/elements/bluefin/distrobox.bst
+++ b/elements/bluefin/distrobox.bst
@@ -16,6 +16,7 @@ variables:
   strip-binaries: ""
 
 environment:
+  GOROOT: "%{libdir}/go"
   GOARCH: "%{go-arch}"
 
 config:

--- a/elements/bluefin/motd.bst
+++ b/elements/bluefin/motd.bst
@@ -26,7 +26,8 @@ config:
   - install -Dm644 template.md "%{install-root}/usr/share/ublue-os/motd/template.md"
   - install -Dm644 tips/10-tips.md "%{install-root}/usr/share/ublue-os/motd/tips/10-tips.md"
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{sysconfdir}/profile.d/bluefin-shell-defaults.sh" <<'EOF'
+    install -Dm644 /dev/null "%{install-root}%{sysconfdir}/profile.d/bluefin-shell-defaults.sh"
+    cat > "%{install-root}%{sysconfdir}/profile.d/bluefin-shell-defaults.sh" <<'EOF'
     : "${BLUEFIN_SHELL_ENABLE_MOTD:=1}"
     export BLUEFIN_SHELL_ENABLE_MOTD
     EOF

--- a/elements/bluefin/network.bst
+++ b/elements/bluefin/network.bst
@@ -10,7 +10,8 @@ variables:
 config:
   install-commands:
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/tmpfiles.d/bluefin-network.conf" <<'EOF'
+    install -Dm644 /dev/null "%{install-root}%{indep-libdir}/tmpfiles.d/bluefin-network.conf"
+    cat > "%{install-root}%{indep-libdir}/tmpfiles.d/bluefin-network.conf" <<'EOF'
     # Symlink /etc/resolv.conf to systemd-resolved's stub resolver.
     # L+ removes any existing file (e.g. the empty placeholder from the base image)
     # so applications that read resolv.conf directly (Steam, Distrobox, etc.) get DNS.
@@ -18,7 +19,8 @@ config:
     EOF
 
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{sysconfdir}/hosts" <<'EOF'
+    install -Dm644 /dev/null "%{install-root}%{sysconfdir}/hosts"
+    cat > "%{install-root}%{sysconfdir}/hosts" <<'EOF'
     127.0.0.1   localhost
     ::1         localhost
     EOF

--- a/elements/bluefin/tailscale.bst
+++ b/elements/bluefin/tailscale.bst
@@ -31,7 +31,8 @@ config:
     mv "%{install-root}%{indep-libdir}/systemd/system/tailscaled.service.patched" \
        "%{install-root}%{indep-libdir}/systemd/system/tailscaled.service"
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/systemd/system-preset/80-tailscale.preset" <<'PRESET'
+    install -Dm644 /dev/null "%{install-root}%{indep-libdir}/systemd/system-preset/80-tailscale.preset"
+    cat > "%{install-root}%{indep-libdir}/systemd/system-preset/80-tailscale.preset" <<'PRESET'
     enable tailscaled.service
     PRESET
   - |

--- a/elements/bluefin/uupd.bst
+++ b/elements/bluefin/uupd.bst
@@ -22,7 +22,8 @@ config:
   - |
     install -Dm755 -t "%{install-root}%{bindir}" uupd
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/systemd/system/uupd.service" <<'SERVICE'
+    install -Dm644 /dev/null "%{install-root}%{indep-libdir}/systemd/system/uupd.service"
+    cat > "%{install-root}%{indep-libdir}/systemd/system/uupd.service" <<'SERVICE'
     [Unit]
     Description=Universal Blue Update Oneshot Service
     StartLimitBurst=3
@@ -40,7 +41,8 @@ config:
     SELinuxContext=system_u:unconfined_r:unconfined_t:s0
     SERVICE
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/systemd/system/uupd.timer" <<'TIMER'
+    install -Dm644 /dev/null "%{install-root}%{indep-libdir}/systemd/system/uupd.timer"
+    cat > "%{install-root}%{indep-libdir}/systemd/system/uupd.timer" <<'TIMER'
     [Unit]
     Description=Auto Update System Timer For Universal Blue
     Wants=network-online.target
@@ -59,7 +61,8 @@ config:
     WantedBy=timers.target
     TIMER
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/systemd/system/uupd-manual.service" <<'MANUAL'
+    install -Dm644 /dev/null "%{install-root}%{indep-libdir}/systemd/system/uupd-manual.service"
+    cat > "%{install-root}%{indep-libdir}/systemd/system/uupd-manual.service" <<'MANUAL'
     [Unit]
     Description=Universal Blue Update Oneshot Service - Manual Activation
     StartLimitBurst=3
@@ -76,7 +79,8 @@ config:
     SELinuxContext=system_u:unconfined_r:unconfined_t:s0
     MANUAL
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{sysconfdir}/uupd/config.json" <<'CONFIG'
+    install -Dm644 /dev/null "%{install-root}%{sysconfdir}/uupd/config.json"
+    cat > "%{install-root}%{sysconfdir}/uupd/config.json" <<'CONFIG'
     {
         "checks": {
             "hardware": {
@@ -104,7 +108,8 @@ config:
     }
     CONFIG
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{sysconfdir}/polkit-1/rules.d/uupd.rules" <<'RULES'
+    install -Dm644 /dev/null "%{install-root}%{sysconfdir}/polkit-1/rules.d/uupd.rules"
+    cat > "%{install-root}%{sysconfdir}/polkit-1/rules.d/uupd.rules" <<'RULES'
     polkit.addRule(function(action, subject) {
         if (action.id == "org.freedesktop.systemd1.manage-units") {
             switch(action.lookup("unit")) {


### PR DESCRIPTION
## What
Set the installed freedesktop-sdk Go root explicitly for Dakota elements that compile Go sources. BuildBarn remote actions currently find the trimmed `go` binary but fail because `GOROOT` is unset.

This covers both the distrobox build that currently blocks the merged testing build and the NVIDIA container toolkit build.

## Verification
- `git diff --check` passed
- `just bst show oci/bluefin.bst` passed
- The failed lab RE build showed `go: cannot find GOROOT directory` in `bluefin/distrobox.bst`
- Lab RE rebuild and boot/e2e validation should run from this exact commit

[x] I am using an agent and I take responsibility for this PR

Assisted-by: GPT-5 via pi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Go-based builds in remote sandboxes by explicitly setting the Go toolchain root (`GOROOT`) for Go build steps.
  * Updated Go-related build recipes to prevent remote action failures stemming from missing Go environment configuration.
* **Documentation**
  * Added a “Lessons Learned” note explaining why dependent Go elements require an explicit `GOROOT` in remote sandboxes.
* **Chores**
  * Refreshed installation steps to write systemd presets/units and config files via a safer two-step file creation approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->