### PR TITLE
fix(framework): bump common ref to remove obsolete hid_sensor_hub karg

### DIFF
--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -209,6 +209,12 @@ Heavy build contributors:
 
 ## Lessons Learned
 
+### Intel Framework hid_sensor_hub karg is obsolete on kernel 6.8+ (2026-07-30)
+
+In pre-6.8 kernels, `module_blacklist=hid_sensor_hub` was used to work around ambient light sensor (ALS) conflicts with keyboard brightness shortcuts on Intel Framework laptops. On Kernel 6.8+, brightness keys are handled natively upstream. Blacklisting `hid_sensor_hub` disables ALS and breaks power supply/battery state transitions (`cros_ec` / `upower`), causing an immediate hard off when unplugging the AC power adapter (dakota#1247).
+
+The fix belongs in `projectbluefin/common`: remove `/usr/lib/bootc/kargs.d/framework-intel.toml` and clean up legacy kargs in `10-framework.sh`.
+
 ### zstd:chunked compression is incompatible with bootc composefs (2026-06-07)
 
 Attempting to push with `--compression-format=zstd:chunked` or via skopeo after chunkah rechunking fails with "unexpected EOF reading tar entry" at the composefs layer. After `chunkah build → podman load`, the only working push path is plain `podman push`. Do not reintroduce skopeo, oci-dir workarounds, or zstd:chunked flags for post-chunkah pushes. See projectbluefin/dakota#119 for the investigation.

--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -4,7 +4,7 @@ sources:
 - kind: git_repo
   url: github:projectbluefin/common.git
   track: main
-  ref: v2026.07-57-gadf04412a3e31353db48f09d07f3e1e17da6f63f
+  ref: 991fc3c2cacf4e82cff48bea52e7a43ae019cab7
 - kind: git_module
   url: github:projectbluefin/branding/
   path: bluefin-branding

--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -4,7 +4,7 @@ sources:
 - kind: git_repo
   url: github:projectbluefin/common.git
   track: main
-  ref: 991fc3c2cacf4e82cff48bea52e7a43ae019cab7
+  ref: 67a0d43053629bb14eb1fc0b66f5675599e5c4a5
 - kind: git_module
   url: github:projectbluefin/branding/
   path: bluefin-branding


### PR DESCRIPTION
### Summary
On Kernel 6.8+, Intel Framework laptops natively handle brightness hotkeys and ambient light sensor (ALS) arbitration. Blacklisting `hid_sensor_hub` via bootc kargs disables ALS and causes power supply / battery state event drops (`cros_ec` / `upower`) during AC power unplug, triggering an immediate emergency hard-off.

### Changes
1. **Upstream Fix in `projectbluefin/common`**: Removed `system_files/shared/usr/lib/bootc/kargs.d/framework-intel.toml` and added karg cleanup in `10-framework.sh` (commit `991fc3c2cacf4e82cff48bea52e7a43ae019cab7`).
2. **Dakota Ref Bump**: Updated `elements/bluefin/common.bst` to `991fc3c2cacf4e82cff48bea52e7a43ae019cab7`.
3. **Skill Update**: Documented the lesson in `docs/skills/overview.md`.

Closes #1247

Assisted-by: Gemini 3.6 Flash via GitHub Copilot