### PR TITLE
ci: publish lab results through MergeRaptor checks

### DIFF
--- a/.github/workflows/lab-check.yml
+++ b/.github/workflows/lab-check.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
           private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
+          permission-checks: write
+          permission-contents: read
 
       - name: Create or update lab check
         env:

--- a/.github/workflows/lab-check.yml
+++ b/.github/workflows/lab-check.yml
@@ -1,0 +1,125 @@
+name: Lab check
+
+on:
+  repository_dispatch:
+    types: [lab-check]
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    name: Update MergeRaptor check
+    if: >-
+      github.event.client_payload.repository == github.repository &&
+      github.event.client_payload.sha != ''
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Get MergeRaptor token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
+          private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
+
+      - name: Create or update lab check
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SHA: ${{ github.event.client_payload.sha }}
+          CHECK_JSON: ${{ toJSON(github.event.client_payload.check) }}
+        run: |
+          set -euo pipefail
+
+          CHECK_NAME="testing-lab / dakota"
+          APP_SLUG="mergeraptor"
+
+          if [[ ! "${SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid commit SHA: ${SHA}" >&2
+            exit 1
+          fi
+
+          gh api "repos/${GITHUB_REPOSITORY}/commits/${SHA}" >/dev/null
+
+          STATE=$(jq -r '.state // empty' <<<"${CHECK_JSON}")
+          case "${STATE}" in
+            queued|in_progress|completed) ;;
+            *)
+              echo "Invalid check state: ${STATE}" >&2
+              exit 1
+              ;;
+          esac
+
+          CONCLUSION=$(jq -r '.conclusion // empty' <<<"${CHECK_JSON}")
+          if [[ "${STATE}" == "completed" ]]; then
+            case "${CONCLUSION}" in
+              success|failure|neutral|cancelled|timed_out|action_required|skipped|stale) ;;
+              *)
+                echo "Invalid completed conclusion: ${CONCLUSION}" >&2
+                exit 1
+                ;;
+            esac
+          fi
+
+          DETAILS_URL=$(jq -r '.details_url // empty' <<<"${CHECK_JSON}")
+          EXTERNAL_ID=$(jq -r '.external_id // empty' <<<"${CHECK_JSON}")
+          TITLE=$(jq -r '(.title // "Dakota lab validation")[0:255]' <<<"${CHECK_JSON}")
+          SUMMARY=$(jq -r '(.summary // "No lab summary was provided.")[0:60000]' <<<"${CHECK_JSON}")
+          TEXT=$(jq -r '(.text // "")[0:60000]' <<<"${CHECK_JSON}")
+          STARTED_AT=$(jq -r '.started_at // empty' <<<"${CHECK_JSON}")
+          COMPLETED_AT=$(jq -r '.completed_at // empty' <<<"${CHECK_JSON}")
+
+          CHECK_ID=$(
+            gh api --method GET \
+              "repos/${GITHUB_REPOSITORY}/commits/${SHA}/check-runs" \
+              -f per_page=100 \
+              --jq '.check_runs
+                | map(select(.name == "'"${CHECK_NAME}"'" and .app.slug == "'"${APP_SLUG}"'"))
+                | sort_by(.id)
+                | last
+                | .id // empty'
+          )
+
+          BODY=$(
+            jq -n \
+              --arg name "${CHECK_NAME}" \
+              --arg head_sha "${SHA}" \
+              --arg details_url "${DETAILS_URL}" \
+              --arg external_id "${EXTERNAL_ID}" \
+              --arg status "${STATE}" \
+              --arg conclusion "${CONCLUSION}" \
+              --arg started_at "${STARTED_AT}" \
+              --arg completed_at "${COMPLETED_AT}" \
+              --arg title "${TITLE}" \
+              --arg summary "${SUMMARY}" \
+              --arg text "${TEXT}" \
+              '{
+                name: $name,
+                head_sha: $head_sha,
+                status: $status,
+                output: {
+                  title: $title,
+                  summary: $summary,
+                  text: $text
+                }
+              }
+              + if $details_url != "" then {details_url: $details_url} else {} end
+              + if $external_id != "" then {external_id: $external_id} else {} end
+              + if $started_at != "" then {started_at: $started_at} else {} end
+              + if $status == "completed" then {conclusion: $conclusion} else {} end
+              + if $status == "completed" and $completed_at != "" then {completed_at: $completed_at} else {} end'
+          )
+
+          if [[ -n "${CHECK_ID}" ]]; then
+            echo "Updating ${CHECK_NAME} check ${CHECK_ID} for ${SHA}"
+            UPDATE_BODY=$(jq 'del(.head_sha)' <<<"${BODY}")
+            gh api \
+              --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/check-runs/${CHECK_ID}" \
+              --input - <<<"${UPDATE_BODY}" >/dev/null
+          else
+            echo "Creating ${CHECK_NAME} check for ${SHA}"
+            gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/check-runs" \
+              --input - <<<"${BODY}" >/dev/null
+          fi

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -4,6 +4,7 @@ description: CI entry point for Dakota. Routes agents to the right CI skill fast
 metadata:
   context7-sources:
     - /websites/github_en_actions
+    - /websites/github_en_rest
     - /actions/cache
     - /bootc-dev/bootc
     - /apache/buildstream
@@ -133,6 +134,7 @@ This is the fast path for stale-image complaints: the image date is usually wron
 | `build.yml` | `push: testing` for key-busting paths, `workflow_dispatch`, `schedule: daily 13:00 UTC` — NOT `pull_request` or `merge_group` | Run a single BuildStream assembly build per target (`oci/bluefin.bst` and `oci/bluefin-nvidia.bst`), push the resulting artifacts to `cache.projectbluefin.io`, and upload logs. Does not push to GHCR. |
 | `publish.yml` | `workflow_run` from `build.yml` (branches: testing, next, + their gh-readonly-queue/* paths) | Fetch the remote-CAS artifact, export to OCI, run `just lint`, push `:$sha`, sign/attest, and promote `:testing`/`:next` tags. No build happens here. |
 | `execute-release.yml` | `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch` | SHA freshness check (:testing vs :stable). If different: cosign verify → skopeo copy `:testing` → `:stable` → fast-forward main → create GitHub Release. Skips if equal. |
+| `lab-check.yml` | `repository_dispatch: lab-check` from the Kubernetes lab | Uses a short-lived MergeRaptor installation token to create or update one `testing-lab / dakota` Check Run for the PR head SHA. It reports queued, running, and final BuildStream/QA details without posting PR comments. |
 | `boot-test-aarch64.yml` | `workflow_run` from `build-aarch64.yml` on `testing`, `workflow_dispatch` (image input) | M0 aarch64 boot gate: verifies the `:aarch64` tag exists on GHCR (skopeo — does not trust build-aarch64's masked conclusion), boots it on `ubuntu-24.04-arm` via bcvk ephemeral (qemu/virtiofs, cargo-built — no upstream aarch64 binaries), gates on `multi-user.target`, reports graphical/gdm/bootc informationally, always uploads serial + journal artifacts. Never blocks x86_64. Tests direct kernel boot, not the bootc install-to-disk bootloader path. |
 | ~~`promote-testing-to-main.yml`~~ | DELETED | Was: `push: testing`, schedule Tue 04:00 UTC, manual. |
 | ~~`pr-release-gate.yml`~~ | DELETED | Was: `pull_request` to `main`. |
@@ -156,6 +158,33 @@ This is the fast path for stale-image complaints: the image date is usually wron
 - `next` or `gh-readonly-queue/next/*` → `:next`
 
 **PR path:** `validate` + `e2e` (change-detected) — no extra BuildStream warmup path. The default Dakota pipeline stays on a single assembly pass per target.
+
+### Lab Check Run bridge
+
+The lab reports Dakota PR validation through GitHub's Checks API, not PR
+comments:
+
+1. The lab creates the Argo workflow and dispatches a `lab-check` event with a
+   nested, bounded payload.
+2. `.github/workflows/lab-check.yml` mints a short-lived MergeRaptor
+   installation token from the existing org secrets.
+3. The workflow finds the latest `testing-lab / dakota` check owned by the
+   `mergeraptor` app for that exact commit and updates it; it creates the check
+   only when none exists.
+4. Argo sends `queued`, `in_progress`, and `completed` updates. The final output
+   includes the workflow parameters, pod/node placement, every workflow node,
+   phase counts, timings, and failure messages.
+
+Do not put the MergeRaptor private key in Kubernetes. The lab's existing GitHub
+credential is used only to call `repository_dispatch`; GitHub Actions owns the
+app-token exchange. Do not post a duplicate PR comment or commit status.
+
+MergeRaptor must have repository `checks: write` and `contents: read`
+permissions. The workflow uses contents access to validate the target commit
+before updating its Check Run. GitHub's Checks endpoints require GitHub App
+authentication; classic PATs and OAuth apps cannot update check runs.
+
+> Source: `/websites/github_en_rest` — Checks runs and repository dispatch.
 
 **e2e change detection:** `e2e` uses a `should-run` job that diffs the PR branch against its base. It runs when `elements/`, `files/`, `patches/`, `Justfile`, or `project.conf` change; otherwise the `e2e` job is skipped. Skipped satisfies the required status check.
 

--- a/docs/skills/workflow-map.md
+++ b/docs/skills/workflow-map.md
@@ -88,6 +88,7 @@ Successful publish.yml on testing   ← PARALLEL, DECOUPLED
 | `.github/workflows/publish.yml` | export, sign, boot-check, promote tags | `workflow_run` from build |
 | `.github/workflows/publish-smoke.yml` | observational smoke only | `workflow_run` from publish |
 | `.github/workflows/e2e.yml` | PR-facing testsuite check | `pull_request` |
+| `.github/workflows/lab-check.yml` | MergeRaptor-owned `testing-lab / dakota` Check Run for the Kubernetes lab | `repository_dispatch: lab-check` |
 | `.github/workflows/execute-release.yml` | SHA freshness check → cosign verify → stable release | `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch`. Skips if `:testing` digest equals `:stable` digest. |
 | `.github/workflows/sync-next-from-main.yml` | merge main into next (preserve junction refs) | `push: main`, `workflow_dispatch` |
 | ~~`promote-testing-to-main.yml`~~ | DELETED | Was: `push: testing`, schedule, manual |


### PR DESCRIPTION
## Summary

- add a default-branch `repository_dispatch` bridge for Dakota lab results
- mint a short-lived MergeRaptor installation token from the existing app secrets
- create or update one `testing-lab / dakota` Check Run for the exact PR head SHA
- include rich Argo workflow evidence without posting PR comments

## Security boundary

The MergeRaptor private key remains in GitHub Actions. Kubernetes sends only a bounded `repository_dispatch` payload using its existing GitHub credential. The workflow validates the commit SHA, lifecycle state, conclusion, and output sizes before calling the Checks API.

MergeRaptor requires `checks: write` and its existing `contents: read` permission. Permission approval is tracked in projectbluefin/common#865.

## Deployment order

Merge this PR before the corresponding `projectbluefin/lab` PR because `repository_dispatch` workflows must exist on the repository's default branch before the lab begins sending events.

## Validation

- `actionlint .github/workflows/lab-check.yml`
- targeted pre-commit hooks for the workflow and CI skills

The repository-wide `just lint` image-content check requires interactive `sudo`; the changed workflow and documentation passed their native lint gates.

## Coordinated lab change

The lab-side Argo reporter and PR poller integration is projectbluefin/lab#397. Keep that PR ordered after this default-branch workflow.

## Factory rollout

The coordinated default-branch bridges are projectbluefin/bluefin#902 and projectbluefin/bluefin-lts#456. The lab-side generic reporter, bounded BST admission, and Cosmic poller are in projectbluefin/lab#397.