### PR TITLE
ci: move daily testing publish to 21:00 UTC

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -190,7 +190,7 @@ lesson (2026-07-09).
 
 ## CI overview
 
-- **Schedule:** nightly at 13:00 UTC (after gnome-build-meta nightly ~08:00 UTC finish)
+- **Schedule:** nightly at 20:00 UTC (after gnome-build-meta nightly ~08:00 UTC finish)
 - **Publish triggers:** `merge_group`, `schedule`, `workflow_dispatch` (not `pull_request`)
 - **Remote cache:** `cache.projectbluefin.io:11002` (mTLS — `CASD_CLIENT_CERT` + `CASD_CLIENT_KEY`)
 - **Image:** `ghcr.io/projectbluefin/dakota:{testing,stable,next,btw}` and `:<sha>` (`:latest` is never published)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -190,7 +190,7 @@ lesson (2026-07-09).
 
 ## CI overview
 
-- **Schedule:** nightly at 20:00 UTC (after gnome-build-meta nightly ~08:00 UTC finish)
+- **Schedule:** nightly at 21:00 UTC (after gnome-build-meta nightly ~08:00 UTC finish)
 - **Publish triggers:** `merge_group`, `schedule`, `workflow_dispatch` (not `pull_request`)
 - **Remote cache:** `cache.projectbluefin.io:11002` (mTLS — `CASD_CLIENT_CERT` + `CASD_CLIENT_KEY`)
 - **Image:** `ghcr.io/projectbluefin/dakota:{testing,stable,next,btw}` and `:<sha>` (`:latest` is never published)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,12 @@ on:
       - "patches/**"
       - "project.conf"
       - "include/**"
-  # Fires daily at 20:00 UTC, after the gnome-build-meta nightly, to absorb
+  # Fires daily at 21:00 UTC, after the gnome-build-meta nightly, to absorb
   # nightly deltas before building and publishing :testing.
   # NOTE: schedule triggers run on the default branch; set testing as the
   # default branch in repo settings for this to target testing.
   schedule:
-    - cron: "0 20 * * *"
+    - cron: "0 21 * * *"
   workflow_dispatch:
 
 permissions: read-all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,12 @@ on:
       - "patches/**"
       - "project.conf"
       - "include/**"
-  # Fires daily at 13:00 UTC — 5 hours after the gnome-build-meta nightly
-  # (~08:00 UTC) to absorb nightly deltas before building.
+  # Fires daily at 20:00 UTC, after the gnome-build-meta nightly, to absorb
+  # nightly deltas before building and publishing :testing.
   # NOTE: schedule triggers run on the default branch; set testing as the
   # default branch in repo settings for this to target testing.
   schedule:
-    - cron: "0 13 * * *"
+    - cron: "0 20 * * *"
   workflow_dispatch:
 
 permissions: read-all

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -6,7 +6,7 @@
 |---|---|---|
 | `validate` | `pull_request` | `bst show` — graph + patch check (~15 min) |
 | `e2e` | `pull_request` when `elements/`, `files/`, `patches/`, `Justfile`, or `project.conf` changed | Smoke test in QEMU via projectbluefin/testsuite |
-| `build` | `push: testing/next` (paths-ignore: `.github/workflows/**`, `docs/**`, `**.md`, `AGENTS.md`), `merge_group`, `workflow_dispatch`, `schedule: daily 20:00 UTC` — skips on `pull_request` | Full OCI build (~60–90 min) |
+| `build` | `push: testing/next` (paths-ignore: `.github/workflows/**`, `docs/**`, `**.md`, `AGENTS.md`), `merge_group`, `workflow_dispatch`, `schedule: daily 21:00 UTC` — skips on `pull_request` | Full OCI build (~60–90 min) |
 | `build-aarch64` | `push: testing/main` (BST-affecting paths only), `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch` | ARM64 — fully decoupled, never blocks release |
 
 ## Publish pipeline (publish.yml)
@@ -36,7 +36,7 @@ build.yml (testing|next) → [workflow_run] → publish.yml
 `execute-release.yml` fires via `workflow_run` from `publish.yml` on the `testing` branch — no commit message gate, no PR, no human approval.
 
 ```
-push to testing (BST-affecting) or daily 20:00 UTC schedule
+push to testing (BST-affecting) or daily 21:00 UTC schedule
   → build.yml → publish.yml → boot-check → :testing
   → execute-release.yml (workflow_run from publish on testing)
        → SHA freshness check (:testing SHA vs :stable SHA)
@@ -51,7 +51,7 @@ push to testing (BST-affecting) or daily 20:00 UTC schedule
 
 ## Schedule
 
-Build fires daily at 20:00 UTC (`schedule:` in `build.yml`), plus on every BST-affecting push to `testing` or `next`, `merge_group`, and `workflow_dispatch`.
+Build fires daily at 21:00 UTC (`schedule:` in `build.yml`), plus on every BST-affecting push to `testing` or `next`, `merge_group`, and `workflow_dispatch`.
 
 ## Remote cache
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -6,7 +6,7 @@
 |---|---|---|
 | `validate` | `pull_request` | `bst show` — graph + patch check (~15 min) |
 | `e2e` | `pull_request` when `elements/`, `files/`, `patches/`, `Justfile`, or `project.conf` changed | Smoke test in QEMU via projectbluefin/testsuite |
-| `build` | `push: testing/next` (paths-ignore: `.github/workflows/**`, `docs/**`, `**.md`, `AGENTS.md`), `merge_group`, `workflow_dispatch`, `schedule: daily 13:00 UTC` — skips on `pull_request` | Full OCI build (~60–90 min) |
+| `build` | `push: testing/next` (paths-ignore: `.github/workflows/**`, `docs/**`, `**.md`, `AGENTS.md`), `merge_group`, `workflow_dispatch`, `schedule: daily 20:00 UTC` — skips on `pull_request` | Full OCI build (~60–90 min) |
 | `build-aarch64` | `push: testing/main` (BST-affecting paths only), `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch` | ARM64 — fully decoupled, never blocks release |
 
 ## Publish pipeline (publish.yml)
@@ -36,7 +36,7 @@ build.yml (testing|next) → [workflow_run] → publish.yml
 `execute-release.yml` fires via `workflow_run` from `publish.yml` on the `testing` branch — no commit message gate, no PR, no human approval.
 
 ```
-push to testing (BST-affecting) or daily 13:00 UTC schedule
+push to testing (BST-affecting) or daily 20:00 UTC schedule
   → build.yml → publish.yml → boot-check → :testing
   → execute-release.yml (workflow_run from publish on testing)
        → SHA freshness check (:testing SHA vs :stable SHA)
@@ -51,7 +51,7 @@ push to testing (BST-affecting) or daily 13:00 UTC schedule
 
 ## Schedule
 
-Build fires daily at 13:00 UTC (`schedule:` in `build.yml`), plus on every BST-affecting push to `testing` or `next`, `merge_group`, and `workflow_dispatch`.
+Build fires daily at 20:00 UTC (`schedule:` in `build.yml`), plus on every BST-affecting push to `testing` or `next`, `merge_group`, and `workflow_dispatch`.
 
 ## Remote cache
 

--- a/docs/skills/ci-reference.md
+++ b/docs/skills/ci-reference.md
@@ -14,7 +14,7 @@ metadata:
 > This file documents workflows and patterns from the pre-OCI-native era, including
 > deleted workflows (`promote-testing-to-main.yml`, `pr-release-gate.yml`,
 > `sync-main-to-testing.yml`, `cache-warm.yml`). Sections may describe workflows
-> that no longer exist, daily schedules that were replaced by `build.yml`'s 20:00 UTC
+> that no longer exist, daily schedules that were replaced by `build.yml`'s 21:00 UTC
 > trigger, or promotion flows that were replaced by `execute-release.yml`. For the
 > current workflow inventory, read `ci.md` and `workflow-map.md`. For current
 > promotion flow, read `release-promotion.md`.
@@ -55,8 +55,8 @@ Route through `ci.md` first, then come here only when the focused skills do not 
 | Published image | `ghcr.io/projectbluefin/dakota:{testing,stable,next,btw}` and `:$SHA` |
 | Build logs artifact | `buildstream-logs-x86_64-<variant>` (7-day retention) |
 | Trigger (validate) | `pull_request` — `bst show --deps all`, no CAS |
-| Trigger (build) | `schedule: daily 20:00 UTC`, `merge_group`, `workflow_dispatch` (no push trigger) |
-**Nightly schedule rationale** — builds on `testing` run once a day at 20:00 UTC (after GNOME nightlies and the `next` branch build) using the CAS cache pre-warmed by `merge_group` PR runs.
+| Trigger (build) | `schedule: daily 21:00 UTC`, `merge_group`, `workflow_dispatch` (no push trigger) |
+**Nightly schedule rationale** — builds on `testing` run once a day at 21:00 UTC (after GNOME nightlies and the `next` branch build) using the CAS cache pre-warmed by `merge_group` PR runs.
 
 **Merge queue path:** `build` fires on `merge_group` — full OCI build, real CI gate before merge. This warms the CAS cache but does not push a public stream tag. The daily schedule does the publishing.
 
@@ -394,7 +394,7 @@ podman run --rm --network=host --security-opt seccomp=unconfined ...
 The pipeline was redesigned so `:testing` publishes only once a day on schedule.
 PR merges warm the CAS via `merge_group`, but the push trigger was removed from
 `build.yml` to prevent global CAS concurrency starvation; builds now fire on
-schedule (`20:00 UTC`), `merge_group`, and `workflow_dispatch`.
+schedule (`21:00 UTC`), `merge_group`, and `workflow_dispatch`.
 
 **New flow:**
 ```

--- a/docs/skills/ci-reference.md
+++ b/docs/skills/ci-reference.md
@@ -14,7 +14,7 @@ metadata:
 > This file documents workflows and patterns from the pre-OCI-native era, including
 > deleted workflows (`promote-testing-to-main.yml`, `pr-release-gate.yml`,
 > `sync-main-to-testing.yml`, `cache-warm.yml`). Sections may describe workflows
-> that no longer exist, daily schedules that were replaced by `build.yml`'s 13:00 UTC
+> that no longer exist, daily schedules that were replaced by `build.yml`'s 20:00 UTC
 > trigger, or promotion flows that were replaced by `execute-release.yml`. For the
 > current workflow inventory, read `ci.md` and `workflow-map.md`. For current
 > promotion flow, read `release-promotion.md`.
@@ -55,8 +55,8 @@ Route through `ci.md` first, then come here only when the focused skills do not 
 | Published image | `ghcr.io/projectbluefin/dakota:{testing,stable,next,btw}` and `:$SHA` |
 | Build logs artifact | `buildstream-logs-x86_64-<variant>` (7-day retention) |
 | Trigger (validate) | `pull_request` — `bst show --deps all`, no CAS |
-| Trigger (build) | `schedule: daily 13:00 UTC`, `merge_group`, `workflow_dispatch` (no push trigger) |
-**Nightly schedule rationale** — builds on `testing` run once a day at 13:00 UTC (after GNOME nightlies and the `next` branch build) using the CAS cache pre-warmed by `merge_group` PR runs.
+| Trigger (build) | `schedule: daily 20:00 UTC`, `merge_group`, `workflow_dispatch` (no push trigger) |
+**Nightly schedule rationale** — builds on `testing` run once a day at 20:00 UTC (after GNOME nightlies and the `next` branch build) using the CAS cache pre-warmed by `merge_group` PR runs.
 
 **Merge queue path:** `build` fires on `merge_group` — full OCI build, real CI gate before merge. This warms the CAS cache but does not push a public stream tag. The daily schedule does the publishing.
 
@@ -394,7 +394,7 @@ podman run --rm --network=host --security-opt seccomp=unconfined ...
 The pipeline was redesigned so `:testing` publishes only once a day on schedule.
 PR merges warm the CAS via `merge_group`, but the push trigger was removed from
 `build.yml` to prevent global CAS concurrency starvation; builds now fire on
-schedule (`13:00 UTC`), `merge_group`, and `workflow_dispatch`.
+schedule (`20:00 UTC`), `merge_group`, and `workflow_dispatch`.
 
 **New flow:**
 ```

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -130,14 +130,14 @@ This is the fast path for stale-image complaints: the image date is usually wron
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| `build.yml` | `push: testing` for key-busting paths, `workflow_dispatch`, `schedule: daily 13:00 UTC` — NOT `pull_request` or `merge_group` | Run a single BuildStream assembly build per target (`oci/bluefin.bst` and `oci/bluefin-nvidia.bst`), push the resulting artifacts to `cache.projectbluefin.io`, and upload logs. Does not push to GHCR. |
+| `build.yml` | `push: testing` for key-busting paths, `workflow_dispatch`, `schedule: daily 20:00 UTC` — NOT `pull_request` or `merge_group` | Run a single BuildStream assembly build per target (`oci/bluefin.bst` and `oci/bluefin-nvidia.bst`), push the resulting artifacts to `cache.projectbluefin.io`, and upload logs. Does not push to GHCR. |
 | `publish.yml` | `workflow_run` from `build.yml` (branches: testing, next, + their gh-readonly-queue/* paths) | Fetch the remote-CAS artifact, export to OCI, run `just lint`, push `:$sha`, sign/attest, and promote `:testing`/`:next` tags. No build happens here. |
 | `execute-release.yml` | `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch` | SHA freshness check (:testing vs :stable). If different: cosign verify → skopeo copy `:testing` → `:stable` → fast-forward main → create GitHub Release. Skips if equal. |
 | `boot-test-aarch64.yml` | `workflow_run` from `build-aarch64.yml` on `testing`, `workflow_dispatch` (image input) | M0 aarch64 boot gate: verifies the `:aarch64` tag exists on GHCR (skopeo — does not trust build-aarch64's masked conclusion), boots it on `ubuntu-24.04-arm` via bcvk ephemeral (qemu/virtiofs, cargo-built — no upstream aarch64 binaries), gates on `multi-user.target`, reports graphical/gdm/bootc informationally, always uploads serial + journal artifacts. Never blocks x86_64. Tests direct kernel boot, not the bootc install-to-disk bootloader path. |
 | ~~`promote-testing-to-main.yml`~~ | DELETED | Was: `push: testing`, schedule Tue 04:00 UTC, manual. |
 | ~~`pr-release-gate.yml`~~ | DELETED | Was: `pull_request` to `main`. |
 | ~~`sync-main-to-testing.yml`~~ | DELETED | Was: `push: main`. |
-| ~~`cache-warm.yml`~~ | DELETED | Was: Mon/Thu 06:00 UTC schedule. Daily 13:00 UTC builds keep CAS warm. |
+| ~~`cache-warm.yml`~~ | DELETED | Was: Mon/Thu 06:00 UTC schedule. Daily 20:00 UTC builds keep CAS warm. |
 
 ## Trigger Behavior
 
@@ -145,7 +145,7 @@ This is the fast path for stale-image complaints: the image date is usually wron
 |---|---|---|---|---|---|
 | `validate` | Yes | No | No | No | No |
 | `e2e` | Yes (change-detected) | No | No | Yes | No |
-| `build` | No | testing only (key-busting paths) | No | Yes | Daily 13:00 UTC |
+| `build` | No | testing only (key-busting paths) | No | Yes | Daily 20:00 UTC |
 | `execute-release` | No | No | No | Yes | Via workflow_run from publish |
 | Push to GHCR? | No | Via publish.yml | No | Via publish.yml | Via publish.yml |
 
@@ -161,7 +161,7 @@ This is the fast path for stale-image complaints: the image date is usually wron
 
 **Merge queue path:** `build` is intentionally excluded from `merge_group`; queued PRs rely on the required validation/e2e checks, and the post-merge push to `testing` starts the real BuildStream path when key-busting files changed.
 
-**Daily build schedule:** `build.yml` fires at 13:00 UTC daily (after `nightly-next-build` completes). This keeps the remote CAS warm and ensures a fresh `:testing` tag even without a code push. `cache-warm.yml` was deleted — the daily build replaces it.
+**Daily build schedule:** `build.yml` fires at 20:00 UTC daily (after `nightly-next-build` completes). This keeps the remote CAS warm and ensures a fresh `:testing` tag even without a code push. `cache-warm.yml` was deleted — the daily build replaces it.
 
 **RE-backed assembly model (target):** `build.yml` must perform one final BST assembly per target through the BuildBarn RE service at `cache.projectbluefin.io:11002` and write the artifact to the remote CAS. The workflow must not run warmup shards, seed jobs, or a VM boot-check path. Remote execution is required, not optional.
 
@@ -2521,14 +2521,14 @@ flow (issue 1073). Key operational facts for CI debugging:
 **Daily BST build windows (serialized for CAS):**
 ```
 03:00 UTC  nightly-next-build → next branch (x86, 90-210 min)
-13:00 UTC  build.yml schedule → testing x86 default+nvidia serial (max-parallel:1, 90-390 min)
+20:00 UTC  build.yml schedule → testing x86 default+nvidia serial (max-parallel:1, 90-390 min)
 ~18:00     publish.yml fires → :testing + :testing-nvidia published
 ~18:00     build-aarch64.yml fires (workflow_run from publish) → ARM default (~90-210 min)
 ~18:00     execute-release.yml fires (workflow_run from publish) → freshness check → promote
 20:00      track-next-junctions → may trigger next junction build
 ```
 
-**`cache-warm.yml` is deleted.** The daily 13:00 UTC `build.yml` schedule replaces it. CAS stays warm as long as the daily build runs. If the daily build is absent for >48 hours, expect cold-start non-determinism.
+**`cache-warm.yml` is deleted.** The daily 20:00 UTC `build.yml` schedule replaces it. CAS stays warm as long as the daily build runs. If the daily build is absent for >48 hours, expect cold-start non-determinism.
 
 **ARM build trigger changed.** `build-aarch64.yml` now fires via `workflow_run` from `publish.yml` on `testing` — not a Tuesday cron. This ensures ARM starts only after x86 CAS writes complete, preventing write contention that was causing `Cached elements after warm: 0`.
 

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -130,14 +130,14 @@ This is the fast path for stale-image complaints: the image date is usually wron
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| `build.yml` | `push: testing` for key-busting paths, `workflow_dispatch`, `schedule: daily 20:00 UTC` — NOT `pull_request` or `merge_group` | Run a single BuildStream assembly build per target (`oci/bluefin.bst` and `oci/bluefin-nvidia.bst`), push the resulting artifacts to `cache.projectbluefin.io`, and upload logs. Does not push to GHCR. |
+| `build.yml` | `push: testing` for key-busting paths, `workflow_dispatch`, `schedule: daily 21:00 UTC` — NOT `pull_request` or `merge_group` | Run a single BuildStream assembly build per target (`oci/bluefin.bst` and `oci/bluefin-nvidia.bst`), push the resulting artifacts to `cache.projectbluefin.io`, and upload logs. Does not push to GHCR. |
 | `publish.yml` | `workflow_run` from `build.yml` (branches: testing, next, + their gh-readonly-queue/* paths) | Fetch the remote-CAS artifact, export to OCI, run `just lint`, push `:$sha`, sign/attest, and promote `:testing`/`:next` tags. No build happens here. |
 | `execute-release.yml` | `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch` | SHA freshness check (:testing vs :stable). If different: cosign verify → skopeo copy `:testing` → `:stable` → fast-forward main → create GitHub Release. Skips if equal. |
 | `boot-test-aarch64.yml` | `workflow_run` from `build-aarch64.yml` on `testing`, `workflow_dispatch` (image input) | M0 aarch64 boot gate: verifies the `:aarch64` tag exists on GHCR (skopeo — does not trust build-aarch64's masked conclusion), boots it on `ubuntu-24.04-arm` via bcvk ephemeral (qemu/virtiofs, cargo-built — no upstream aarch64 binaries), gates on `multi-user.target`, reports graphical/gdm/bootc informationally, always uploads serial + journal artifacts. Never blocks x86_64. Tests direct kernel boot, not the bootc install-to-disk bootloader path. |
 | ~~`promote-testing-to-main.yml`~~ | DELETED | Was: `push: testing`, schedule Tue 04:00 UTC, manual. |
 | ~~`pr-release-gate.yml`~~ | DELETED | Was: `pull_request` to `main`. |
 | ~~`sync-main-to-testing.yml`~~ | DELETED | Was: `push: main`. |
-| ~~`cache-warm.yml`~~ | DELETED | Was: Mon/Thu 06:00 UTC schedule. Daily 20:00 UTC builds keep CAS warm. |
+| ~~`cache-warm.yml`~~ | DELETED | Was: Mon/Thu 06:00 UTC schedule. Daily 21:00 UTC builds keep CAS warm. |
 
 ## Trigger Behavior
 
@@ -145,7 +145,7 @@ This is the fast path for stale-image complaints: the image date is usually wron
 |---|---|---|---|---|---|
 | `validate` | Yes | No | No | No | No |
 | `e2e` | Yes (change-detected) | No | No | Yes | No |
-| `build` | No | testing only (key-busting paths) | No | Yes | Daily 20:00 UTC |
+| `build` | No | testing only (key-busting paths) | No | Yes | Daily 21:00 UTC |
 | `execute-release` | No | No | No | Yes | Via workflow_run from publish |
 | Push to GHCR? | No | Via publish.yml | No | Via publish.yml | Via publish.yml |
 
@@ -161,7 +161,7 @@ This is the fast path for stale-image complaints: the image date is usually wron
 
 **Merge queue path:** `build` is intentionally excluded from `merge_group`; queued PRs rely on the required validation/e2e checks, and the post-merge push to `testing` starts the real BuildStream path when key-busting files changed.
 
-**Daily build schedule:** `build.yml` fires at 20:00 UTC daily (after `nightly-next-build` completes). This keeps the remote CAS warm and ensures a fresh `:testing` tag even without a code push. `cache-warm.yml` was deleted — the daily build replaces it.
+**Daily build schedule:** `build.yml` fires at 21:00 UTC daily (after `nightly-next-build` completes). This keeps the remote CAS warm and ensures a fresh `:testing` tag even without a code push. `cache-warm.yml` was deleted — the daily build replaces it.
 
 **RE-backed assembly model (target):** `build.yml` must perform one final BST assembly per target through the BuildBarn RE service at `cache.projectbluefin.io:11002` and write the artifact to the remote CAS. The workflow must not run warmup shards, seed jobs, or a VM boot-check path. Remote execution is required, not optional.
 
@@ -2521,14 +2521,14 @@ flow (issue 1073). Key operational facts for CI debugging:
 **Daily BST build windows (serialized for CAS):**
 ```
 03:00 UTC  nightly-next-build → next branch (x86, 90-210 min)
-20:00 UTC  build.yml schedule → testing x86 default+nvidia serial (max-parallel:1, 90-390 min)
+21:00 UTC  build.yml schedule → testing x86 default+nvidia serial (max-parallel:1, 90-390 min)
 ~18:00     publish.yml fires → :testing + :testing-nvidia published
 ~18:00     build-aarch64.yml fires (workflow_run from publish) → ARM default (~90-210 min)
 ~18:00     execute-release.yml fires (workflow_run from publish) → freshness check → promote
 20:00      track-next-junctions → may trigger next junction build
 ```
 
-**`cache-warm.yml` is deleted.** The daily 20:00 UTC `build.yml` schedule replaces it. CAS stays warm as long as the daily build runs. If the daily build is absent for >48 hours, expect cold-start non-determinism.
+**`cache-warm.yml` is deleted.** The daily 21:00 UTC `build.yml` schedule replaces it. CAS stays warm as long as the daily build runs. If the daily build is absent for >48 hours, expect cold-start non-determinism.
 
 **ARM build trigger changed.** `build-aarch64.yml` now fires via `workflow_run` from `publish.yml` on `testing` — not a Tuesday cron. This ensures ARM starts only after x86 CAS writes complete, preventing write contention that was causing `Cached elements after warm: 0`.
 

--- a/docs/skills/release-promotion.md
+++ b/docs/skills/release-promotion.md
@@ -71,7 +71,7 @@ Use when the task mentions:
 
 ```text
 push to testing (BST-affecting paths)
-  → build.yml (build job, including daily 20:00 UTC schedule)
+  → build.yml (build job, including daily 21:00 UTC schedule)
   → publish.yml (workflow_run)
       → boot-check gate (must boot before :testing is promoted)
       → :testing tag published to GHCR
@@ -272,8 +272,8 @@ flow (issue 1073). The key differences:
 - **`testing` is the development trunk.** All contributor, Renovate, and BST source
   bump PRs target `testing`. The `testing-merge-queue-no-review` ruleset requires
   `validate` + `e2e` and enables the merge queue.
-- **Daily build schedule:** `build.yml` has a `schedule: '0 20 * * *'` trigger that
-  fires at 20:00 UTC daily, keeping CAS warm and ensuring a fresh `:testing` each
+- **Daily build schedule:** `build.yml` has a `schedule: '0 21 * * *'` trigger that
+  fires at 21:00 UTC daily, keeping CAS warm and ensuring a fresh `:testing` each
   day even without a code push.
 - **ARM trigger change:** `build-aarch64.yml` now fires via `workflow_run` from
   `publish.yml` — not a Tuesday cron. This serializes ARM after x86 CAS writes

--- a/docs/skills/release-promotion.md
+++ b/docs/skills/release-promotion.md
@@ -71,7 +71,7 @@ Use when the task mentions:
 
 ```text
 push to testing (BST-affecting paths)
-  → build.yml (build job, including daily 13:00 UTC schedule)
+  → build.yml (build job, including daily 20:00 UTC schedule)
   → publish.yml (workflow_run)
       → boot-check gate (must boot before :testing is promoted)
       → :testing tag published to GHCR
@@ -272,8 +272,8 @@ flow (issue 1073). The key differences:
 - **`testing` is the development trunk.** All contributor, Renovate, and BST source
   bump PRs target `testing`. The `testing-merge-queue-no-review` ruleset requires
   `validate` + `e2e` and enables the merge queue.
-- **Daily build schedule:** `build.yml` has a `schedule: '0 13 * * *'` trigger that
-  fires at 13:00 UTC daily, keeping CAS warm and ensuring a fresh `:testing` each
+- **Daily build schedule:** `build.yml` has a `schedule: '0 20 * * *'` trigger that
+  fires at 20:00 UTC daily, keeping CAS warm and ensuring a fresh `:testing` each
   day even without a code push.
 - **ARM trigger change:** `build-aarch64.yml` now fires via `workflow_run` from
   `publish.yml` — not a Tuesday cron. This serializes ARM after x86 CAS writes

--- a/docs/skills/workflow-map.md
+++ b/docs/skills/workflow-map.md
@@ -54,7 +54,7 @@ Merge queue → testing or next
             ├─ publish-sbom [parallel]
             └─ promote to :testing / :next / :btw
 
-Daily 20:00 UTC / push: testing (BST-affecting paths) / manual
+Daily 21:00 UTC / push: testing (BST-affecting paths) / manual
   └─ build.yml (schedule or push trigger)
        └─ publish.yml (workflow_run from build)
             ├─ boot-check gate [must boot before :testing]
@@ -83,7 +83,7 @@ Successful publish.yml on testing   ← PARALLEL, DECOUPLED
 
 | Workflow | Owns | Normal trigger |
 |---|---|---|
-| `.github/workflows/build.yml` | BST build into remote CAS | `push: testing` (BST + CI-build-path files), `workflow_dispatch`, `schedule: daily 20:00 UTC`. `validate` lives in `validate.yml`; this workflow does not run on `pull_request` or `merge_group`. |
+| `.github/workflows/build.yml` | BST build into remote CAS | `push: testing` (BST + CI-build-path files), `workflow_dispatch`, `schedule: daily 21:00 UTC`. `validate` lives in `validate.yml`; this workflow does not run on `pull_request` or `merge_group`. |
 | `.github/workflows/build-aarch64.yml` | aarch64 OCI build + GHCR push | `push: testing/main` (BST-affecting paths), `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch`. Fully decoupled — never in `needs:` of publish/promote/release. |
 | `.github/workflows/publish.yml` | export, sign, boot-check, promote tags | `workflow_run` from build |
 | `.github/workflows/publish-smoke.yml` | observational smoke only | `workflow_run` from publish |
@@ -99,7 +99,7 @@ Successful publish.yml on testing   ← PARALLEL, DECOUPLED
 
 | Branch | Trigger | Published tag(s) | Notes |
 |---|---|---|---|
-| `testing` | `push` (BST-affecting paths only) or `schedule: 20:00 UTC` | `:testing` | **Development trunk. Primary `:testing` publish path.** Every BST-affecting push builds → publishes → promotes. Doc/workflow-only pushes are ignored (paths-ignore). |
+| `testing` | `push` (BST-affecting paths only) or `schedule: 21:00 UTC` | `:testing` | **Development trunk. Primary `:testing` publish path.** Every BST-affecting push builds → publishes → promotes. Doc/workflow-only pushes are ignored (paths-ignore). |
 | `main` | fast-forward from `execute-release.yml` | `:stable` | **Release bookmark only.** Only `execute-release.yml` writes here after a successful SHA freshness check + cosign verify + boot-check. No PRs target `main`. |
 | `next` | `push` or `sync-next-from-main` dispatch | `:next`, `:btw` | Rolling GNOME master; never stable. No PR requirement on branch protection. |
 | `gh-readonly-queue/testing/*` | merge-queue | (build only, no tag) | Gate before merge to `testing`. |
@@ -108,7 +108,7 @@ Successful publish.yml on testing   ← PARALLEL, DECOUPLED
 
 **What testing does (not just PRs):**
 ```
-push to testing (BST-affecting) or daily 20:00 UTC schedule
+push to testing (BST-affecting) or daily 21:00 UTC schedule
   → build.yml (build job)
   → publish.yml (workflow_run)
       → :testing tag published to GHCR

--- a/docs/skills/workflow-map.md
+++ b/docs/skills/workflow-map.md
@@ -54,7 +54,7 @@ Merge queue → testing or next
             ├─ publish-sbom [parallel]
             └─ promote to :testing / :next / :btw
 
-Daily 13:00 UTC / push: testing (BST-affecting paths) / manual
+Daily 20:00 UTC / push: testing (BST-affecting paths) / manual
   └─ build.yml (schedule or push trigger)
        └─ publish.yml (workflow_run from build)
             ├─ boot-check gate [must boot before :testing]
@@ -83,7 +83,7 @@ Successful publish.yml on testing   ← PARALLEL, DECOUPLED
 
 | Workflow | Owns | Normal trigger |
 |---|---|---|
-| `.github/workflows/build.yml` | BST build into remote CAS | `push: testing` (BST + CI-build-path files), `workflow_dispatch`, `schedule: daily 13:00 UTC`. `validate` lives in `validate.yml`; this workflow does not run on `pull_request` or `merge_group`. |
+| `.github/workflows/build.yml` | BST build into remote CAS | `push: testing` (BST + CI-build-path files), `workflow_dispatch`, `schedule: daily 20:00 UTC`. `validate` lives in `validate.yml`; this workflow does not run on `pull_request` or `merge_group`. |
 | `.github/workflows/build-aarch64.yml` | aarch64 OCI build + GHCR push | `push: testing/main` (BST-affecting paths), `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch`. Fully decoupled — never in `needs:` of publish/promote/release. |
 | `.github/workflows/publish.yml` | export, sign, boot-check, promote tags | `workflow_run` from build |
 | `.github/workflows/publish-smoke.yml` | observational smoke only | `workflow_run` from publish |
@@ -99,7 +99,7 @@ Successful publish.yml on testing   ← PARALLEL, DECOUPLED
 
 | Branch | Trigger | Published tag(s) | Notes |
 |---|---|---|---|
-| `testing` | `push` (BST-affecting paths only) or `schedule: 13:00 UTC` | `:testing` | **Development trunk. Primary `:testing` publish path.** Every BST-affecting push builds → publishes → promotes. Doc/workflow-only pushes are ignored (paths-ignore). |
+| `testing` | `push` (BST-affecting paths only) or `schedule: 20:00 UTC` | `:testing` | **Development trunk. Primary `:testing` publish path.** Every BST-affecting push builds → publishes → promotes. Doc/workflow-only pushes are ignored (paths-ignore). |
 | `main` | fast-forward from `execute-release.yml` | `:stable` | **Release bookmark only.** Only `execute-release.yml` writes here after a successful SHA freshness check + cosign verify + boot-check. No PRs target `main`. |
 | `next` | `push` or `sync-next-from-main` dispatch | `:next`, `:btw` | Rolling GNOME master; never stable. No PR requirement on branch protection. |
 | `gh-readonly-queue/testing/*` | merge-queue | (build only, no tag) | Gate before merge to `testing`. |
@@ -108,7 +108,7 @@ Successful publish.yml on testing   ← PARALLEL, DECOUPLED
 
 **What testing does (not just PRs):**
 ```
-push to testing (BST-affecting) or daily 13:00 UTC schedule
+push to testing (BST-affecting) or daily 20:00 UTC schedule
   → build.yml (build job)
   → publish.yml (workflow_run)
       → :testing tag published to GHCR

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -165,7 +165,7 @@ Dakota uses trunk-based development. `testing` is the development trunk; `main` 
 ```
 testing (development trunk — all PRs land here)
   │
-  └─► build.yml (daily 13:00 UTC + merge_group + workflow_dispatch)
+  └─► build.yml (daily 20:00 UTC + merge_group + workflow_dispatch)
           │
           └─► publish.yml (workflow_run on build success)
                   │
@@ -182,7 +182,7 @@ testing (development trunk — all PRs land here)
 | Stream | Tag | Cadence | Gate |
 |---|---|---|---|
 | Development | `:sha` | Every merge to `testing` | None |
-| Testing | `:testing` | Daily (13:00 UTC build) | boot-check |
+| Testing | `:testing` | Daily (20:00 UTC build) | boot-check |
 | Stable | `:stable` | Daily (if :testing != :stable) | SHA freshness check + cosign verify + boot-check |
 
 **All PRs target `testing`.** This includes contributor PRs, Renovate PRs, and BST source bump PRs. The `main` git branch is a release bookmark only — it is fast-forwarded by `execute-release.yml` after each successful promotion and must not be used as a PR base.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -165,7 +165,7 @@ Dakota uses trunk-based development. `testing` is the development trunk; `main` 
 ```
 testing (development trunk — all PRs land here)
   │
-  └─► build.yml (daily 20:00 UTC + merge_group + workflow_dispatch)
+  └─► build.yml (daily 21:00 UTC + merge_group + workflow_dispatch)
           │
           └─► publish.yml (workflow_run on build success)
                   │
@@ -182,7 +182,7 @@ testing (development trunk — all PRs land here)
 | Stream | Tag | Cadence | Gate |
 |---|---|---|---|
 | Development | `:sha` | Every merge to `testing` | None |
-| Testing | `:testing` | Daily (20:00 UTC build) | boot-check |
+| Testing | `:testing` | Daily (21:00 UTC build) | boot-check |
 | Stable | `:stable` | Daily (if :testing != :stable) | SHA freshness check + cosign verify + boot-check |
 
 **All PRs target `testing`.** This includes contributor PRs, Renovate PRs, and BST source bump PRs. The `main` git branch is a release bookmark only — it is fast-forwarded by `execute-release.yml` after each successful promotion and must not be used as a PR base.


### PR DESCRIPTION
## Summary

- move Dakota's scheduled `build.yml` trigger from 13:00 UTC to 21:00 UTC daily
- retain push and manual build triggers
- update the CI, workflow-map, and release documentation to match

A successful scheduled build still triggers `publish.yml`, which publishes the immutable SHA and advances `:testing` only after the boot-check gate.

## Local time

21:00 UTC is 17:00 EDT (5:00 PM) and 16:00 EST (4:00 PM). GitHub Actions cron remains fixed in UTC and does not follow daylight-saving changes.

## Validation

- `actionlint .github/workflows/build.yml`
- targeted pre-commit checks for the workflow and owning documentation
