### PR TITLE
fix(ci): enqueue with app token so merge groups dispatch checks

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -134,12 +134,26 @@ jobs:
             *) echo "is_maintainer=false" >> "$GITHUB_OUTPUT" ;;
           esac
 
+      # Merge-queue groups created by github-actions[bot] never dispatch
+      # required checks; enqueue with the MergeRaptor app token instead.
+      - name: Get MergeRaptor token
+        if: >-
+          steps.perm.outputs.is_maintainer == 'true' &&
+          github.event.review.state == 'approved'
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
+          private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Approved — clear label, enable auto-merge, update branch
         if: >-
           steps.perm.outputs.is_maintainer == 'true' &&
           github.event.review.state == 'approved'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           gh pr edit "$PR_URL" --remove-label "pr/needs-review" 2>/dev/null || true

--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -16,3 +16,8 @@ jobs:
     with:
       head_sha: ${{ github.event.workflow_run.head_sha }}
       base_branch: testing
+    # Merge-queue groups created by github-actions[bot] never dispatch
+    # required checks; the app token keeps the queue from wedging.
+    secrets:
+      app_id: ${{ secrets.MERGERAPTOR_APP_ID }}
+      private_key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Dependency PRs enqueued by our automation wedge the testing merge queue: entries created with GITHUB_TOKEN produce merge groups authored by github-actions[bot], and events from that token never trigger workflows, so the group's required validate check is never dispatched and the entry starves at AWAITING_CHECKS until eviction. #1206 rode that add/evict loop from July 26 to 29.

1. **`renovate-automerge.yml` passes MergeRaptor app credentials** to the reusable workflow so the merge is performed by the app and queue checks dispatch.

2. **`pr-triage.yml` enqueues approved PRs with a minted app token** instead of GITHUB_TOKEN, closing the same gap on the review-approval path.

**Draft until projectbluefin/actions#348 merges and `@v1` advances** — the reusable workflow does not accept the new secrets before then.

Related: projectbluefin/actions#348
