### PR TITLE
ci: make CAS warm-up pull non-fatal and fit a seeded cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,12 +104,14 @@ jobs:
           enable-remote-execution: "false"
           enable-push: "false"
 
+      # Warm-up only; the build step pulls missing artifacts on demand.
       - name: Pull prebuilt artifacts from remote CAS
+        continue-on-error: true
         env:
           BST_FLAGS: -o x86_64_v3 false --no-interactive --config /src/buildstream-ci.conf
         run: |
           just bst artifact pull --deps all ${{ matrix.element }}
-        timeout-minutes: 15
+        timeout-minutes: 60
 
       - name: Count elements for progress tracking
         id: count


### PR DESCRIPTION
## Summary

The build jobs failed on testing because the warm-up pull step timed out at 15 minutes. The remote CAS now holds the full artifact set for all four variants (roughly 50 GB after pre-seeding), so pulling every dependency takes longer than the old budget. The step is a warm-up optimization, the build step already pulls anything missing on demand with its own 330 minute timeout.

1. **The pull step is now continue-on-error.** A slow or partial warm-up can no longer fail a build job.
2. **Its timeout is raised to 60 minutes** so it can still do its job against a fully seeded cache.

Verified: the failing run ([30236182393](https://github.com/projectbluefin/dakota/actions/runs/30236182393)) shows the timeout as the only failure, with the build steps never reached.