### PR TITLE
ci: fit the artifact push timeout to full image uploads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,7 @@ jobs:
           BST_FLAGS: -o x86_64_v3 false --no-interactive --config /src/buildstream-push.conf
         run: |
           just bst artifact push --deps run ${{ matrix.element }}
-        timeout-minutes: 30
+        timeout-minutes: 120
 
       - name: Upload build logs
         if: always()


### PR DESCRIPTION
## Summary

The stock build jobs on testing rebuilt their image artifacts and then hit the push step's 30 minute timeout while uploading roughly 9 GB to the remote CAS, twice in a row ([30238033133](https://github.com/projectbluefin/dakota/actions/runs/30238033133), [30255788189](https://github.com/projectbluefin/dakota/actions/runs/30255788189)). Image rebuilds are not byte-reproducible across runners, so retries re-upload the full artifact instead of resuming.

1. **The push timeout is raised to 120 minutes.** Unlike the warm-up pull this step must stay fatal, publish depends on the artifacts reaching the CAS, so it gets a budget that fits a full image upload at observed runner throughput.