### PR TITLE
fix: restore Bluefin dinosaur avatars in GNOME user-account picker

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -22,6 +22,7 @@ depends:
   - bluefin/umotd.bst
 
   - bluefin/common.bst
+  - bluefin/user-avatars.bst
   - bluefin/just-overrides.bst
   - bluefin/firstboot-date.bst
   - bluefin/firstboot-services.bst

--- a/elements/bluefin/user-avatars.bst
+++ b/elements/bluefin/user-avatars.bst
@@ -1,0 +1,21 @@
+kind: manual
+
+# Points GNOME's avatar chooser (gnome-control-center) and gnome-initial-setup's
+# account page at bluefin-common's dinosaur avatar directory. See the keyfile
+# for the full explanation. Fixes: projectbluefin/dakota#353
+sources:
+- kind: local
+  path: files/user-avatars
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    install -Dm644 07-dakota-avatar-directories \
+      "%{install-root}%{sysconfdir}/dconf/db/distro.d/07-dakota-avatar-directories"
+  - "%{install-extra}"

--- a/files/user-avatars/07-dakota-avatar-directories
+++ b/files/user-avatars/07-dakota-avatar-directories
@@ -1,0 +1,17 @@
+# Restore the Bluefin dinosaur avatar icons in the GNOME "Users" account-picture
+# picker (fixes: projectbluefin/dakota#353).
+#
+# bluefin-common ships Bluefin's custom (dinosaur-themed) avatars under a
+# `bluefin/` category subdirectory: system_files/bluefin/usr/share/pixmaps/faces/bluefin/*.jpg
+# (installed here as /usr/share/pixmaps/faces/bluefin/*.jpg by bluefin/common.bst).
+#
+# gnome-control-center's avatar chooser (panels/system/users/cc-avatar-chooser.c)
+# and gnome-initial-setup's account page only enumerate files directly inside
+# <datadir>/pixmaps/faces/ — they never recurse into subdirectories. Without an
+# explicit avatar-directories setting, both silently fall back to Fedora/GNOME's
+# stock (near-empty) pixmaps/faces dir and Bluefin's avatars never appear.
+#
+# Setting org.gnome.desktop.interface avatar-directories tells both UIs to scan
+# our bluefin/ subdirectory explicitly.
+[org/gnome/desktop/interface]
+avatar-directories=['/usr/share/pixmaps/faces/bluefin']


### PR DESCRIPTION
## Summary

Fixes #353 — Bluefin's custom dinosaur-themed avatars (drawn by Jacob Schnurr,
see docs/dinosaurs.md in projectbluefin/documentation) never showed up in the
GNOME Users account-picture picker on Dakota, even though the image files are
correctly ingested from projectbluefin/common.

## Root cause

bluefin-common ships these avatars under a `bluefin/` category subdirectory:
`/usr/share/pixmaps/faces/bluefin/*.jpg` (named after GNOME's old stock face
filenames — bicycle.jpg, cat.jpg, etc. — but the artwork itself is Bluefin's
own).

GNOME's avatar pickers only look directly inside `<datadir>/pixmaps/faces/`:

- cc-avatar-chooser.c (get_system_facesdirs/add_faces_from_dirs) in gnome-control-center
- gnome-initial-setup's account page (um-photo-dialog.c)

Neither recurses into subdirectories, so the `bluefin/` folder is silently
skipped and both UIs fall back to Fedora/GNOME's near-empty stock
pixmaps/faces dir. This isn't a file-ingestion bug — bluefin/common.bst
already copies the files correctly — it's that nothing tells GNOME to look in
the bluefin/ subdirectory.

## Fix

org.gnome.desktop.interface has an avatar-directories GSetting (as)
specifically for this: both pickers check it first and, if set, scan every
listed directory in full. This adds a new bluefin/user-avatars.bst element
that installs a distro dconf override
(/etc/dconf/db/distro.d/07-dakota-avatar-directories) setting
avatar-directories=['/usr/share/pixmaps/faces/bluefin'], following the same
pattern already used by files/dconf/05-dakota-custom-command-menu and
06-dakota-keybindings.

## Testing

- Validated new/edited .bst YAML parses correctly and that
  bluefin/user-avatars.bst is wired into elements/bluefin/deps.bst.
- Could not run just build/just boot-test in this environment (no
  podman/BuildStream available); requesting a maintainer/CI build to confirm
  the avatars appear in Settings → Users → account picture.

Closes #353

Assisted-by: Claude Sonnet 5 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>