### PR TITLE
fix(lab-check): drop explicit permission scopes from MergeRaptor token

### DIFF
--- a/.github/workflows/lab-check.yml
+++ b/.github/workflows/lab-check.yml
@@ -1,0 +1,91 @@
+name: Lab check
+
+on:
+  repository_dispatch:
+    types: [lab-check]
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  report:
+    name: Update MergeRaptor check
+    if: >-
+      github.event.client_payload.repository == github.repository &&
+      github.event.client_payload.sha != ''
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Create or update lab check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event.client_payload.sha }}
+          CHECK_JSON: ${{ toJSON(github.event.client_payload.check) }}
+        run: |
+          set -euo pipefail
+
+          PRODUCT="${GITHUB_REPOSITORY#*/}"
+          CHECK_NAME="testing-lab / ${PRODUCT}"
+
+          if [[ ! "${SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid commit SHA: ${SHA}" >&2
+            exit 1
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/commits/${SHA}" >/dev/null
+
+          STATE=$(jq -r '.state // empty' <<<"${CHECK_JSON}")
+          case "${STATE}" in
+            queued|in_progress|completed) ;;
+            *)
+              echo "Invalid check state: ${STATE}" >&2
+              exit 1
+              ;;
+          esac
+
+          CONCLUSION=$(jq -r '.conclusion // empty' <<<"${CHECK_JSON}")
+          if [[ "${STATE}" == "completed" ]]; then
+            case "${CONCLUSION}" in
+              success|failure|neutral|cancelled|timed_out|action_required|skipped|stale) ;;
+              *)
+                echo "Invalid completed conclusion: ${CONCLUSION}" >&2
+                exit 1
+                ;;
+            esac
+          fi
+
+          DETAILS_URL=$(jq -r '.details_url // empty' <<<"${CHECK_JSON}")
+          EXTERNAL_ID=$(jq -r '.external_id // empty' <<<"${CHECK_JSON}")
+          TITLE=$(jq -r '(.title // "Dakota lab validation")[0:255]' <<<"${CHECK_JSON}")
+          SUMMARY=$(jq -r '(.summary // "No lab summary was provided.")[0:60000]' <<<"${CHECK_JSON}")
+          TEXT=$(jq -r '(.text // "")[0:60000]' <<<"${CHECK_JSON}")
+          STARTED_AT=$(jq -r '.started_at // empty' <<<"${CHECK_JSON}")
+          COMPLETED_AT=$(jq -r '.completed_at // empty' <<<"${CHECK_JSON}")
+
+          CHECK_ID=$(
+            gh api --method GET               "repos/${GITHUB_REPOSITORY}/commits/${SHA}/check-runs"               -f per_page=100               --jq '.check_runs
+                | map(select(.name == "'"${CHECK_NAME}"'"))
+                | sort_by(.id)
+                | last
+                | .id // empty'
+          )
+
+          BODY=$(
+            jq -n               --arg name "${CHECK_NAME}"               --arg head_sha "${SHA}"               --arg details_url "${DETAILS_URL}"               --arg external_id "${EXTERNAL_ID}"               --arg status "${STATE}"               --arg conclusion "${CONCLUSION}"               --arg started_at "${STARTED_AT}"               --arg completed_at "${COMPLETED_AT}"               --arg title "${TITLE}"               --arg summary "${SUMMARY}"               --arg text "${TEXT}"               '{
+                name: $name,
+                head_sha: $head_sha,
+                status: $status,
+                output: {title: $title, summary: $summary, text: $text}
+              }
+              + if $details_url != "" then {details_url: $details_url} else {} end
+              + if $external_id != "" then {external_id: $external_id} else {} end
+              + if $started_at != "" then {started_at: $started_at} else {} end
+              + if $status == "completed" then {conclusion: $conclusion} else {} end
+              + if $status == "completed" and $completed_at != "" then {completed_at: $completed_at} else {} end'
+          )
+
+          if [[ -n "${CHECK_ID}" ]]; then
+            jq 'del(.head_sha)' <<<"${BODY}" |
+              gh api --method PATCH                 "repos/${GITHUB_REPOSITORY}/check-runs/${CHECK_ID}"                 --input - >/dev/null
+          else
+            gh api --method POST               "repos/${GITHUB_REPOSITORY}/check-runs"               --input - <<<"${BODY}" >/dev/null
+          fi


### PR DESCRIPTION
Same fix as projectbluefin/bluefin#915 — `permission-checks: write` and `permission-contents: read` in `actions/create-github-app-token@v3` cause 422 because the MergeRaptor installation hasn't been approved for `checks:write` via fine-grained tokens. Dropping them uses the App's full installation permissions instead.