### PR TITLE
fix(ujust): keep report success status

### DIFF
--- a/.github/skills/ujust-recipes.md
+++ b/.github/skills/ujust-recipes.md
@@ -5,6 +5,14 @@
 
 ---
 
+## Report submission exit status
+
+`ujust report` completes the public submission before it optionally opens the
+issue in a browser. Browser launching is best-effort and must not determine
+the recipe's exit status; return success explicitly after the issue URL has
+been created. Keep this downstream guard only until the shared
+`bonedigger-report` fix is included by the tracked common ref.
+
 ## Heredoc content in shebang recipes — defensive pattern
 
 just parses heredoc content inside shebang recipes and can reject constructs

--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -11,6 +11,8 @@ sources:
   ref: f5213ca61615bb79a8315fc4c5378a80ca93922e
 - kind: local
   path: files/wallpaper-month
+- kind: patch_queue
+  path: patches/common
 
 build-depends:
 - gnome-build-meta.bst:gnomeos-deps/just.bst

--- a/patches/common/0001-bonedigger-report-success-status.patch
+++ b/patches/common/0001-bonedigger-report-success-status.patch
@@ -1,0 +1,25 @@
+From 8890000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dakota Contributors <contributors@projectbluefin.io>
+Date: Fri, 31 Jul 2026 16:10:00 +0000
+Subject: [PATCH] bonedigger-report: keep browser launch from changing success
+
+Upstream-Status: Submitted https://github.com/projectbluefin/common/pull/889
+Exit: Drop after common PR 889 lands and Dakota tracks the fixed common ref.
+
+Opening the issue in a browser is best-effort after the report has already
+been submitted. Ignore browser-helper failures and return success explicitly
+so they cannot make `ujust report` look unsuccessful.
+---
+ system_files/bluefin/usr/libexec/bonedigger-report | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/system_files/bluefin/usr/libexec/bonedigger-report b/system_files/bluefin/usr/libexec/bonedigger-report
+index 9b4033c..9b4033c 100755
+--- a/system_files/bluefin/usr/libexec/bonedigger-report
++++ b/system_files/bluefin/usr/libexec/bonedigger-report
+@@ -504,3 +504,4 @@ submit_draft() {
+     rm -rf "$DRAFT_DIR"
+-    offer_browser "$issue_url"
++    offer_browser "$issue_url" || true
++    return 0
+ }


### PR DESCRIPTION
## What problem are you solving?

`ujust report` successfully creates the report and opens the browser, but the browser helper's exit status can still make the recipe return code 1. That makes users think the report failed even though the submission completed.

- [x] I am using an agent and I take responsibility for this PR

## Changes

- Ignore best-effort browser-launch failures after successful report submission.
- Return success explicitly from the report submission path.
- Carry the fix as a temporary common-source patch linked to projectbluefin/common PR 889, with an exit condition for the common ref update.
- Document the report exit-status contract in the ujust skill.

## Testing

- [ ] `just validate` passes — unavailable in this environment (`just` and `podman` are not installed).
- [ ] `just boot-test` passes — requires the Dakota image build and boot test.
- [ ] `just lint` passes on a built image — requires the Dakota image build.
- [ ] `just boot-fast` or `just boot-vm` — requires the Dakota image build.
- Applied the patch to Dakota's pinned common source, passed `bash -n`, and ran a regression harness where the browser helper fails while submission still returns success.

## Checklist

- [ ] New BST elements wired into `deps.bst` — not applicable.
- [ ] Patches in `patches/` regenerated if junction refs changed — no junction refs changed.

## Community verification (bug-fix PRs)

```verify
ujust report
```

Closes #940