### PR TITLE
feat(bluefin): add ydotool input automation

### DIFF
--- a/docs/skills/add-package.md
+++ b/docs/skills/add-package.md
@@ -173,3 +173,11 @@ junction. If a Shell extension needs the GTK3 introspection ABI, build with `-Dg
 (depends on `gnome-build-meta.bst:sdk/gtk+-3.bst`); upstream's VTE is GTK4-only. Push demo
 binaries and unversioned `.so` linker symlinks to the `devel` split so `bluefin-runtime`'s
 compose (which excludes `devel`) keeps only the `.typelib` + versioned `.so.N`.
+
+### User services that require `/dev/uinput` need both module loading and uaccess (2026-07-31)
+
+For a user-level daemon that opens `/dev/uinput`, installing the upstream unit
+alone is insufficient. Ship a modules-load entry for `uinput` and a udev rule
+with `TAG+="uaccess"` so the active desktop user receives device ACL access
+without manual `chmod` or group edits. Keep the user unit present but unenabled
+unless the feature is explicitly opt-in.

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -19,6 +19,7 @@ depends:
 
   - bluefin/gum.bst
   - bluefin/tealdeer.bst
+  - bluefin/ydotool.bst
   - bluefin/umotd.bst
 
   - bluefin/common.bst

--- a/elements/bluefin/ydotool.bst
+++ b/elements/bluefin/ydotool.bst
@@ -1,0 +1,36 @@
+# ydotool provides input injection for Wayland sessions through /dev/uinput.
+# Keep the daemon unit disabled by default; users opt in with systemctl --user.
+kind: cmake
+
+sources:
+- kind: git_repo
+  url: github:ReimuNotMoe/ydotool.git
+  track: v1.0.4
+  ref: v1.0.4-0-g57ba7d0af525e82da2de0e275d169477f293b197
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-cmake.bst
+- freedesktop-sdk.bst:components/scdoc.bst
+- freedesktop-sdk.bst:components/systemd.bst
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  cmake-local: >-
+    -DCMAKE_INSTALL_MANDIR=%{mandir}
+
+config:
+  install-commands:
+    (>):
+    - |
+      install -Dm644 /dev/null "%{install-root}%{indep-libdir}/udev/rules.d/80-ydotool.rules"
+      cat > "%{install-root}%{indep-libdir}/udev/rules.d/80-ydotool.rules" <<'EOF'
+      KERNEL=="uinput", GROUP="input", MODE="0660", TAG+="uaccess", OPTIONS+="static_node=uinput"
+      EOF
+    - |
+      install -Dm644 /dev/null "%{install-root}%{indep-libdir}/modules-load.d/ydotool.conf"
+      printf '%s\n' uinput > "%{install-root}%{indep-libdir}/modules-load.d/ydotool.conf"
+    - |
+      install -d "%{install-root}%{indep-libdir}/systemd/user"
+      ln -s ydotool.service "%{install-root}%{indep-libdir}/systemd/user/ydotoold.service"


### PR DESCRIPTION
## What problem are you solving?

Add ydotool to Dakota so Wayland speech-to-text and automation tools have a uinput-backed input injection path.

- [ ] I am using an agent and I take responsibility for this PR

## Changes

- Add a pinned BuildStream CMake element for ydotool v1.0.4.
- Ship `ydotool` and `ydotoold`, upstream man pages, and an opt-in user service alias.
- Load the `uinput` kernel module and grant the active desktop user uaccess to `/dev/uinput`.
- Wire the element into the Dakota image dependency stack.
- Document the uinput user-service packaging pattern.

Closes #1217

## Testing

- BST YAML parsed successfully.
- `git diff --check` passed.
- `just bst show --deps all oci/bluefin.bst` could not run locally because `just` is unavailable in this environment; CI will perform graph/build validation.
- Booted-image typing smoke test remains for CI/lab hardware verification.

## Checklist

- [ ] `just validate` passes
- [ ] `just lint` passes on a built image
- [ ] `just boot-test` passes
- [ ] Commit trailer: `Assisted-by:`
- [ ] I am using an agent and I take responsibility for this PR