### PR TITLE
fix(ujust): bootstrap fzf for recipe chooser

### DIFF
--- a/.github/skills/ujust-recipes.md
+++ b/.github/skills/ujust-recipes.md
@@ -5,6 +5,19 @@
 
 ---
 
+## Homebrew-managed chooser dependencies
+
+`ujust --choose` is a wrapper-level command, so it can run before the
+first-login `brew-preinstall.service` has finished. If the chooser binary is
+managed by Homebrew rather than shipped in the image, the `ujust` wrapper must
+install it on demand, evaluate `brew shellenv`, and verify it with
+`command -v` before dispatching to `just`. Match `--choose` as an exact
+argument so unrelated recipe arguments cannot trigger an install.
+
+Keep this bootstrap temporary when the wrapper is inherited from
+`projectbluefin/common`: carry it as a local patch with an exit condition, then
+drop it when the shared fix is merged and the common ref includes it.
+
 ## Heredoc content in shebang recipes — defensive pattern
 
 just parses heredoc content inside shebang recipes and can reject constructs

--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -11,6 +11,8 @@ sources:
   ref: f5213ca61615bb79a8315fc4c5378a80ca93922e
 - kind: local
   path: files/wallpaper-month
+- kind: patch_queue
+  path: patches/common
 
 build-depends:
 - gnome-build-meta.bst:gnomeos-deps/just.bst

--- a/patches/common/0001-ujust-install-fzf-before-choose.patch
+++ b/patches/common/0001-ujust-install-fzf-before-choose.patch
@@ -1,0 +1,61 @@
+From e4f7e5e7fad8bd83e90055e54439804c24a8b846 Mon Sep 17 00:00:00 2001
+From: Jorge O. Castro <jorge@projectbluefin.io>
+Date: Mon, 27 Jul 2026 21:14:10 -0400
+Subject: [PATCH] ujust: install fzf before choosing recipes
+
+Upstream-Status: Submitted https://github.com/projectbluefin/common/tree/fix/ujust-install-fzf
+Exit: Drop after projectbluefin/common merges fix/ujust-install-fzf and Dakota tracks it.
+
+The chooser is now managed by Homebrew and may not be available until the
+first-login preinstall service completes. Install it on demand before
+dispatching --choose, then verify that the Homebrew environment exposes it.
+---
+ system_files/shared/usr/bin/ujust | 37 ++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 36 insertions(+), 1 deletion(-)
+
+diff --git a/system_files/shared/usr/bin/ujust b/system_files/shared/usr/bin/ujust
+index 28ea130..d5ec6d0 100755
+--- a/system_files/shared/usr/bin/ujust
++++ b/system_files/shared/usr/bin/ujust
+@@ -1,3 +1,38 @@
+-#!/usr/bin/bash
+-
+-just --justfile /usr/share/ublue-os/just/00-entry.just "${@}"
++#!/usr/bin/bash
++
++CHOOSE=false
++for arg in "$@"; do
++    if [[ "$arg" == "--choose" ]]; then
++        CHOOSE=true
++        break
++    fi
++done
++
++if [[ "${CHOOSE}" == true ]] && ! command -v fzf >/dev/null 2>&1; then
++    BREW_BIN="${BREW_BIN:-$(command -v brew 2>/dev/null || true)}"
++    BREW_BIN="${BREW_BIN:-/var/home/linuxbrew/.linuxbrew/bin/brew}"
++
++    if [[ ! -x "${BREW_BIN}" ]]; then
++        echo "ujust: fzf is missing and Homebrew was not found" >&2
++        exit 127
++    fi
++
++    echo "ujust: installing missing fzf with Homebrew..." >&2
++    if ! "${BREW_BIN}" install fzf; then
++        echo "ujust: failed to install fzf" >&2
++        exit 1
++    fi
++
++    SHELLENV_OUTPUT="$("${BREW_BIN}" shellenv)" || {
++        echo "ujust: failed to initialize Homebrew environment" >&2
++        exit 1
++    }
++    eval "${SHELLENV_OUTPUT}"
++
++    if ! command -v fzf >/dev/null 2>&1; then
++        echo "ujust: fzf is still unavailable after Homebrew setup" >&2
++        exit 127
++    fi
++fi
++
++exec just --justfile /usr/share/ublue-os/just/00-entry.just "${@}"


### PR DESCRIPTION
## What problem are you solving?

`ujust --choose` invokes just's fzf chooser, but fzf was moved from the immutable image to Homebrew. On a fresh Dakota login, the brew-preinstall service may not have completed yet, so the chooser exits with `fzf: command not found`.

- [x] I am using an agent and I take responsibility for this PR

## Changes

- Backport the shared common fix that installs fzf on demand when `--choose` is requested.
- Initialize and verify the Homebrew environment before dispatching to just.
- Document the temporary patch and its removal condition in the ujust skill.

## Testing

- [ ] `just validate` passes — unavailable in this environment (`just` and `podman` are not installed).
- [ ] `just boot-test` passes — requires the Dakota image build and boot test.
- [ ] `just lint` passes on a built image — requires the Dakota image build.
- [ ] `just boot-fast` or `just boot-vm` — requires the Dakota image build.
- Materialized the patch against Dakota's pinned common source, verified it matches the shared fix, passed `bash -n`, and exercised the missing-Homebrew failure path.

## Checklist

- [ ] New BST elements wired into `deps.bst` — not applicable.
- [ ] Patches in `patches/` regenerated if junction refs changed — no junction refs changed.

## Community verification (bug-fix PRs)

```verify
ujust --choose
```

Closes projectbluefin/common#899