### PR TITLE
fix(audio): disable PC-speaker WirePlumber sink

### DIFF
--- a/docs/skills/add-package.md
+++ b/docs/skills/add-package.md
@@ -136,6 +136,17 @@ variables:
   strip-binaries: ""
 ```
 
+### Ship WirePlumber policy as a `/usr/share` fragment (2026-07-31)
+
+WirePlumber 0.5 loads distribution-provided configuration fragments from
+`/usr/share/wireplumber/wireplumber.conf.d/*.conf`, while `/etc` and user
+configuration directories remain higher-priority override locations. For
+system-wide ALSA policy, add a config-only manual element with a local source,
+install the fragment under that `/usr/share` path, and wire the element into
+`elements/bluefin/deps.bst`. Use `monitor.alsa.rules` to match a device and
+set `device.disabled = true` when the device must remain kernel-visible but
+must not become a desktop PipeWire node.
+
 ### BST variables cannot be used in source URL fields (2026-06-07)
 
 Unlike install commands where `%{version}` expands correctly, BuildStream does NOT expand variables inside `sources[].url:` fields. Use `include/aliases.yml` to define a URL alias, then reference the alias.

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -43,6 +43,7 @@ depends:
   # Restores the VTE typelibs the app-drop strips out (dakota#1022)
   - bluefin/vte.bst
   - bluefin/network.bst
+  - bluefin/wireplumber-pcsp.bst
   - bluefin/countme.bst
   - bluefin/alsa-utils.bst
   # - bluefin/lsp-plugins-lv2.bst

--- a/elements/bluefin/wireplumber-pcsp.bst
+++ b/elements/bluefin/wireplumber-pcsp.bst
@@ -1,0 +1,21 @@
+kind: manual
+description: |
+  Prevent WirePlumber from exposing the PC-speaker ALSA card as a desktop
+  audio device. Keep the kernel driver loaded for console beeps, but avoid
+  selecting the unusable mono fallback sink after suspend/resume.
+  Fixes projectbluefin/dakota#1248.
+
+sources:
+- kind: local
+  path: files/wireplumber
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - install -Dm644 51-disable-pcsp.conf \
+      "%{install-root}%{datadir}/wireplumber/wireplumber.conf.d/51-disable-pcsp.conf"

--- a/files/wireplumber/51-disable-pcsp.conf
+++ b/files/wireplumber/51-disable-pcsp.conf
@@ -1,0 +1,16 @@
+# Keep snd_pcsp available for console beeps without exposing its PCM card as a
+# desktop audio device. Otherwise it can become the default sink after resume.
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        device.name = "alsa_card.platform-pcspkr"
+      }
+    ]
+    actions = {
+      update-props = {
+        device.disabled = true
+      }
+    }
+  }
+]


### PR DESCRIPTION
## What problem are you solving?

After suspend/resume, WirePlumber can expose the PC-speaker ALSA card as a 37 kHz mono fallback sink and select it as the desktop default. That produces silence and slows video playback until the real HDA speakers are manually selected.

- [x] I am using an agent and I take responsibility for this PR

## Changes

- Add a system WirePlumber 0.5 fragment matching `alsa_card.platform-pcspkr`.
- Set `device.disabled = true` so the PC-speaker PCM device is not exposed as a desktop sink.
- Keep `snd_pcsp` loaded for console beep support.
- Wire the config-only element into the image and document the `/usr/share` fragment pattern.

Closes #1248

## Testing

- [x] Verified the policy contents and exact device match.
- [x] Verified the fragment installs to `/usr/share/wireplumber/wireplumber.conf.d/`.
- [ ] `just validate` — unavailable in this host because `just` and Podman are not installed and cannot be installed without root.
- [ ] `just boot-test` — requires the image build/runtime tools.
- [ ] `just lint` — requires an exported image.

## Checklist

- [x] New BST element wired into `deps.bst`
- [x] No junction refs or patch queues changed
