### PR TITLE
ci(build): route x86 variants through BuildBox remote execution

### DIFF
--- a/.github/actions/generate-bst-ci-config/action.yml
+++ b/.github/actions/generate-bst-ci-config/action.yml
@@ -1,12 +1,12 @@
 name: Generate BuildStream CI config
-description: Write BuildStream CI config for the runner-based Dakota workflow.
+description: Write BuildStream CI config for remote builds and local artifact consumers.
 
 inputs:
   enable-remote-execution:
-    description: Retained for compatibility; Dakota uses the GitHub runner for builds and cache.projectbluefin.io for artifact/source caches.
+    description: Route build actions and CAS storage through cache.projectbluefin.io.
     required: true
   enable-push:
-    description: Push artifacts and sources to the remote cache. Set false for build jobs.
+    description: Publish built artifacts and fetched sources during the BuildStream build.
     required: false
     default: 'true'
 
@@ -23,13 +23,15 @@ runs:
         WORKSPACE_ROOT="${GITHUB_WORKSPACE:-$PWD}"
         mkdir -p "$WORKSPACE_ROOT/logs"
 
-        if [[ "${ENABLE_REMOTE_EXECUTION:-false}" == "true" ]]; then
-          echo "::error::Dakota CI uses the GitHub runner for the BuildStream build; remote execution is intentionally disabled."
+        if [[ "${ENABLE_REMOTE_EXECUTION:-false}" == "true" ]] &&
+           { [[ -z "${CASD_CLIENT_CERT:-}" ]] || [[ -z "${CASD_CLIENT_KEY:-}" ]]; }; then
+          echo "::error::remote execution was requested but CASD client credentials are missing"
           exit 1
         fi
 
         printf '%s\n' "${CASD_CLIENT_CERT:-}" > "$WORKSPACE_ROOT/client.crt"
         printf '%s\n' "${CASD_CLIENT_KEY:-}" > "$WORKSPACE_ROOT/client.key"
+        chmod 0600 "$WORKSPACE_ROOT/client.crt" "$WORKSPACE_ROOT/client.key"
 
         cat > "$WORKSPACE_ROOT/buildstream-ci.conf" <<'BSTCONF'
         scheduler:
@@ -46,11 +48,21 @@ runs:
         logdir: /src/logs
         BSTCONF
 
-        cat >> "$WORKSPACE_ROOT/buildstream-ci.conf" <<'BSTCONFBUILD'
+        if [[ "${ENABLE_REMOTE_EXECUTION:-false}" == "true" ]]; then
+          cat >> "$WORKSPACE_ROOT/buildstream-ci.conf" <<'BSTCONFBUILD'
+        build:
+          retry-failed: True
+          # Four BuildBox action slots × four jobs per action is the initial
+          # conservative ceiling on the 32-thread, 128 GiB executor.
+          max-jobs: 4
+        BSTCONFBUILD
+        else
+          cat >> "$WORKSPACE_ROOT/buildstream-ci.conf" <<'BSTCONFBUILD'
         build:
           retry-failed: True
           max-jobs: 1
         BSTCONFBUILD
+        fi
 
         if [[ -n "${CASD_CLIENT_CERT:-}" ]] && [[ -n "${CASD_CLIENT_KEY:-}" ]]; then
           PUSH_FLAG="true"
@@ -118,41 +130,46 @@ runs:
           cache-buildtrees: never
         BSTCONFCACHEBLOCK
 
-        if ! grep -Eq '^[[:space:]]*max-jobs:[[:space:]]*1[[:space:]]*$' "$WORKSPACE_ROOT/buildstream-ci.conf"; then
-          echo "::error::buildstream-ci.conf is missing build.max-jobs: 1; the runner-based Dakota build requires this cap."
-          exit 1
-        fi
+        if [[ "${ENABLE_REMOTE_EXECUTION:-false}" == "true" ]]; then
+          # The top-level storage service makes the runner's local casd a
+          # remote-backed cache, so artifact payloads stay on the BuildBox host.
+          # Keep this out of fetch-only publish configs: export must materialize
+          # the final artifact on the runner.
+          cat >> "$WORKSPACE_ROOT/buildstream-ci.conf" <<'BSTCONFREMOTE'
+          storage-service:
+            url: https://cache.projectbluefin.io:11002
+            connection-config:
+              keepalive-time: 180
+              retry-limit: 5
+              retry-delay: 1000
+              request-timeout: 180
+            auth:
+              client-key: /src/client.key
+              client-cert: /src/client.crt
 
-        cp "$WORKSPACE_ROOT/buildstream-ci.conf" "$WORKSPACE_ROOT/logs/buildstream-ci.conf"
-        echo "Remote execution enabled: no"
-        echo "=== BuildStream CI config ==="
-        cat "$WORKSPACE_ROOT/buildstream-ci.conf"
-
-        if [[ -n "${CASD_CLIENT_CERT:-}" ]] && [[ -n "${CASD_CLIENT_KEY:-}" ]]; then
-          cat > "$WORKSPACE_ROOT/buildstream-push.conf" <<'BSTCONFPUSH'
-        scheduler:
-          on-error: continue
-          fetchers: 16
-          builders: 2
-          network-retries: 3
-
-        logging:
-          message-format: '[%{wallclock}][%{elapsed}][%{key}][%{element}] %{action} %{message}'
-          error-lines: 80
-
-        cachedir: /root/.cache/buildstream
-        logdir: /src/logs
-
-        build:
-          retry-failed: True
-          max-jobs: 1
-
-        cache:
-          cache-buildtrees: never
-
-        artifacts:
-          servers:
-          - url: https://cache.projectbluefin.io:11002
+        remote-execution:
+          execution-service:
+            url: https://cache.projectbluefin.io:11002
+            connection-config:
+              keepalive-time: 180
+              retry-limit: 5
+              retry-delay: 1000
+              request-timeout: 180
+            auth:
+              client-key: /src/client.key
+              client-cert: /src/client.crt
+          storage-service:
+            url: https://cache.projectbluefin.io:11002
+            connection-config:
+              keepalive-time: 180
+              retry-limit: 5
+              retry-delay: 1000
+              request-timeout: 180
+            auth:
+              client-key: /src/client.key
+              client-cert: /src/client.crt
+          action-cache-service:
+            url: https://cache.projectbluefin.io:11002
             push: true
             connection-config:
               keepalive-time: 180
@@ -162,23 +179,35 @@ runs:
             auth:
               client-key: /src/client.key
               client-cert: /src/client.crt
-          - url: https://gbm.gnome.org:11003
-            push: false
-            connection-config:
-              keepalive-time: 180
-              retry-limit: 5
-              retry-delay: 1000
-              request-timeout: 180
-          - url: https://cache.freedesktop-sdk.io:11001
-            push: false
-            connection-config:
-              keepalive-time: 180
-              retry-limit: 5
-              retry-delay: 1000
-              request-timeout: 180
-
-        BSTCONFPUSH
-          cp "$WORKSPACE_ROOT/buildstream-push.conf" "$WORKSPACE_ROOT/logs/buildstream-push.conf"
-          echo "=== BuildStream push config ==="
-          cat "$WORKSPACE_ROOT/buildstream-push.conf"
+        BSTCONFREMOTE
         fi
+
+        if [[ "${ENABLE_REMOTE_EXECUTION:-false}" == "true" ]]; then
+          if ! grep -Eq '^[[:space:]]*max-jobs:[[:space:]]*4[[:space:]]*$' "$WORKSPACE_ROOT/buildstream-ci.conf"; then
+            echo "::error::remote build config is missing build.max-jobs: 4"
+            exit 1
+          fi
+          if ! grep -Fq 'remote-execution:' "$WORKSPACE_ROOT/buildstream-ci.conf"; then
+            echo "::error::remote-execution block missing from generated buildstream-ci.conf"
+            exit 1
+          fi
+          if [[ $(grep -c '^[[:space:]]*storage-service:' "$WORKSPACE_ROOT/buildstream-ci.conf") -ne 2 ]]; then
+            echo "::error::remote build config requires top-level and remote-execution storage services"
+            exit 1
+          fi
+          echo "Remote execution enabled: yes"
+        else
+          if ! grep -Eq '^[[:space:]]*max-jobs:[[:space:]]*1[[:space:]]*$' "$WORKSPACE_ROOT/buildstream-ci.conf"; then
+            echo "::error::local build config is missing build.max-jobs: 1"
+            exit 1
+          fi
+          if grep -Fq 'remote-execution:' "$WORKSPACE_ROOT/buildstream-ci.conf"; then
+            echo "::error::remote-execution block present in a local/fetch-only config"
+            exit 1
+          fi
+          echo "Remote execution enabled: no"
+        fi
+
+        cp "$WORKSPACE_ROOT/buildstream-ci.conf" "$WORKSPACE_ROOT/logs/buildstream-ci.conf"
+        echo "=== BuildStream CI config ==="
+        cat "$WORKSPACE_ROOT/buildstream-ci.conf"

--- a/.github/actions/generate-bst-ci-config/action.yml
+++ b/.github/actions/generate-bst-ci-config/action.yml
@@ -33,6 +33,31 @@ runs:
         printf '%s\n' "${CASD_CLIENT_KEY:-}" > "$WORKSPACE_ROOT/client.key"
         chmod 0600 "$WORKSPACE_ROOT/client.crt" "$WORKSPACE_ROOT/client.key"
 
+        # Every remote service entry shares one endpoint tuning and mTLS
+        # identity; the stanzas expand inside the unquoted heredocs below.
+        CONNECTION_CONFIG=$(cat <<'EOF'
+            connection-config:
+              keepalive-time: 180
+              retry-limit: 5
+              retry-delay: 1000
+              request-timeout: 180
+        EOF
+        )
+        CLIENT_AUTH=$(cat <<'EOF'
+            auth:
+              client-key: /src/client.key
+              client-cert: /src/client.crt
+        EOF
+        )
+
+        if [[ "${ENABLE_REMOTE_EXECUTION:-false}" == "true" ]]; then
+          # Four BuildBox action slots × four jobs per action is the initial
+          # conservative ceiling on the 32-thread, 128 GiB executor.
+          MAX_JOBS=4
+        else
+          MAX_JOBS=1
+        fi
+
         cat > "$WORKSPACE_ROOT/buildstream-ci.conf" <<'BSTCONF'
         scheduler:
           on-error: continue
@@ -48,21 +73,11 @@ runs:
         logdir: /src/logs
         BSTCONF
 
-        if [[ "${ENABLE_REMOTE_EXECUTION:-false}" == "true" ]]; then
-          cat >> "$WORKSPACE_ROOT/buildstream-ci.conf" <<'BSTCONFBUILD'
+        cat >> "$WORKSPACE_ROOT/buildstream-ci.conf" <<BSTCONFBUILD
         build:
           retry-failed: True
-          # Four BuildBox action slots × four jobs per action is the initial
-          # conservative ceiling on the 32-thread, 128 GiB executor.
-          max-jobs: 4
+          max-jobs: ${MAX_JOBS}
         BSTCONFBUILD
-        else
-          cat >> "$WORKSPACE_ROOT/buildstream-ci.conf" <<'BSTCONFBUILD'
-        build:
-          retry-failed: True
-          max-jobs: 1
-        BSTCONFBUILD
-        fi
 
         if [[ -n "${CASD_CLIENT_CERT:-}" ]] && [[ -n "${CASD_CLIENT_KEY:-}" ]]; then
           PUSH_FLAG="true"
@@ -72,55 +87,27 @@ runs:
           servers:
           - url: https://cache.projectbluefin.io:11002
             push: ${PUSH_FLAG}
-            connection-config:
-              keepalive-time: 180
-              retry-limit: 5
-              retry-delay: 1000
-              request-timeout: 180
-            auth:
-              client-key: /src/client.key
-              client-cert: /src/client.crt
+        ${CONNECTION_CONFIG}
+        ${CLIENT_AUTH}
           - url: https://gbm.gnome.org:11003
             push: false
-            connection-config:
-              keepalive-time: 180
-              retry-limit: 5
-              retry-delay: 1000
-              request-timeout: 180
+        ${CONNECTION_CONFIG}
           - url: https://cache.freedesktop-sdk.io:11001
             push: false
-            connection-config:
-              keepalive-time: 180
-              retry-limit: 5
-              retry-delay: 1000
-              request-timeout: 180
+        ${CONNECTION_CONFIG}
 
         source-caches:
           servers:
           - url: https://cache.projectbluefin.io:11002
             push: ${PUSH_FLAG}
-            connection-config:
-              keepalive-time: 180
-              retry-limit: 5
-              retry-delay: 1000
-              request-timeout: 180
-            auth:
-              client-key: /src/client.key
-              client-cert: /src/client.crt
+        ${CONNECTION_CONFIG}
+        ${CLIENT_AUTH}
           - url: https://gbm.gnome.org:11003
             push: false
-            connection-config:
-              keepalive-time: 180
-              retry-limit: 5
-              retry-delay: 1000
-              request-timeout: 180
+        ${CONNECTION_CONFIG}
           - url: https://cache.freedesktop-sdk.io:11001
             push: false
-            connection-config:
-              keepalive-time: 180
-              retry-limit: 5
-              retry-delay: 1000
-              request-timeout: 180
+        ${CONNECTION_CONFIG}
         BSTCONFCACHE
         fi
 
@@ -135,76 +122,29 @@ runs:
           # remote-backed cache, so artifact payloads stay on the BuildBox host.
           # Keep this out of fetch-only publish configs: export must materialize
           # the final artifact on the runner.
-          cat >> "$WORKSPACE_ROOT/buildstream-ci.conf" <<'BSTCONFREMOTE'
+          cat >> "$WORKSPACE_ROOT/buildstream-ci.conf" <<BSTCONFREMOTE
           storage-service:
             url: https://cache.projectbluefin.io:11002
-            connection-config:
-              keepalive-time: 180
-              retry-limit: 5
-              retry-delay: 1000
-              request-timeout: 180
-            auth:
-              client-key: /src/client.key
-              client-cert: /src/client.crt
+        ${CONNECTION_CONFIG}
+        ${CLIENT_AUTH}
 
         remote-execution:
           execution-service:
             url: https://cache.projectbluefin.io:11002
-            connection-config:
-              keepalive-time: 180
-              retry-limit: 5
-              retry-delay: 1000
-              request-timeout: 180
-            auth:
-              client-key: /src/client.key
-              client-cert: /src/client.crt
+        ${CONNECTION_CONFIG}
+        ${CLIENT_AUTH}
           storage-service:
             url: https://cache.projectbluefin.io:11002
-            connection-config:
-              keepalive-time: 180
-              retry-limit: 5
-              retry-delay: 1000
-              request-timeout: 180
-            auth:
-              client-key: /src/client.key
-              client-cert: /src/client.crt
+        ${CONNECTION_CONFIG}
+        ${CLIENT_AUTH}
           action-cache-service:
             url: https://cache.projectbluefin.io:11002
             push: true
-            connection-config:
-              keepalive-time: 180
-              retry-limit: 5
-              retry-delay: 1000
-              request-timeout: 180
-            auth:
-              client-key: /src/client.key
-              client-cert: /src/client.crt
+        ${CONNECTION_CONFIG}
+        ${CLIENT_AUTH}
         BSTCONFREMOTE
-        fi
-
-        if [[ "${ENABLE_REMOTE_EXECUTION:-false}" == "true" ]]; then
-          if ! grep -Eq '^[[:space:]]*max-jobs:[[:space:]]*4[[:space:]]*$' "$WORKSPACE_ROOT/buildstream-ci.conf"; then
-            echo "::error::remote build config is missing build.max-jobs: 4"
-            exit 1
-          fi
-          if ! grep -Fq 'remote-execution:' "$WORKSPACE_ROOT/buildstream-ci.conf"; then
-            echo "::error::remote-execution block missing from generated buildstream-ci.conf"
-            exit 1
-          fi
-          if [[ $(grep -c '^[[:space:]]*storage-service:' "$WORKSPACE_ROOT/buildstream-ci.conf") -ne 2 ]]; then
-            echo "::error::remote build config requires top-level and remote-execution storage services"
-            exit 1
-          fi
           echo "Remote execution enabled: yes"
         else
-          if ! grep -Eq '^[[:space:]]*max-jobs:[[:space:]]*1[[:space:]]*$' "$WORKSPACE_ROOT/buildstream-ci.conf"; then
-            echo "::error::local build config is missing build.max-jobs: 1"
-            exit 1
-          fi
-          if grep -Fq 'remote-execution:' "$WORKSPACE_ROOT/buildstream-ci.conf"; then
-            echo "::error::remote-execution block present in a local/fetch-only config"
-            exit 1
-          fi
           echo "Remote execution enabled: no"
         fi
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -170,12 +170,13 @@ re-run the pre-flight until it is clean. Only then proceed.
 - "The stale build is for a different branch, it won't interfere" → **It uses the same runners and CAS. Cancel it.**
 - "I already cancelled one build, that's enough" → **Cancel ALL of them. Run the pre-flight again.**
 
-Concurrent BST builds share the same `ubuntu-24.04` runner pool and the same remote CAS
-write bandwidth at `cache.projectbluefin.io:11002`. Two concurrent builds do not halve
-wall time — they more than double it and risk 6-hour timeouts with
-`Cached elements after warm: 0`.
+Independent BST **workflow runs** share the same remote executor and CAS. Never
+start a second build workflow while one is active. The four x86_64 matrix jobs inside
+one `build.yml` run are the intentional exception: they start together and are bounded
+by the BuildBox backend's four global action slots. Do not cancel matrix siblings or
+serialize them; their CAS payloads stay remote and BuildBox enforces capacity.
 
-**One build. Field clear first. No exceptions.**
+**One build workflow run, with its four coordinated variants. Field clear first.**
 
 **Pre-flight is atomic:** cancel → verify clear → push/dispatch must complete in one
 uninterrupted sequence. Cancelling the active build and then not pushing the
@@ -191,8 +192,8 @@ lesson (2026-07-09).
 ## CI overview
 
 - **Schedule:** nightly at 13:00 UTC (after gnome-build-meta nightly ~08:00 UTC finish)
-- **Publish triggers:** `merge_group`, `schedule`, `workflow_dispatch` (not `pull_request`)
-- **Remote cache:** `cache.projectbluefin.io:11002` (mTLS — `CASD_CLIENT_CERT` + `CASD_CLIENT_KEY`)
+- **Build triggers:** BST-affecting `push: testing`, daily schedule, or `workflow_dispatch` (not PR/merge-group)
+- **Remote build:** BuildBox execution + remote CAS at `cache.projectbluefin.io:11002` (mTLS — `CASD_CLIENT_CERT` + `CASD_CLIENT_KEY`)
 - **Image:** `ghcr.io/projectbluefin/dakota:{testing,stable,next,btw}` and `:<sha>` (`:latest` is never published)
 
 ## Key architecture

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,9 +48,11 @@ jobs:
     if: (!cancelled()) && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'push')
     runs-on: ubuntu-24.04
     timeout-minutes: 350
+    # The BuildBox backend has four action slots. Start every image variant
+    # together; the backend remains the global execution-capacity limit.
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 4
       matrix:
         include:
           - variant: default
@@ -101,17 +103,11 @@ jobs:
           CASD_CLIENT_KEY: ${{ secrets.CASD_CLIENT_KEY }}
         uses: ./.github/actions/generate-bst-ci-config
         with:
-          enable-remote-execution: "false"
-          enable-push: "false"
-
-      # Warm-up only; the build step pulls missing artifacts on demand.
-      - name: Pull prebuilt artifacts from remote CAS
-        continue-on-error: true
-        env:
-          BST_FLAGS: -o x86_64_v3 false --no-interactive --config /src/buildstream-ci.conf
-        run: |
-          just bst artifact pull --deps all ${{ matrix.element }}
-        timeout-minutes: 60
+          enable-remote-execution: "true"
+          # BuildStream adds artifact/source push queues to the build when the
+          # configured remotes are writable. RE and the caches share one CAS,
+          # so payloads remain on the BuildBox host and are deduplicated there.
+          enable-push: "true"
 
       - name: Count elements for progress tracking
         id: count
@@ -139,16 +135,19 @@ jobs:
           ELEMENT_TOTAL: ${{ steps.count.outputs.total }}
         run: |
           set -o pipefail
+          CONSOLE_LOG="logs/bst-console-${{ matrix.variant }}.log"
           just bst build --deps none ${{ matrix.element }} 2>&1 \
+            | tee "$CONSOLE_LOG" \
             | python3 files/scripts/bst-progress.py
-        timeout-minutes: 330
 
-      - name: Push OCI artifact to remote CAS
-        env:
-          BST_FLAGS: -o x86_64_v3 false --no-interactive --config /src/buildstream-push.conf
-        run: |
-          just bst artifact push --deps run ${{ matrix.element }}
-        timeout-minutes: 120
+          # Fail closed: a green cache hit is not proof that BuildStream loaded
+          # the remote executor. The startup banner is emitted whenever the
+          # remote-execution block is active, even if no action needs rebuilding.
+          if ! grep -Fq "Remote Execution Configuration" "$CONSOLE_LOG"; then
+            echo "::error::BuildStream did not load the remote execution configuration"
+            exit 1
+          fi
+        timeout-minutes: 330
 
       - name: Upload build logs
         if: always()

--- a/Justfile
+++ b/Justfile
@@ -78,6 +78,7 @@ bst *ARGS:
 [group('dev')]
 check-publish-workflow:
     python3 scripts/check_publish_workflow.py
+    python3 -m unittest scripts.test_check_publish_workflow
 
 [group('dev')]
 monitor-pipeline BUILD_RUN_ID="":

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -6,7 +6,7 @@
 |---|---|---|
 | `validate` | `pull_request` | `bst show` — graph + patch check (~15 min) |
 | `e2e` | `pull_request` when `elements/`, `files/`, `patches/`, `Justfile`, or `project.conf` changed | Smoke test in QEMU via projectbluefin/testsuite |
-| `build` | `push: testing/next` (paths-ignore: `.github/workflows/**`, `docs/**`, `**.md`, `AGENTS.md`), `merge_group`, `workflow_dispatch`, `schedule: daily 13:00 UTC` — skips on `pull_request` | Full OCI build (~60–90 min) |
+| `build` | `push: testing` (BST-affecting paths), `workflow_dispatch`, `schedule: daily 13:00 UTC` — skips on `pull_request`/`merge_group` | Four x86 variants concurrently through remote BuildBox execution; artifacts land in the remote CAS |
 | `build-aarch64` | `push: testing/main` (BST-affecting paths only), `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch` | ARM64 — fully decoupled, never blocks release |
 
 ## Publish pipeline (publish.yml)
@@ -51,11 +51,11 @@ push to testing (BST-affecting) or daily 13:00 UTC schedule
 
 ## Schedule
 
-Build fires daily at 13:00 UTC (`schedule:` in `build.yml`), plus on every BST-affecting push to `testing` or `next`, `merge_group`, and `workflow_dispatch`.
+Build fires daily at 13:00 UTC, on BST-affecting pushes to `testing`, and through `workflow_dispatch`. The nightly-next dispatcher invokes the same workflow explicitly on `next`; PR and merge-queue events do not run it.
 
-## Remote cache
+## Remote execution and cache
 
-`cache.projectbluefin.io:11002` — mTLS via `CASD_CLIENT_CERT` + `CASD_CLIENT_KEY`.
+`cache.projectbluefin.io:11002` — BuildBox 1.4.11 execution, remote CAS, artifact/source caches, and action cache behind mTLS via `CASD_CLIENT_CERT` + `CASD_CLIENT_KEY`. Build jobs fail closed; publish uses a fetch-only configuration so it can materialize images locally.
 
 ## Published images
 

--- a/docs/skills/buildstream.md
+++ b/docs/skills/buildstream.md
@@ -138,24 +138,25 @@ Changing a `kind: stack` dependency does not always invalidate downstream `compo
 
 Dakota's `patches/` directory is still carrying a small downstream patch queue for FSDK and GNOME Build Meta behavior that has not landed in the pinned upstream release yet. Every patch should carry an `Upstream-Status` header plus an `Exit` line so the next engineer can tell whether the workaround is still pending upstream or should be dropped. This is especially important when the patch is only needed because the junction is still older than the stock GNOME OS baseline.
 
-### Warm-cache builds still take 90-120 min — this is normal (2026-06-23)
+### Legacy runner-local warm-cache timing (2026-06-23)
 
-Even with a fully warm remote CAS, a full build takes 90-120 min. Common misconception: "cache is hot = fast build." Actual breakdown:
+> Superseded for x86 CI by remote-backed CAS and BuildBox execution on
+> 2026-07-28. The 90–150 minute range described the old explicit pre-pull and
+> runner-local assembly path; do not use it to justify reintroducing those steps.
 
-- **Pull volume:** ~1,400 elements × a few seconds each / 32 parallel fetchers = 15-30 min just for network pulls
-- **Two parallel jobs:** `default` and `nvidia` both run simultaneously, each hitting the same CAS endpoint, halving effective bandwidth per job
-- **OCI assembly is sequential:** After all elements pull/build, `oci/bluefin.bst` runs chunkify + image assembly — single-threaded, typically 20-40 min on its own
-- **Cold elements:** Any junction ref bump (Renovate PRs for distrobox, gnome-build-meta, etc.) invalidates those subtrees → full recompile from source adds 30-90 min
+Cold junction changes can still take time because actions genuinely need to run,
+but they run on the remote executor. Measure the new path before tuning.
 
-Do not cancel a build under 120 min just because it "seems slow." Historical range for successful builds: 90-150 min.
+### Fetcher count needs measurement under remote-backed CAS (2026-06-23)
 
-### 32 fetchers is the right setting for cache.projectbluefin.io (2026-06-23)
-
-`buildstream-ci.conf` uses `fetchers: 32` (BST default is 10). With default + nvidia running simultaneously = 64 concurrent gRPC streams. The CAS server is a Hetzner AX102-U (1 Gbit/s uplink, NVMe Gen4) and can serve 64 streams comfortably. The bottleneck is network bandwidth (~125 MB/s total), not server capacity. Do not reduce fetchers without evidence of server-side saturation.
+`buildstream-ci.conf` retains `fetchers: 32` for the initial RE rollout. Four
+variant jobs can create more metadata requests than the old two-job model, while
+top-level remote storage avoids transferring file payloads through the runners.
+Change this value only from observed endpoint saturation or latency evidence.
 
 ### Avoid /dev/stdin redirection in remote sandboxes (2026-07-25)
 
-BuildStream elements that write inline configuration files using `install -Dm644 /dev/stdin ... <<'EOF'` fail in remote execution sandboxes (like BuildBarn) where `/dev/stdin` is not available as a standard character device. Write inline files using a two-step pattern: create the destination file with `install -Dm644 /dev/null target`, then populate it with `cat > target <<'EOF'`.
+BuildStream elements that write inline configuration files using `install -Dm644 /dev/stdin ... <<'EOF'` fail in remote execution sandboxes (such as BuildBox) where `/dev/stdin` is not available as a standard character device. Write inline files using a two-step pattern: create the destination file with `install -Dm644 /dev/null target`, then populate it with `cat > target <<'EOF'`.
 
 ### overlap-whitelist required for base system file replacement
 

--- a/docs/skills/ci-tooling.md
+++ b/docs/skills/ci-tooling.md
@@ -53,8 +53,11 @@ jobs to fail before BuildStream started. `scripts/check_publish_workflow.py`
 extracts that block and passes it to `bash -n`; `validate.yml` runs the
 checker through `just check-publish-workflow`.
 
-Keep this check when changing the config generator. A generated cache
-configuration is not evidence that the composite shell itself is parseable.
+Keep this check when changing the config generator. The checker also executes
+the shell with dummy credentials in remote-build and fetch-only modes, verifies
+fail-closed credential handling, and inspects the resulting configs. Run its
+unit tests through `just check-publish-workflow`; a test file that is not wired
+into a Just recipe and CI is not protection.
 
 ### Composite-action shell structure
 

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -19,26 +19,29 @@ Load this file, identify the failure class, then load only the next skill you ne
 
 ## Dakota build model
 
-**Target contract:** Dakota builds must use a single BuildStream build per target executed through **verified remote execution (RE) on the BuildBarn grid** at `cache.projectbluefin.io:11002`.
-The runner drives the build and pushes results to the remote CAS; expensive compile actions must run on BuildBarn workers, not on the GitHub runner.
+**Target contract:** Dakota's four x86_64 image variants execute through the
+BuildBox 1.4.11 CAS/executor at `cache.projectbluefin.io:11002`. The GitHub
+runner drives BuildStream, but build actions and CAS payloads remain on the
+remote host.
+
 For Dakota, that means:
-- one build job per target (`dakota` and `dakota-nvidia`)
-- BuildStream config that contains a `remote-execution:` block routed through `cache.projectbluefin.io:11002`
-- no seed/warmup shards and no VM boot-check path in the default workflow
-- verification via the RE fail-fast evidence checks below and the existing image export/publish path before `:testing` is moved
+- one concurrent matrix job for each of default, NVIDIA, gaming, and NVIDIA-gaming;
+- `max-parallel: 4`, matching the backend's four global action slots;
+- `cache.storage-service` plus `remote-execution` execution, storage, and action-cache services;
+- writable artifact/source remotes so BuildStream's build pipeline publishes results automatically;
+- no explicit dependency pre-pull, standalone artifact push, seed shards, or local fallback;
+- `build.max-jobs: 4` for the initial capacity setting.
 
-**Current verified state:** The tracked workflow is **not compliant** with this contract. `build.yml` calls the config generator with `enable-remote-execution: "false"`, the generator action errors if `enable-remote-execution` is set to `"true"`, and the generated `buildstream-ci.conf` contains no `remote-execution:` block. The current CI path is therefore runner-local / cache-only and is unacceptable under this policy. Restoring RE requires an implementation fix in the workflow and generator.
+The x86 build is fail-closed. Missing mTLS credentials, a missing RE block, an
+unreachable executor, or an absent `Remote Execution Configuration` startup
+banner fails the job. Fetch-only consumers such as `publish.yml` intentionally
+omit top-level remote storage and RE because artifact checkout must materialize
+the final image on that runner.
 
-The following operational states are **unacceptable** for normal Dakota builds:
-- remote artifact/source cache with local driver execution (runner-local builds)
-- cache-only mode where the runner performs the build work
-- any config that omits the `remote-execution:` block while still claiming to use remote cache
-
-The only acceptable exception is an **explicit, diagnosed failure investigation** where a known RE failure mode has been identified and documented for that run. A fallback to runner-local or cache-only execution is itself a failure state that must be recovered from, not a normal operating mode.
-
-When the workflow uses a composite action to generate BuildStream config, write the config files into `${GITHUB_WORKSPACE}` (the checkout root) rather than the action directory. The `just bst` wrapper mounts the checkout at `/src` inside the bst2 container, so the files must be visible there as `/src/buildstream-ci.conf` and `/src/buildstream-push.conf`.
-
-The generated config must contain a `remote-execution:` block. See the RE fail-fast evidence checks below.
+When the composite action generates BuildStream configuration, it writes
+`buildstream-ci.conf` into `${GITHUB_WORKSPACE}`. The `just bst` wrapper mounts
+the checkout at `/src`, making the file available as
+`/src/buildstream-ci.conf` inside the bst2 container.
 
 ## When to Use
 
@@ -58,7 +61,7 @@ Use this skill when the task mentions:
 
 ## ⚠️ Builder Discipline — Read Before Doing Anything
 
-**ONE BST build at a time. Always.**
+**ONE BUILD WORKFLOW RUN at a time. Its four x86_64 variants run together.**
 
 Before merging, pushing, or dispatching any workflow, run the mandatory pre-flight:
 
@@ -80,7 +83,10 @@ else:
 
 If output is not `OK: field is clear` — **cancel every listed run first**.
 
-**Cache-warm is not exempt.** It shares the same `ubuntu-24.04` runner pool and CAS write bandwidth as real builds. Two concurrent BST jobs do not halve wall time — they more than double it and risk 6-hour timeouts with zero elements cached.
+**Cache-warm is not exempt.** Independent workflow runs still contend for the
+same executor and CAS. The four matrix jobs within one x86 build are a single,
+coordinated run: BuildBox caps them at four remote actions and their payloads
+stay in the remote CAS. Never cancel or serialize those matrix siblings.
 
 The rationalizations that have caused real production failures:
 - "Cache-warm is additive, it helps the build" → **No. Cancel it.**
@@ -143,7 +149,7 @@ This is the fast path for stale-image complaints: the image date is usually wron
 
 | Workflow | Trigger | What it does |
 |---|---|---|
-| `build.yml` | `push: testing` for key-busting paths, `workflow_dispatch`, `schedule: daily 13:00 UTC` — NOT `pull_request` or `merge_group` | Run a single BuildStream assembly build per target (`oci/bluefin.bst` and `oci/bluefin-nvidia.bst`), push the resulting artifacts to `cache.projectbluefin.io`, and upload logs. Does not push to GHCR. |
+| `build.yml` | `push: testing` for key-busting paths, `workflow_dispatch`, `schedule: daily 13:00 UTC` — NOT `pull_request` or `merge_group` | Run default, NVIDIA, gaming, and NVIDIA-gaming concurrently through BuildBox; BuildStream publishes artifacts to the remote CAS and uploads logs. Does not push to GHCR. |
 | `publish.yml` | `workflow_run` from `build.yml` (branches: testing, next, + their gh-readonly-queue/* paths) | Fetch the remote-CAS artifact, export to OCI, run `just lint`, push `:$sha`, sign/attest, and promote `:testing`/`:next` tags. No build happens here. |
 | `execute-release.yml` | `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch` | SHA freshness check (:testing vs :stable). If different: cosign verify → skopeo copy `:testing` → `:stable` → fast-forward main → create GitHub Release. Skips if equal. |
 | `lab-check.yml` | `repository_dispatch: lab-check` from the Kubernetes lab | Uses a short-lived MergeRaptor installation token to create or update one `testing-lab / dakota` Check Run for the PR head SHA. It reports queued, running, and final BuildStream/QA details without posting PR comments. |
@@ -204,13 +210,28 @@ authentication; classic PATs and OAuth apps cannot update check runs.
 
 **Daily build schedule:** `build.yml` fires at 13:00 UTC daily (after `nightly-next-build` completes). This keeps the remote CAS warm and ensures a fresh `:testing` tag even without a code push. `cache-warm.yml` was deleted — the daily build replaces it.
 
-**RE-backed assembly model (target):** `build.yml` must perform one final BST assembly per target through the BuildBarn RE service at `cache.projectbluefin.io:11002` and write the artifact to the remote CAS. The workflow must not run warmup shards, seed jobs, or a VM boot-check path. Remote execution is required, not optional.
-
-**Current state:** The tracked `build.yml` and `.github/actions/generate-bst-ci-config/action.yml` do not implement this model. They explicitly set `enable-remote-execution: "false"`, error if it is set to `"true"`, and generate a config with `artifacts:` / `source-caches:` but no `remote-execution:` block. This is a cache-only / runner-local build and is noncompliant.
+**RE-backed assembly model:** `build.yml` starts all four x86 variants together.
+Each invokes one final BuildStream target with remote storage, execution, and
+action-cache services. BuildStream automatically queues artifact/source pushes
+during the build; there is no warm-up pull or post-build push phase.
 
 ## Remote Cache Architecture
 
-`cache.projectbluefin.io:11002` is the Dakota remote cache endpoint for artifact cache, source cache, CAS storage, and the BuildBarn remote-execution frontend. The default workflow routes build actions to the BuildBarn grid through this endpoint; the runner must not perform the actual build work.
+`cache.projectbluefin.io:11002` terminates mTLS in Traefik and forwards all REAPI
+and Remote Asset traffic to one BuildBox 1.4.11 `buildbox-casd` instance. The
+backend runs on a 32-thread Ryzen 9 7950X3D host with 128 GiB RAM and starts with
+`--jobs 4`. This is a single BuildBox executor, not the historical BuildBarn
+Kubernetes grid described by older lessons.
+
+The build config deliberately contains both forms of storage service:
+
+- top-level `cache.storage-service` keeps the runner's CAS remote-backed, avoiding
+  full artifact pull/push payloads;
+- nested `remote-execution.storage-service` supplies action inputs and outputs to
+  the remote executor.
+
+Publish/export configs must not contain the top-level storage service: checkout
+needs the image's file blobs locally before podman can export and push to GHCR.
 
 ### mTLS Authentication
 
@@ -219,54 +240,47 @@ authentication; classic PATs and OAuth apps cannot update check runs.
 | `CASD_CLIENT_CERT` | Repository **variable** | PEM-encoded client certificate (public) |
 | `CASD_CLIENT_KEY` | Repository **secret** | PEM-encoded private key |
 
-**Push is conditional:** Remote cache section is only added to `buildstream-ci.conf` if **both** are set. Without credentials, BST cannot push to the remote CAS. External contributors' forks may fall back to local-only builds, but this is a degraded local-development path and is not the Dakota CI contract.
-
-**RE sanity check:** the generated `buildstream-ci.conf` must contain a `remote-execution:` block and the `artifacts:` / `source-caches:` sections for `cache.projectbluefin.io:11002`. The workflow stores the generated config in the `logs/` artifact for inspection. A config that contains cache sections but no `remote-execution:` block is a misconfiguration and must fail fast.
+The x86 build refuses to start RE unless both values are present. The generated
+credential files are mode `0600`; only the non-secret config containing their
+paths is copied into `logs/`.
 
 ## ⚠️ RE Fail-Fast Evidence
 
-A Dakota build is not considered to be using remote execution until all three of the following pieces of evidence are present. Any run missing one of them must be treated as runner-local/cache-only and failed or fixed before it is allowed to continue.
-
-**Current state:** The tracked `build.yml` / `generate-bst-ci-config` action does not satisfy these checks. It generates a config with `artifacts:` / `source-caches:` but no `remote-execution:` block, so the current CI path is cache-only / runner-local and noncompliant. The checks below are the target contract; they will only pass after the workflow and generator are fixed.
-
-1. **Generated config contains `remote-execution:`**
-
-   Inspect the uploaded `buildstream-ci.conf`:
+1. **Generated config contains remote storage and execution**
 
    ```bash
-   grep -n "remote-execution:" buildstream-ci.conf
+   grep -nE "^(cache:|remote-execution:|  storage-service:)" buildstream-ci.conf
    ```
 
-   A valid config must contain a `remote-execution:` block (not only `artifacts:` / `source-caches:`). If this block is absent, the build is not using RE.
+   A build config needs one top-level and one nested `storage-service:` plus the
+   `remote-execution:` block. The checked-in validator generates both build and
+   fetch-only modes with dummy credentials and rejects drift.
 
-2. **BuildStream startup reports "Remote Execution Configuration"**
+2. **BuildStream startup reports `Remote Execution Configuration`**
 
-   BuildStream prints a `Remote Execution Configuration` section in the startup banner when a `remote-execution:` block is loaded. Verify it in the BuildStream log:
+   `build.yml` captures the console and fails the job if this startup section is
+   missing, even when the requested artifact is already cached:
 
    ```bash
-   grep -A5 "Remote Execution Configuration" logs/*/*.log
+   grep -F "Remote Execution Configuration" logs/bst-console-*.log
    ```
 
-   The section should list the execution, storage, and action-cache services. If the log shows only `User Configuration` and no `Remote Execution Configuration` section, the build is running locally on the runner.
+3. **Uncached actions wait on the remote executor**
 
-3. **Live BuildBarn worker actions are observed on scheduler-selected workers**
-
-   RE is only proven when actions are being dispatched to and executed by BuildBarn workers. Verify this from the BuildStream logs:
+   A run that actually has cache misses should show:
 
    ```bash
-   grep -E "Waiting for the remote build to complete" logs/*/*.log | tail -50
+   grep -F "Waiting for the remote build to complete" logs/bst-console-*.log
    ```
 
-   The scheduler assigns work to workers; seeing cache pulls or frontend connectivity is not enough. For deeper verification, inspect the BuildBarn namespace directly. The existing RE backend lesson notes worker log lines of the form `Action: ... with timeout ...`:
+   A completely warm run may legitimately have no worker action to observe. In
+   that case the generated configuration, startup banner, and successful remote
+   cache initialization prove the fail-closed path was loaded; do not force a
+   cache miss merely to create worker activity.
 
-   ```bash
-   kubectl get pods -n buildbarn
-   kubectl logs -n buildbarn deploy/worker | grep "Action:"
-   ```
-
-   A run that shows cache pulls but no worker-executed actions is in cache-only / local-driver mode and is unacceptable for production Dakota builds.
-
-**Do not claim a healthy production RE path without these three checks.** Cache hits, fast step times, or a green job status are not substitutes for the evidence above. If RE cannot be verified, treat the run as a diagnosed RE failure investigation and restore RE before merging.
+For host-side diagnosis, SSH to `ahmedadan@cache.projectbluefin.io` and inspect
+`cache-buildbox-casd-1` with rootful podman. Do not use the superseded
+`kubectl -n buildbarn` instructions.
 
 ## ⚠️ Pre-Commit BST Syntax Gate
 
@@ -307,7 +321,7 @@ git push --force-with-lease origin <branch-name>
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| Build OOM or hangs | Worker memory pressure under RE; or runner-local fallback running too many jobs | First verify RE is actually enabled with the fail-fast evidence checks above. If RE is healthy, check element build resource usage and BuildBarn worker capacity. For GCC/bootstrap ICEs or OOM crashes, do not introduce local GCC toolchain workarounds or compiler-flag hacks. Prefer matching the upstream GNOME OS / `gnome-build-meta` / `freedesktop-sdk` ref that already works, and only use a local override if there is no upstream-aligned path and it has a documented exit condition. If the runner has fallen back to local execution, restore RE; runner-local builds are not a supported operating mode. |
+| Build OOM or hangs | Worker memory pressure under RE, or a failed RE configuration | Verify the startup banner, then inspect the four-slot BuildBox host. Keep `max-jobs: 4` for the initial rollout. Prefer upstream GNOME OS / GBM / FSDK alignment over local compiler workarounds. Runner-local compilation is not a supported fallback. |
 | "No space left on device" during **Chunkify** | Overlay copy-ups from `inject-xattrs.py` exhaust the ~1 GB root FS left by `setup-runner`'s BTRFS loopback | Fixed centrally in `chunka@v1` — auto-selects `/var/lib/containers` (BTRFS, ~49 GB) over `/var/tmp` (~1 GB) |
 | "No space left on device" during **Build** | BST cache fills runner disk | Check if any element generates large buildtrees. With RE enabled, the runner should not be building elements locally; if it is, see the semi-cold RE cascade lesson below. |
 | `bootc container lint` fails | Image structure issues | Check OCI assembly, `/usr/etc` merge |
@@ -315,14 +329,14 @@ git push --force-with-lease origin <branch-name>
 | GHCR push fails | Token permissions | Check `packages: write` permission |
 | aarch64 push fails `localhost/dakota:aarch64: image not known` (exit 125) | `just export`/`just lint` tag `{image_name}:{image_tag}` from `BUILD_IMAGE_TAG` (default `latest`); `build-aarch64.yml` must set `BUILD_IMAGE_TAG: aarch64` at workflow env level or the push step's `dakota:aarch64` ref never exists | Fixed 2026-07 by adding `BUILD_IMAGE_TAG: aarch64` to workflow env. Beware: `build-aarch64.yml`'s job-level `continue-on-error: true` makes the run conclusion read `success` even when the job failed — check job conclusions, not run conclusions (`boot-test-aarch64.yml` verifies the tag exists via skopeo instead of trusting the conclusion). |
 | Remote cache not used | Cert/key not configured or RE block missing | Check repo Variables and Secrets. Also verify the generated config contains both `remote-execution:` and the cache sections; cache credentials alone do not prove RE. |
-| Cache-only / runner-local build | `enable-remote-execution: false` (the current tracked default), missing `remote-execution:` block, or RE backend unreachable | This is an unacceptable operational state. The current `build.yml` / generator default is in this state. Collect the RE fail-fast evidence above, diagnose the specific RE failure (see the BuildBarn lessons below), and restore RE before merging. |
+| Cache-only / runner-local x86 build | Missing `remote-execution:` or `cache.storage-service`, missing credentials, or unreachable BuildBox backend | The generator and runtime banner checks fail closed. Diagnose the endpoint; do not add a local fallback. |
 
 ### Debugging Workflow
 
 1. **Check config step output** — confirm the generated `buildstream-ci.conf` contains a `remote-execution:` block, not only `artifacts:` / `source-caches:` sections
 2. **Search build log** — look for `[FAILURE]` lines; `on-error: continue` collects all failures
-3. **Verify RE is active** — confirm BuildStream startup reports "Remote Execution Configuration" and logs show actions completing on BuildBarn workers (see RE fail-fast evidence above)
-4. **Check if remote cache was hit** — look for `[get artifact]` lines showing `cache.projectbluefin.io:11002`
+3. **Verify RE is active** — confirm BuildStream reports `Remote Execution Configuration`; on a cache miss, look for `Waiting for the remote build to complete`
+4. **Check remote cache activity** — inspect pull/push metadata without expecting full payload transfers through the runner
 5. **Reproduce locally only as a failure investigation** — `just bst build oci/bluefin.bst` uses the same bst2 container, but a local runner-only reproduction is for diagnosing a specific RE failure, not for bypassing RE in CI
 
 ## Generated Files (Pre-Commit Required)
@@ -406,6 +420,26 @@ gh run list --repo projectbluefin/dakota --limit 5
 
 > **Note:** Lessons are ordered newest-first. Deleted CI paths are historical evidence only; do not recreate them.
 
+### Remote-backed CAS removes runner transfer phases (2026-07-28)
+
+The production endpoint is a single BuildBox 1.4.11 `buildbox-casd` executor
+behind Traefik mTLS, not the historical BuildBarn cluster. It has four action
+slots on a 32-thread, 128 GiB host. Match that capacity with four concurrent
+variant jobs and start conservatively at `build.max-jobs: 4` per action.
+
+BuildStream 2.7 distinguishes artifact remotes, remote execution storage, and
+the top-level cache storage service. A `remote-execution:` block alone still
+leaves the runner's CAS local. Adding `cache.storage-service` makes that CAS
+remote-backed: directory metadata is available locally while file payloads stay
+on the BuildBox host. Because the writable artifact/source remotes use the same
+CAS, BuildStream's automatic push queues publish metadata and deduplicate blobs
+without a separate `bst artifact push` transfer.
+
+Use the top-level storage service only for build jobs. Publish/export and
+filemap generation need local file materialization and must use fetch-only
+configs without it. The generated config tests enforce both modes, credential
+fail-closed behavior, and composite shell syntax.
+
 ### Architecture options must match upstream artifact producers (2026-07-13)
 
 BuildStream project options participate in artifact cache keys. Passing
@@ -423,25 +457,16 @@ Keep the standard local, build, validation, export, push, and SBOM paths on
 `-o x86_64_v3 false`. The project option remains available for an explicit
 local opt-in, but an opt-in v3 build must expect to compile and maintain its own
 architecture-specific artifacts rather than relying on upstream cache reuse.
-### Verified BuildBarn remote execution is required — runner-local/cache-only are unacceptable operational states (2026-07-19)
+### Verified remote execution is required — runner-local/cache-only are unacceptable operational states (2026-07-19)
 
-**Policy:** Dakota builds must use verified BuildStream remote execution through the BuildBarn grid at `cache.projectbluefin.io:11002`. The runner drives the build and handles CAS push/pull; compile actions must execute on BuildBarn workers so that cluster hardware is maximally utilized.
+> The original lesson named a BuildBarn grid and described the then-disabled
+> workflow. The backend and implementation details are superseded by the
+> 2026-07-28 BuildBox lesson above; the fail-closed policy remains.
 
-The following are unacceptable operational states for a normal Dakota build:
-- remote artifact/source cache with local driver execution (runner-local builds);
-- cache-only mode where the runner performs the build work;
-- any generated config that omits the `remote-execution:` block while still claiming to use remote cache.
-
-The only acceptable exception is an **explicit, diagnosed failure investigation** where a known RE failure mode has been identified and documented for that specific run. Any such fallback must be followed by work to restore verified RE before merge.
-
-**Current verified state:** The tracked workflow is noncompliant. `build.yml` calls `.github/actions/generate-bst-ci-config` with `enable-remote-execution: "false"`, the action errors if `enable-remote-execution` is `"true"`, and the generated `buildstream-ci.conf` contains no `remote-execution:` block. The current CI path is therefore runner-local / cache-only. An implementation fix is required before Dakota builds satisfy this policy.
-
-**Fail-fast evidence:** A build is not proven to be using RE until all three checks from the RE Fail-Fast Evidence section above are satisfied:
-1. generated `buildstream-ci.conf` contains `remote-execution:`;
-2. BuildStream startup reports "Remote Execution Configuration";
-3. live BuildBarn worker actions are observed on scheduler-selected workers.
-
-Do not claim a healthy production RE path, extend timeouts, or merge without this evidence. Cache hits and green job status are not substitutes.
+Normal x86 builds require the generated remote storage/execution configuration
+and the BuildStream startup banner. Remote artifact/source access without RE,
+or a local compilation fallback after RE failure, is not an acceptable
+production state.
 
 ### Breaking Cold-Cache Starvation Loops via Temporary Timeout Extension (2026-07-13)
 
@@ -473,16 +498,13 @@ Do not claim a healthy production RE path, extend timeouts, or merge without thi
 
 ### Runner cache configuration must preserve upstream fallbacks (2026-07-11)
 
-The normal path is a BuildStream build per target routed through the BuildBarn RE
-service at `cache.projectbluefin.io:11002`. `cache.projectbluefin.io:11002` is the
-authenticated writable cache; `gbm.gnome.org:11003` and
-`cache.freedesktop-sdk.io:11001` must remain read-only artifact and source-cache
-fallbacks. Replacing that server list forces a cold SDK and GNOME compile,
-causing multi-hour runs even on BuildBarn. The generated files must be written
-under `${GITHUB_WORKSPACE}` because the `just bst` container maps it to `/src`.
-A known-good warm run completes the assembly in about 20 minutes; each assembly
-is capped at 30 minutes with a 15-minute artifact-push tail. Do not recreate seed
-shards, retry chains, or local publish fallbacks.
+The normal path is a BuildStream build per target routed through the BuildBox
+executor at `cache.projectbluefin.io:11002`. That endpoint is the authenticated
+writable cache; `gbm.gnome.org:11003` and `cache.freedesktop-sdk.io:11001` must
+remain read-only artifact/source fallbacks. Replacing the server list forces a
+cold SDK and GNOME compile. The config is written under `${GITHUB_WORKSPACE}`
+because the `just bst` container maps it to `/src`. Do not recreate seed shards,
+pre-pulls, retry chains, standalone push tails, or local publish fallbacks.
 
 ### Publishing is the deliverable — local full-image builds are never a push gate (2026-07-09)
 
@@ -496,17 +518,15 @@ The pre-flight rule (cancel all active runs before any CI action) has a failure 
 
 Applying any patches to the `gnome-build-meta` junction (e.g., local patch queues) invalidates cache keys for downstream elements and forces hours of WebKit compilation from source. In July 2026, the local patch queue was completely removed from `elements/gnome-build-meta.bst` (commit `dbb9f6d6`). This restores 100% cache alignment with `gbm.gnome.org:11003`. WebKit and other platform elements are now fetched as cached artifacts. DO NOT introduce any local patches to gnome-build-meta or freedesktop-sdk junctions, as this forces WebKit recompilation. DO NOT run any WebKit compilation or seed shards in CI workflows, as they are completely unnecessary and slow down the publish pipeline.
 
-### RE-backed BST builds route compile work to BuildBarn (2026-07-11)
+### RE-backed BST builds route compile work off the runner (2026-07-11)
 
-> **Superseded by the RE-first policy.** The original lesson kept the build on the GitHub runner and used the remote cache only for artifact/source pulls. Dakota now requires verified remote execution.
+> Backend and configuration details are superseded by the 2026-07-28 lesson.
 
-**Target contract:** The supported Dakota path is a single `just bst build ...` invocation on the GitHub runner **with a `remote-execution:` block** that dispatches build actions to the BuildBarn grid. The runner must not perform the compile work; `cache.projectbluefin.io:11002` provides both the RE frontend and the artifact/source-cache services the build needs.
-
-**Current state:** The tracked generator is hard-coded to reject `enable-remote-execution: "true"` and emits a runner-local config with `build.max-jobs: 1`. This is noncompliant and must be fixed before the target contract is met.
-
-The CI config generator must write `buildstream-ci.conf` and `buildstream-push.conf` to `/src/` so the workflow's `BST_FLAGS: --config /src/buildstream-ci.conf` path stays correct. Writing the files into the repository checkout instead of `/src/` breaks the build path even when the YAML itself is otherwise valid.
-
-For RE-backed CI, keep `scheduler.builders: 2` and set `build.max-jobs` to a value the BuildBarn workers can sustain. Historical tuning on this project reached a ceiling of `max-jobs: 8` after `max-jobs: 16` correlated with server-side instability (see the 2026-07-09 lessons below). Do not cap the whole build to `max-jobs: 1` to protect the runner; with RE, the runner is not the compile host. A missing or disabled `remote-execution:` block is a misconfiguration, not a supported local-execution mode.
+The durable rule is that `just bst build ...` loads a `remote-execution:` block
+and does not silently fall back to local compilation. The current BuildBox host
+provides the RE frontend and cache services. Keep `scheduler.builders: 2` and
+start at `build.max-jobs: 4`; backend `--jobs 4` caps global action concurrency.
+The only generated file used by the build is `/src/buildstream-ci.conf`.
 
 ### Cache access and RE are separate; verify both (2026-07-11)
 
@@ -515,15 +535,12 @@ For RE-backed CI, keep `scheduler.builders: 2` and set `build.max-jobs` to a val
 Cache access and remote execution are distinct concerns in BuildStream:
 
 - `artifacts:` / `source-caches:` make the runner talk to `cache.projectbluefin.io:11002` for pulls and pushes.
-- `remote-execution:` routes actual build actions to the BuildBarn grid so the runner does not perform the compile work.
+- `cache.storage-service` keeps CAS file payloads off the runner.
+- `remote-execution:` routes actual build actions to BuildBox.
 
-**Current state:** The tracked generator produces `artifacts:` / `source-caches:` but no `remote-execution:` block. This is cache-only / runner-local and is noncompliant.
-
-The required evidence once the workflow is fixed is the RE fail-fast evidence above:
-
-1. The generated `buildstream-ci.conf` contains a `remote-execution:` block.
-2. BuildStream startup reports "Remote Execution Configuration".
-3. BuildStream logs show actions completing on BuildBarn workers.
+The required evidence is the generated remote-backed config and BuildStream's
+`Remote Execution Configuration` startup banner. On cache misses, logs also show
+remote action waits; fully cached runs do not need to manufacture one.
 
 A config with cache sections but no `remote-execution:` block puts the build into cache-only / runner-local mode. That is an unacceptable operational state and must be treated as a bug, not a working fallback.
 
@@ -2569,14 +2586,14 @@ flow (issue 1073). Key operational facts for CI debugging:
 
 **Deleted workflows (do not recreate):** `promote-testing-to-main.yml`, `pr-release-gate.yml`, `sync-main-to-testing.yml`, `cache-warm.yml`.
 
-**Daily BST build windows (serialized for CAS):**
+**Daily BST build windows (workflow runs serialize; x86 variants do not):**
 ```
-03:00 UTC  nightly-next-build → next branch (x86, 90-210 min)
-13:00 UTC  build.yml schedule → testing x86 default+nvidia serial (max-parallel:1, 90-390 min)
-~18:00     publish.yml fires → :testing + :testing-nvidia published
-~18:00     build-aarch64.yml fires (workflow_run from publish) → ARM default (~90-210 min)
-~18:00     execute-release.yml fires (workflow_run from publish) → freshness check → promote
-20:00      track-next-junctions → may trigger next junction build
+03:00 UTC  nightly-next-build → next branch
+13:00 UTC  build.yml schedule → four x86 variants concurrently on four BuildBox slots
+on success publish.yml → four stream images exported and published in parallel
+on publish build-aarch64.yml → ARM default (decoupled)
+on publish execute-release.yml → freshness check → promote
+20:00 UTC  track-next-junctions → may trigger next junction build
 ```
 
 **`cache-warm.yml` is deleted.** The daily 13:00 UTC `build.yml` schedule replaces it. CAS stays warm as long as the daily build runs. If the daily build is absent for >48 hours, expect cold-start non-determinism.

--- a/docs/skills/debugging.md
+++ b/docs/skills/debugging.md
@@ -164,18 +164,16 @@ Elements that install non-ELF payloads (plain text files, shell scripts, fonts, 
 
 When a remote BST build is slow or hits the workflow timeout, the first question is not "should we change the timeout again?" The first question is whether the generated BuildStream config is actually enabling remote execution and whether the run is progressing with remote cache activity. The 2026-07-06 investigation showed that a workflow can appear to be using the remote cache while still not dispatching expensive build actions to the remote execution service.
 
-**Current state:** The tracked workflow explicitly disables remote execution (`enable-remote-execution: "false"`), so a slow build today is expected to fail the RE-active checks below. The diagnosis first confirms the noncompliance, then drives the implementation fix; do not assume RE is present just because the job is running.
-
 Good evidence to gather before changing anything else:
 
-1. Confirm the workflow passes `enable-remote-execution: 'true'` to the generator.
-2. Confirm the generated `buildstream-ci.conf` contains a `remote-execution:` block.
-3. Confirm BuildStream startup reports "Remote Execution Configuration" in the build log.
-4. Confirm live BuildBarn worker actions are observed on scheduler-selected workers (`Waiting for the remote build to complete` in BuildStream logs, or `Action:` lines in BuildBarn worker logs).
-5. Inspect the build logs for remote cache activity (`Pulled artifact`, `Pulled source`, `does not have artifact/source cached`) and for evidence that the build is continuing past the initial fetch phase.
-6. If the build still stalls, inspect the active element graph and the latest upstream nightly delta rather than making another workflow-only change.
+1. Confirm the workflow requests remote execution and writable caches.
+2. Confirm `buildstream-ci.conf` contains top-level `cache.storage-service` plus `remote-execution:`.
+3. Confirm BuildStream reports `Remote Execution Configuration`; `build.yml` enforces this automatically.
+4. On a real cache miss, look for `Waiting for the remote build to complete`. A warm artifact can complete without dispatching an action.
+5. Inspect the active element graph and the latest upstream nightly delta before making another workflow-only change.
+6. For backend diagnosis, inspect the rootful `cache-buildbox-casd-1` container on `ahmedadan@cache.projectbluefin.io`; old `kubectl -n buildbarn` instructions are obsolete.
 
-A run that satisfies checks 1–2 but not 3–4 is in cache-only / runner-local mode and is an unacceptable operational state. Do not extend timeouts or merge until RE is actually executing actions on BuildBarn workers. A real fix must show up in the generated config and in the BuildStream logs as worker-executed actions.
+A missing config section or startup banner is an unacceptable runner-local/cache-only state. Fail closed rather than extending timeouts or adding a local fallback.
 
 ### Ghost-lab input-root staging failure is a diagnosed RE failure, not a reason to disable RE (2026-07-07)
 

--- a/docs/skills/quickstart.md
+++ b/docs/skills/quickstart.md
@@ -152,19 +152,16 @@ Full details: `release-promotion.md` and `ci-tooling.md`.
 
 If a Dakota remote build is slow or times out, do not start by toggling the same workflow flag again. First verify that the workflow still passes the correct inputs to the config generator and that the generated BuildStream config actually contains a `remote-execution:` block. The 2026-07-06 investigation showed that cache access alone can be present while expensive build actions are still happening locally on the runner.
 
-**Current state:** The tracked `build.yml` still calls the generator with `enable-remote-execution: "false"`, so the current CI path is runner-local / cache-only and noncompliant. A slow build today is expected to fail the RE evidence checks below until the workflow and generator are fixed.
+The required RE fail-fast checklist is:
 
-The required RE fail-fast checklist for the next run is:
+1. Confirm `build.yml` sets both `enable-remote-execution: 'true'` and `enable-push: 'true'`.
+2. Confirm `buildstream-ci.conf` contains top-level `cache.storage-service` and the `remote-execution:` services.
+3. Confirm BuildStream reports `Remote Execution Configuration`; the workflow fails this check automatically.
+4. On cache misses, confirm `Waiting for the remote build to complete` appears in the console log. A fully warm run may have no action to dispatch.
+5. If RE is active and the build still runs long, inspect the active element graph and the BuildBox host rather than reintroducing pre-pull/push phases.
 
-1. Confirm `build.yml` still sets `enable-remote-execution: 'true'`.
-2. Confirm the generated `buildstream-ci.conf` includes a `remote-execution:` section with the remote CAS endpoint.
-3. Confirm BuildStream startup reports "Remote Execution Configuration" in the build log.
-4. Confirm live BuildBarn worker actions are observed on scheduler-selected workers:
-   - `Waiting for the remote build to complete` in BuildStream logs, or
-   - BuildBarn worker logs showing `Action:` lines (see the RE backend lesson in `ci.md`).
-5. Only after 1–4 are satisfied, inspect the uploaded BuildStream logs for `Pulled artifact`, `Pulled source`, and `does not have artifact/source cached` lines to confirm cache activity.
-6. If RE is verified active and the build still runs long, treat the next bottleneck as an actual build / upstream-cache issue and inspect the active element graph rather than another workflow-only change.
-
-A run that satisfies 1–2 but not 3–4 is in cache-only / runner-local mode. That is an unacceptable operational state for Dakota; do not extend timeouts or merge until RE is restored and proven.
+The production backend is one BuildBox 1.4.11 executor with four action slots,
+not the historical BuildBarn Kubernetes grid. Missing RE evidence is a hard
+failure; do not add a runner-local fallback.
 
 This keeps the work evidence-first and leaves the next run with a concrete verification path instead of another round of blind churn.

--- a/scripts/check_publish_workflow.py
+++ b/scripts/check_publish_workflow.py
@@ -1,32 +1,190 @@
 #!/usr/bin/env python3
+import os
 from pathlib import Path
 import re
+import subprocess
 import sys
+import tempfile
+import textwrap
 
-publish = Path('.github/workflows/publish.yml').read_text()
-errors = []
 
-sbom_match = re.search(
-    r'publish-sbom:\n(?P<body>.*?)(?:\n\S|\Z)',
-    publish,
-    re.S,
-)
-if not sbom_match:
-    errors.append('could not find publish-sbom job in .github/workflows/publish.yml')
-else:
-    sbom_body = sbom_match.group('body')
-    default_continue = re.search(
-        r'- variant: default\n\s+element: oci/bluefin\.bst\n\s+image_suffix: \'\'\n\s+sbom_filename: dakota\.spdx\.json\n\s+continue: true',
-        sbom_body,
+ROOT = Path(".")
+PUBLISH = ROOT / ".github/workflows/publish.yml"
+BUILD = ROOT / ".github/workflows/build.yml"
+CI_CONFIG_ACTION = ROOT / ".github/actions/generate-bst-ci-config/action.yml"
+
+
+def extract_composite_shell(action: str) -> str | None:
+    run_indent = None
+    shell_lines = []
+    for line in action.splitlines(keepends=True):
+        if run_indent is None:
+            match = re.match(r"^(?P<indent> *)run: \|\s*$", line)
+            if match:
+                run_indent = len(match.group("indent"))
+            continue
+
+        if line.strip() and len(line) - len(line.lstrip()) <= run_indent:
+            break
+        shell_lines.append(line)
+
+    if run_indent is None:
+        return None
+    return textwrap.dedent("".join(shell_lines))
+
+
+def run_generator(shell: str, *, remote: bool, push: bool, credentials: bool):
+    with tempfile.TemporaryDirectory() as tempdir:
+        workspace = Path(tempdir)
+        env = os.environ.copy()
+        env.update(
+            {
+                "GITHUB_WORKSPACE": str(workspace),
+                "ENABLE_REMOTE_EXECUTION": str(remote).lower(),
+                "ENABLE_PUSH": str(push).lower(),
+                "CASD_CLIENT_CERT": "test certificate" if credentials else "",
+                "CASD_CLIENT_KEY": "test private key" if credentials else "",
+            }
+        )
+        result = subprocess.run(
+            ["bash", "-c", shell],
+            cwd=workspace,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        config_path = workspace / "buildstream-ci.conf"
+        config = config_path.read_text() if config_path.exists() else ""
+        return result, config
+
+
+def check_generated_configs(shell: str, errors: list[str]) -> None:
+    syntax = subprocess.run(
+        ["bash", "-n"], input=shell, text=True, capture_output=True, check=False
     )
-    if not default_continue:
-        errors.append('publish-sbom default variant must stay continue-on-error via continue: true')
-    if 'continue-on-error: ${{ matrix.continue }}' not in sbom_body:
-        errors.append('publish-sbom job must wire continue-on-error: ${{ matrix.continue }}')
+    if syntax.returncode:
+        errors.append(f"generate-bst-ci-config shell is invalid: {syntax.stderr.strip()}")
+        return
 
-if errors:
-    for err in errors:
-        print(err, file=sys.stderr)
-    sys.exit(1)
+    remote_result, remote_config = run_generator(
+        shell, remote=True, push=True, credentials=True
+    )
+    if remote_result.returncode:
+        errors.append(
+            "remote BuildStream config generation failed: "
+            + (remote_result.stderr.strip() or remote_result.stdout.strip())
+        )
+    else:
+        required = {
+            "remote-execution:": "remote-execution block",
+            "  execution-service:": "execution service",
+            "  action-cache-service:": "action-cache service",
+            "  max-jobs: 4": "build.max-jobs: 4",
+            "cache:\n  cache-buildtrees: never\n  storage-service:": "top-level cache storage service",
+        }
+        for token, description in required.items():
+            if token not in remote_config:
+                errors.append(f"remote config is missing {description}")
+        if len(re.findall(r"^  storage-service:", remote_config, re.M)) != 2:
+            errors.append("remote config must contain top-level and RE storage services")
+        if remote_config.count("push: true") < 3:
+            errors.append("remote config must publish artifacts, sources, and action-cache results")
 
-print('publish workflow SBOM path looks sane')
+    fetch_result, fetch_config = run_generator(
+        shell, remote=False, push=False, credentials=True
+    )
+    if fetch_result.returncode:
+        errors.append(
+            "fetch-only BuildStream config generation failed: "
+            + (fetch_result.stderr.strip() or fetch_result.stdout.strip())
+        )
+    else:
+        if "remote-execution:" in fetch_config:
+            errors.append("fetch-only config must not contain remote-execution")
+        if re.search(r"^  storage-service:", fetch_config, re.M):
+            errors.append("fetch-only config must not use top-level remote storage")
+        if "  max-jobs: 1" not in fetch_config:
+            errors.append("fetch-only/local config must retain build.max-jobs: 1")
+        if "push: true" in fetch_config:
+            errors.append("fetch-only config must keep every cache read-only")
+
+    missing_result, _ = run_generator(
+        shell, remote=True, push=True, credentials=False
+    )
+    if missing_result.returncode == 0:
+        errors.append("remote config generation must fail when mTLS credentials are missing")
+
+
+def check_build_workflow(build: str, errors: list[str]) -> None:
+    required = {
+        "max-parallel: 4": "four-way variant concurrency",
+        'enable-remote-execution: "true"': "fail-closed remote execution",
+        'enable-push: "true"': "automatic artifact publication",
+        'grep -Fq "Remote Execution Configuration"': "runtime RE evidence check",
+    }
+    for token, description in required.items():
+        if token not in build:
+            errors.append(f"build workflow is missing {description}")
+
+    forbidden = {
+        "Pull prebuilt artifacts from remote CAS": "explicit CAS pre-pull",
+        "Push OCI artifact to remote CAS": "standalone artifact push",
+        "buildstream-push.conf": "legacy push-only config",
+    }
+    for token, description in forbidden.items():
+        if token in build:
+            errors.append(f"build workflow still contains {description}")
+
+
+def check_publish_workflow(publish: str, errors: list[str]) -> None:
+    sbom_match = re.search(r"publish-sbom:\n(?P<body>.*?)(?:\n\S|\Z)", publish, re.S)
+    if not sbom_match:
+        errors.append("could not find publish-sbom job in .github/workflows/publish.yml")
+    else:
+        sbom_body = sbom_match.group("body")
+        default_continue = re.search(
+            r"- variant: default\n"
+            r"\s+element: oci/bluefin\.bst\n"
+            r"\s+image_suffix: ''\n"
+            r"\s+sbom_filename: dakota\.spdx\.json\n"
+            r"\s+continue: true",
+            sbom_body,
+        )
+        if not default_continue:
+            errors.append("publish-sbom default variant must stay continue-on-error")
+        if "continue-on-error: ${{ matrix.continue }}" not in sbom_body:
+            errors.append("publish-sbom job must wire continue-on-error to the matrix")
+
+    if publish.count("enable-remote-execution: 'false'") < 2:
+        errors.append("publish export and SBOM jobs must remain local/fetch-only")
+    if publish.count("enable-push: 'false'") < 2:
+        errors.append("publish export and SBOM jobs must keep remote caches read-only")
+
+
+def main() -> int:
+    errors: list[str] = []
+    publish = PUBLISH.read_text()
+    build = BUILD.read_text()
+    action = CI_CONFIG_ACTION.read_text()
+
+    shell = extract_composite_shell(action)
+    if shell is None:
+        errors.append("could not find composite action shell in generate-bst-ci-config")
+    else:
+        check_generated_configs(shell, errors)
+
+    check_build_workflow(build, errors)
+    check_publish_workflow(publish, errors)
+
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print("build, publish, and BuildStream CI configuration checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_publish_workflow.py
+++ b/scripts/test_check_publish_workflow.py
@@ -23,47 +23,62 @@ class CheckPublishWorkflowTests(unittest.TestCase):
 
     def copy_workspace(self, workspace: Path) -> None:
         shutil.copytree(REPOSITORY / ".github", workspace / ".github")
-        shutil.copytree(REPOSITORY / "files", workspace / "files")
+
+    def mutate(self, relative_path: str, old: str, new: str) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as tempdir:
+            workspace = Path(tempdir)
+            self.copy_workspace(workspace)
+            path = workspace / relative_path
+            original = path.read_text()
+            self.assertIn(old, original)
+            path.write_text(original.replace(old, new, 1))
+            return self.run_checker(workspace)
+
+    def test_current_configuration_passes(self) -> None:
+        result = self.run_checker(REPOSITORY)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
 
     def test_rejects_unterminated_composite_action_shell(self) -> None:
-        with tempfile.TemporaryDirectory() as tempdir:
-            workspace = Path(tempdir)
-            self.copy_workspace(workspace)
+        result = self.mutate(
+            ".github/actions/generate-bst-ci-config/action.yml",
+            "        set -euo pipefail\n",
+            "        if true; then\n",
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
 
-            action = workspace / ".github/actions/generate-bst-ci-config/action.yml"
-            action.write_text(
-                "runs:\n"
-                "  using: composite\n"
-                "  steps:\n"
-                "    - shell: bash\n"
-                "      run: |\n"
-                "        echo setup\n"
-                "\n"
-                "        if true; then\n"
-                "          echo broken\n"
-            )
+    def test_rejects_missing_remote_execution_block(self) -> None:
+        result = self.mutate(
+            ".github/actions/generate-bst-ci-config/action.yml",
+            "        remote-execution:\n",
+            "        disabled-executor:\n",
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
 
-            result = self.run_checker(workspace)
+    def test_rejects_serial_build_matrix(self) -> None:
+        result = self.mutate(
+            ".github/workflows/build.yml",
+            "      max-parallel: 4\n",
+            "      max-parallel: 1\n",
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
 
-            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+    def test_rejects_explicit_artifact_pull(self) -> None:
+        result = self.mutate(
+            ".github/workflows/build.yml",
+            "      - name: Count elements for progress tracking\n",
+            "      - name: Pull prebuilt artifacts from remote CAS\n"
+            "        run: true\n\n"
+            "      - name: Count elements for progress tracking\n",
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
 
-    def test_rejects_optional_nvidia_publication(self) -> None:
-        with tempfile.TemporaryDirectory() as tempdir:
-            workspace = Path(tempdir)
-            self.copy_workspace(workspace)
-
-            publish = workspace / ".github/workflows/publish.yml"
-            publish.write_text(
-                publish.read_text().replace(
-                    "sbom_filename: dakota-nvidia.spdx.json\n            continue: false",
-                    "sbom_filename: dakota-nvidia.spdx.json\n            continue: true",
-                    1,
-                )
-            )
-
-            result = self.run_checker(workspace)
-
-            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+    def test_rejects_remote_publish_export(self) -> None:
+        result = self.mutate(
+            ".github/workflows/publish.yml",
+            "          enable-remote-execution: 'false'\n",
+            "          enable-remote-execution: 'true'\n",
+        )
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

x86 builds currently run entirely on the GitHub runner: variants are serialized with `max-parallel: 1` and `build.max-jobs: 1`, and every run spends long pre-pull and post-build push phases moving artifact payloads through the runner. The CI docs have tracked this state as noncompliant with the remote execution contract. This PR routes the four x86_64 variants through the BuildBox 1.4.11 executor at `cache.projectbluefin.io:11002` and makes the whole path fail closed.

1. **The config generator now emits a real remote-build mode.** Passing `enable-remote-execution: "true"` produces execution, storage, and action-cache services against `cache.projectbluefin.io:11002`, errors out when the mTLS credentials are missing instead of silently degrading, and writes the credential files with mode 0600.

2. **A top-level `cache.storage-service` keeps CAS payloads off the runner.** The runner's local casd becomes remote-backed, so directory metadata stays local while file payloads remain on the BuildBox host. Fetch-only consumers like publish keep a config without it, since artifact checkout has to materialize the image locally before podman can export it.

3. **`build.yml` starts all four variants together and drops the transfer phases.** `max-parallel: 4` matches the backend's four global action slots, the explicit artifact pre-pull and standalone push steps are removed because the writable remotes make BuildStream publish during the build, and the job fails if the console log lacks BuildStream's `Remote Execution Configuration` startup banner, so a green cache hit cannot mask a silently local build.

4. **The workflow checker now exercises both config modes.** `check_publish_workflow.py` executes the composite action shell with dummy credentials in remote-build and fetch-only modes, asserts the fail-closed credential handling, and inspects the generated configs. Its unit tests are wired into `just check-publish-workflow` so validate runs them in CI.

5. **Docs and skills reflect the BuildBox backend.** `docs/ci.md`, the CI skills, and the copilot instructions now describe the single BuildBox executor, supersede the BuildBarn-era lessons, and drop the noncompliance warnings.
