### PR TITLE
docs(skills): document verification path for testsuite-owned E2E failures

### DIFF
--- a/docs/skills/e2e-ci.md
+++ b/docs/skills/e2e-ci.md
@@ -67,6 +67,38 @@ sudo podman run --rm --privileged --pid=host --ipc=host \
 
 Then attach the resulting raw file on the host and continue with QEMU boot checks.
 
+## Diagnosing E2E Failures That Live Upstream
+
+Dakota does not own any behave/step code — `tests/`, `steps/`, and the rerun
+retry logic all live in `projectbluefin/testsuite`. When an E2E/smoke run
+fails with an error that looks like GNOME Shell JS or Python step code
+(`AttributeError`, `TypeError: ... is undefined`, `ConfigError: No steps
+directory`), do not assume Dakota's workflow wiring is at fault. Check the
+upstream testsuite first:
+
+1. **Confirm the failure is current, not historical.** `gh run view <id>
+   --repo projectbluefin/dakota --log-failed` gives the exact traceback and
+   commit under test. A failure from weeks ago may already be fixed upstream.
+2. **Diff the pinned tag against testsuite `main`:**
+   ```bash
+   gh api repos/projectbluefin/testsuite/compare/v1...main --jq '{ahead,behind}'
+   ```
+   `ahead: 0` means the `@v1` floating tag Dakota calls (`e2e.yml`,
+   `run-testsuite.yml`) already includes everything on `main` — there is
+   nothing to re-pin.
+3. **Only if `v1` is behind `main`** is there a real Dakota-side action: open
+   an issue/PR against `projectbluefin/actions` (or ping testsuite
+   maintainers) to move the tag, per the "pin once in the wrapper" rule above.
+4. **If the tag is current, re-run the workflow** (`workflow_dispatch` on
+   `e2e.yml`, or wait for the next `publish-smoke.yml` run) to get a fresh
+   result before concluding anything is still broken.
+
+This was the resolution path for [dakota#627](https://github.com/projectbluefin/dakota/issues/627)
+(`eval_js` AttributeError, undefined `_do_not_disturb`, and a behave rerun
+`ConfigError`) — all three were already fixed in `projectbluefin/testsuite`
+`main`, and the `@v1` tag Dakota consumes was already even with `main`, so no
+Dakota workflow change was needed.
+
 ## Observational Smoke Rule
 
 A reusable-workflow call job cannot be made truly non-blocking with


### PR DESCRIPTION
## What problem are you solving?

Issue #627 reported three E2E failures (`eval_js` AttributeError, undefined `_do_not_disturb`, and a behave rerun `ConfigError`). Investigation found all three root causes are already fixed on `projectbluefin/testsuite` `main`, and none of the failing code (behave steps, rerun retry logic) lives in this repo — Dakota only delegates to testsuite's reusable workflow via the `@v1` tag. Confirmed `@v1` is already even with testsuite `main` (`gh api repos/projectbluefin/testsuite/compare/v1...main` -> `ahead: 0`), so no workflow/pin change is needed here. This PR captures that diagnosis path in `docs/skills/e2e-ci.md` so a future agent doesn't re-litigate an already-fixed upstream bug.

- [x] I am using an agent and I take responsibility for this PR

---

## Changes

- `docs/skills/e2e-ci.md`: new "Diagnosing E2E Failures That Live Upstream" section - check testsuite `main` and the `@v1` tag drift before assuming Dakota's workflow wiring is broken; documents the #627 resolution as the worked example.

## Testing

Docs-only change, no BST elements or workflows touched:
- [x] `git diff --check` - clean, no whitespace errors
- [ ] `just validate` / `just boot-test` / `just lint` - N/A, no BST elements or image content changed

## Checklist

- [ ] New BST elements wired into `deps.bst` - N/A
- [ ] Patches in `patches/` regenerated if junction refs changed - N/A

Closes #627
