### PR TITLE
fix(bluefin): support ydotool on CMake 4

### DIFF
--- a/docs/skills/add-package.md
+++ b/docs/skills/add-package.md
@@ -123,6 +123,25 @@ install-commands:
 
 ## Lessons Learned
 
+### CMake 4 rejects pre-3.5 policy versions; set a package-local floor (2026-08-02)
+
+CMake 4 removed compatibility with policy versions older than 3.5, so pinned
+releases whose `CMakeLists.txt` declares `cmake_minimum_required(VERSION 3.4)`
+fail before configuration. If upstream has fixed the declaration but has not
+published a newer release, use CMake's packager-facing compatibility variable
+through the BuildStream CMake plugin's per-element `cmake-local` variable:
+
+```yaml
+variables:
+  cmake-local: >-
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+```
+
+Keep the override package-local; do not lower policy behavior globally. Prefer a
+newer fixed upstream release when one exists, and remove the override after the
+source bump. This follows the CMake 4.0 release notes' **Deprecated and Removed
+Features** section and the official `CMAKE_POLICY_VERSION_MINIMUM` documentation.
+
 ### `strip-binaries: ""` is required for all non-ELF staging directories (2026-06-07)
 
 BST's default behavior calls `strip` on every binary in the staging area. If an element installs any file that is not a valid ELF binary (fonts, config files, shell scripts, pre-built tarballs, .so stubs), the build fails at the strip step with an obscure error. Always set `strip-binaries: ""` in the element's `variables:` block for:

--- a/elements/bluefin/ydotool.bst
+++ b/elements/bluefin/ydotool.bst
@@ -18,6 +18,7 @@ depends:
 
 variables:
   cmake-local: >-
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     -DCMAKE_INSTALL_MANDIR=%{mandir}
 
 config:


### PR DESCRIPTION
## What problem are you solving?

The post-merge testing build fails while configuring ydotool because v1.0.4 declares CMake policy version 3.4, and CMake 4 no longer accepts policy versions older than 3.5.

- [ ] I am using an agent and I take responsibility for this PR

---

## Changes

- Set CMake's documented package-local policy floor to 3.5 for ydotool.
- Document the compatibility pattern for pinned releases that predate CMake 4.

Closes #1217
Related: #1258

## Testing

- [x] `just validate` passes
- [x] `just bst show oci/bluefin.bst` passes
- [x] `just bst build bluefin/ydotool.bst` passes with CMake 4
- [x] The built artifact contains `ydotool`, `ydotoold`, the user units, and the udev/modules-load files
- [ ] `just boot-test` passes (automated boot smoke test)
- [ ] `just lint` passes on a built image
- [ ] `just boot-fast` or `just boot-vm` confirms the desktop comes up without regressions

## Checklist

- [x] The existing ydotool element remains wired into `deps.bst`
- [x] No junction refs or patches changed

## Community verification

This is a build-time compatibility fix, so there are no hardware verification steps.
