### PR TITLE
fix(zswap): disable zram via integration command, overlap lost

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -185,6 +185,11 @@ jobs:
           BUILD_IMAGE_NAME: ${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
         run: just lint
 
+      - name: Audit swap/zram configuration
+        env:
+          BUILD_IMAGE_NAME: ${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
+        run: just swap-audit
+
       - name: Login to GHCR
         env:
           GH_ACTOR: ${{ github.actor }}

--- a/Justfile
+++ b/Justfile
@@ -1006,6 +1006,7 @@ boot-test: _ensure-bcvk
         "graphical.target:systemctl is-active graphical.target"
         "gdm:systemctl is-active gdm"
         "bootc:bootc status"
+        "no-zram:test ! -e /sys/block/zram0"
     )
 
     PASS=0
@@ -1200,3 +1201,60 @@ lint:
     $SUDO_CMD podman run --rm --privileged --pull=never \
         "{{image_name}}:{{image_tag}}" \
         bootc container lint
+
+# ── Swap audit ───────────────────────────────────────────────────────
+# Assert the image's swap architecture: zram disabled, zswap kargs present,
+# swapfile units wired. Guards against the #1131 overlap regression where the
+# upstream zram-generator config silently won over the intended override.
+[group('test')]
+swap-audit:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # Use sudo unless already root
+    SUDO_CMD=""
+    if [ "$(id -u)" -ne 0 ]; then
+        SUDO_CMD="sudo"
+    fi
+
+    echo "==> Auditing swap/zram configuration in {{image_name}}:{{image_tag}}..."
+    $SUDO_CMD podman run --rm --pull=never \
+        "{{image_name}}:{{image_tag}}" \
+        bash -c '
+        set -uo pipefail
+        STATUS=0
+        fail() { echo "FAIL: $1" >&2; STATUS=1; }
+
+        if grep -q "^\[zram" /usr/lib/systemd/zram-generator.conf 2>/dev/null; then
+            fail "/usr/lib/systemd/zram-generator.conf still defines a zram device"
+        fi
+        if compgen -G "/etc/systemd/zram-generator.conf*" > /dev/null; then
+            fail "unexpected zram-generator config under /etc"
+        fi
+
+        KARGS=/usr/lib/bootc/kargs.d/20-zswap.toml
+        if [ ! -f "$KARGS" ]; then
+            fail "$KARGS missing"
+        else
+            grep -q "zswap.enabled=1" "$KARGS" || fail "zswap.enabled=1 karg missing"
+            # kernel 7.x removed the zswap.zpool parameter
+            grep -q "zpool" "$KARGS" && fail "dead zswap.zpool karg present"
+        fi
+
+        [ -f /usr/lib/systemd/system/var-swap-swapfile.swap ] \
+            || fail "var-swap-swapfile.swap unit missing"
+        [ -L /usr/lib/systemd/system/swap.target.wants/var-swap-swapfile.swap ] \
+            || fail "swap.target.wants/var-swap-swapfile.swap symlink missing"
+        [ -x /usr/libexec/bluefin-swapfile-init ] \
+            || fail "/usr/libexec/bluefin-swapfile-init missing or not executable"
+
+        # Actually run it. The container overlayfs cannot back a swapfile so it
+        # exits early, but only after sizing and the free-space arithmetic --
+        # which is where a broken coreutils invocation would surface. Presence
+        # checks alone shipped exactly such a bug once.
+        /usr/libexec/bluefin-swapfile-init \
+            || fail "bluefin-swapfile-init exited non-zero"
+
+        [ "$STATUS" -eq 0 ] && echo "PASS: swap/zram configuration OK"
+        exit "$STATUS"
+        '

--- a/docs/skills/buildstream.md
+++ b/docs/skills/buildstream.md
@@ -173,3 +173,13 @@ public:
 ```
 
 *Note: Replacing base system files destroys the base mappings. Whenever possible, prefer injecting changes dynamically via a hook (e.g., in `common.bst`) rather than completely replacing junction files.*
+
+**A whitelist is not precedence.** `overlap-whitelist` only silences the overlap
+error — the file that survives is decided by staging order, and a dakota element
+can lose to a junction element. This shipped as a real regression: the empty
+`zram-generator.conf` from `just-overrides.bst` was whitelisted but lost to
+`gnomeos-deps/zram-generator.bst`, so images ran zram *and* zswap together
+(#1131). To deterministically replace a junction-owned file, overwrite it in an
+`integration-commands` block (e.g. `oci/layers/bluefin-stack.bst`), which runs
+after all elements are staged — and add a CI assertion on the composed image
+(`just swap-audit`) so a silent flip cannot ship again.

--- a/docs/skills/oci-layers.md
+++ b/docs/skills/oci-layers.md
@@ -186,10 +186,10 @@ Running `ldconfig` after `build-oci` has no effect. Running `build-oci` before `
 
 When a remote CAS/object cache reuses the wrong content for a layer digest/size tuple, the safest fix is to change the layer contents in a targeted way instead of only changing workflow timeouts or element keys. A small manual element that installs a versioned marker file into the compose layer keeps the fix in the layer boundary and avoids turning the final OCI script into a broad rebuild path.
 
-### Stateless bootc configurations must reside in /usr (like /usr/lib/systemd/ and /usr/lib/bootc/kargs.d/) rather than /etc (2026-07-01)
+### Stateless bootc configurations must reside in /usr (like /usr/lib/systemd/ and /usr/lib/bootc/kargs.d/) rather than /etc (2026-07-01; corrected 2026-07-31)
 
 In a bootc/OSTree-based immutable OS like Dakota, `/etc` is mutable, user-owned, and must remain completely stateless. Baking default system configs into `/etc` at build time is an anti-pattern. Instead:
-1. **Disable ZRAM**: Override `zram-generator` by copying an empty `zram-generator.conf` to `/usr/lib/systemd/zram-generator.conf` (via `just-overrides.bst`) and whitelist it. Since this is in `/usr/lib`, it cleanly preempts the generator from creating devices without cluttering `/etc`.
+1. **Disable ZRAM**: Overwrite `/usr/lib/systemd/zram-generator.conf` with a no-device config from an *integration command* in `oci/layers/bluefin-stack.bst`. The original approach — installing an empty conf from `just-overrides.bst` with an overlap-whitelist — shipped with zram still enabled: the whitelist only permits the overlap, and staging order let the junction's `gnomeos-deps/zram-generator.bst` copy win (#1131 regression). Integration commands run after all staging, so they are the deterministic override point for junction-owned `/usr` files. The `/usr`-not-`/etc` guidance itself still stands.
 2. **Inject Bootc Kernel Arguments**: Install kargs TOML files directly under `/usr/lib/bootc/kargs.d/` (e.g. `/usr/lib/bootc/kargs.d/20-zswap.toml`). Bootc automatically reads these on switch/upgrade and applies them.
 3. **Vendor Sysctl parameters**: Store system defaults under `/usr/lib/sysctl.d/*.conf` (e.g. `60-swappiness.conf`) instead of `/etc/sysctl.conf`.
 

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -24,6 +24,7 @@ depends:
   - bluefin/common.bst
   - bluefin/just-overrides.bst
   - bluefin/zswap-config.bst
+  - bluefin/swapfile.bst
   - bluefin/firstboot-date.bst
   - bluefin/firstboot-services.bst
   - bluefin/wallpaper-month.bst

--- a/elements/bluefin/just-overrides.bst
+++ b/elements/bluefin/just-overrides.bst
@@ -16,7 +16,6 @@ public:
     - /usr/share/ublue-os/just/default.just
     - /usr/share/ublue-os/just/changelog.just
     - /usr/share/ublue-os/just/system.just
-    - /usr/lib/systemd/zram-generator.conf
 
 config:
   install-commands:
@@ -24,5 +23,4 @@ config:
   - install -Dm644 changelog.just "%{install-root}/usr/share/ublue-os/just/changelog.just"
   - install -Dm644 system.just "%{install-root}/usr/share/ublue-os/just/system.just"
   - install -Dm644 flutter.just "%{install-root}/usr/share/ublue-os/just/flutter.just"
-  - install -Dm644 zram-generator.conf "%{install-root}%{prefix}/lib/systemd/zram-generator.conf"
   - "%{install-extra}"

--- a/elements/bluefin/swapfile.bst
+++ b/elements/bluefin/swapfile.bst
@@ -1,0 +1,40 @@
+kind: manual
+description: |
+  Disk-backed swapfile at /var/swap/swapfile: the backing store zswap fronts
+  (kargs in bluefin/zswap-config.bst). Without a real swap device zswap is
+  inert, and Dakota disables the GNOME OS zram default.
+
+  A oneshot init service creates the file on first need (min(RAM/2, 8 GiB),
+  dd-written for xfs/btrfs swapon compatibility, skipped on small disks); the
+  .swap unit is pulled in via a static swap.target.wants symlink so existing
+  installs pick it up on upgrade — presets only apply on first boot.
+
+  /var/swap is created at runtime: bluefin-stack.bst integration wipes /var,
+  and bootc lints against baked /var content.
+
+sources:
+- kind: local
+  path: files/swapfile
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    install -Dm755 bluefin-swapfile-init \
+            "%{install-root}/usr/libexec/bluefin-swapfile-init"
+  - |
+    install -Dm644 bluefin-swapfile-init.service \
+            "%{install-root}%{indep-libdir}/systemd/system/bluefin-swapfile-init.service"
+  - |
+    install -Dm644 var-swap-swapfile.swap \
+            "%{install-root}%{indep-libdir}/systemd/system/var-swap-swapfile.swap"
+  - |
+    install -d "%{install-root}%{indep-libdir}/systemd/system/swap.target.wants"
+    ln -sf ../var-swap-swapfile.swap \
+           "%{install-root}%{indep-libdir}/systemd/system/swap.target.wants/var-swap-swapfile.swap"
+  - "%{install-extra}"

--- a/elements/bluefin/zswap-config.bst
+++ b/elements/bluefin/zswap-config.bst
@@ -6,6 +6,11 @@ description: |
   The vm.swappiness=100 sysctl instructs the kernel to treat anonymous and file-backed
   memory with parity, routing swap I/O through high-speed zswap cache.
 
+  No zswap.zpool karg: kernel 7.x removed the parameter (zsmalloc is the only
+  backend). The backing swap device zswap fronts is provided by
+  bluefin/swapfile.bst; zram is disabled via an integration command in
+  oci/layers/bluefin-stack.bst.
+
 depends:
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
@@ -20,7 +25,6 @@ config:
     kargs = [
         "zswap.enabled=1",
         "zswap.compressor=zstd",
-        "zswap.zpool=zsmalloc",
         "zswap.max_pool_percent=20",
         "zswap.shrinker_enabled=1",
     ]

--- a/elements/oci/layers/bluefin-stack.bst
+++ b/elements/oci/layers/bluefin-stack.bst
@@ -25,6 +25,12 @@ depends:
 public:
   bst:
     integration-commands:
+      # Overwrite the zram-generator config from gnomeos-deps/zram-generator.bst.
+      # An element-level override loses the staging-order overlap (see
+      # docs/skills/buildstream.md); integration commands run after all staging,
+      # so this is the deterministic winner. No [zramN] section = no zram device.
+      - printf '# zram disabled; Dakota swaps via zswap + /var/swap/swapfile\n' > /usr/lib/systemd/zram-generator.conf
+
       - rm -rfv /boot /run
 
       # Required for bootc to create the image

--- a/files/just-overrides/zram-generator.conf
+++ b/files/just-overrides/zram-generator.conf
@@ -1,1 +1,0 @@
-# Empty zram-generator config to disable automatic zram generation.

--- a/files/swapfile/bluefin-swapfile-init
+++ b/files/swapfile/bluefin-swapfile-init
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Create the disk-backed swapfile that zswap fronts (see bluefin/zswap-config.bst).
+# Idempotent: exits successfully if the swapfile already exists or the disk is
+# too small; removes a partially written file so the next boot retries.
+set -eu
+
+SWAPDIR=/var/swap
+SWAPFILE="${SWAPDIR}/swapfile"
+
+[ -e "${SWAPFILE}" ] && exit 0
+
+# min(MemTotal / 2, 8192) MiB
+mem_kib=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
+size_mib=$((mem_kib / 2048))
+[ "${size_mib}" -gt 8192 ] && size_mib=8192
+
+mkdir -p -m 0700 "${SWAPDIR}"
+
+# Skip (not fail) when /var can't hold the swapfile plus a 1 GiB margin.
+# stat, not df: uutils df (shipped via uutils-coreutils.bst) rejects
+# -P combined with --output, and stat -f avoids parsing tabular output.
+# Ordered before the fstype check so `just swap-audit` exercises this
+# arithmetic when it runs the script inside the (overlayfs) image.
+free_mib=$(( $(stat -f -c '%a' "${SWAPDIR}") * $(stat -f -c '%S' "${SWAPDIR}") / 1048576 ))
+if [ "${free_mib}" -lt $((size_mib + 1024)) ]; then
+    echo "bluefin-swapfile-init: ${free_mib} MiB free on /var, need $((size_mib + 1024)) MiB; skipping swapfile creation"
+    exit 0
+fi
+
+# Skip on filesystems that can't back a swapfile (e.g. the virtiofs root of
+# bcvk/testsuite ephemeral VMs, where swapon would fail the .swap unit).
+fstype=$(stat -f -c %T "${SWAPDIR}")
+case "${fstype}" in
+    xfs|btrfs|ext2/ext3) ;;
+    *)
+        echo "bluefin-swapfile-init: ${fstype} does not support swapfiles; skipping"
+        exit 0
+        ;;
+esac
+
+cleanup() { rm -f "${SWAPFILE}"; }
+trap cleanup EXIT
+
+touch "${SWAPFILE}"
+chmod 0600 "${SWAPFILE}"
+# btrfs requires NOCOW for swapfiles; must be set while the file is empty.
+# Fails harmlessly on xfs.
+chattr +C "${SWAPFILE}" 2>/dev/null || true
+# dd, not fallocate: xfs and btrfs reject preallocated (unwritten) extents
+# at swapon time ("swapfile has holes").
+dd if=/dev/zero of="${SWAPFILE}" bs=1M count="${size_mib}" conv=fsync status=none
+mkswap "${SWAPFILE}"
+
+trap - EXIT
+echo "bluefin-swapfile-init: created ${size_mib} MiB swapfile at ${SWAPFILE}"

--- a/files/swapfile/bluefin-swapfile-init.service
+++ b/files/swapfile/bluefin-swapfile-init.service
@@ -1,0 +1,18 @@
+# DefaultDependencies=no: with default deps this unit gains After=sysinit.target,
+# while swap.target (via var-swap-swapfile.swap -> this unit) must complete
+# before sysinit.target — an ordering cycle systemd would break by dropping the
+# swap unit.
+[Unit]
+Description=Create swapfile backing store for zswap
+DefaultDependencies=no
+RequiresMountsFor=/var/swap
+After=systemd-remount-fs.service
+Conflicts=shutdown.target
+Before=shutdown.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Writing up to 8 GiB with dd can exceed the default 90s on slow media.
+TimeoutStartSec=15min
+ExecStart=/usr/libexec/bluefin-swapfile-init

--- a/files/swapfile/var-swap-swapfile.swap
+++ b/files/swapfile/var-swap-swapfile.swap
@@ -1,0 +1,12 @@
+# Activated via a static swap.target.wants symlink, not a preset: system
+# presets are only applied on first boot (empty machine-id), so a preset would
+# never enable this on already-installed machines.
+[Unit]
+Description=Swapfile (zswap backing store)
+Requires=bluefin-swapfile-init.service
+After=bluefin-swapfile-init.service
+# If init skipped creation (disk too small), skip activation cleanly.
+ConditionPathExists=/var/swap/swapfile
+
+[Swap]
+What=/var/swap/swapfile


### PR DESCRIPTION
## Summary

Dakota has shipped zram and zswap enabled together since #1131, reported as disastrously slow IO on hardware against a workload that ran fine on stock Fedora. Since `:stable` promotes on every successful `testing` publish, this has been in stable images since 2026-07-26.

1. **zram is now disabled from an integration command** in `oci/layers/bluefin-stack.bst`. The old override was whitelisted in `just-overrides.bst`, but a whitelist only permits an overlap, it does not decide which file survives, and staging order let the junction's copy win. Integration commands run after all staging.
2. **A disk-backed swapfile gives zswap something to front.** zswap is a cache in front of real swap, not a swap provider, so with zram off the image had no swap at all. A oneshot service creates `/var/swap/swapfile` at min(RAM/2, 8 GiB), written with `dd` because xfs and btrfs reject preallocated extents at swapon.
3. **The swap unit activates from a static `swap.target.wants` symlink, not a preset**, since presets only apply on first boot and would never enable it on existing installs.
4. **`just swap-audit` gates the image in `publish.yml`** before it reaches the registry, and runs the init script inside the image rather than only checking the file exists.

Also drops the dead `zswap.zpool` karg (removed in kernel 7.x) and corrects the overlap guidance in `docs/skills/buildstream.md` and `docs/skills/oci-layers.md`.

Verified in the default and nvidia-gaming images: no `[zram0]` section, no `zpool` karg, units present, init script exits 0 inside the image. On hardware (nvidia-gaming via local zot, VERSION_ID 20260801) zram is gone and zswap reports `enabled=Y` with zstd. Swapfile creation on hardware and the publish audit run are still outstanding.

Related: #1131