### PR TITLE
fix(gaming): ship 32-bit GL/Vulkan drivers and re-enable Steam UI GPU

### DIFF
--- a/elements/bluefin-nvidia/nvidia-drivers.bst
+++ b/elements/bluefin-nvidia/nvidia-drivers.bst
@@ -116,74 +116,91 @@ config:
     set -euo pipefail
     cd extracted
     LIBDIR="%{install-root}%{libdir}"
-    install -d "$LIBDIR" "$LIBDIR/vdpau"
+    LIBDIR32="%{install-root}/usr/lib/i386-linux-gnu"
+    install -d "$LIBDIR" "$LIBDIR/vdpau" "$LIBDIR32" "$LIBDIR32/vdpau"
 
     # Libraries and their symlinks come from the .run's .manifest (the
-    # same metadata nvidia-installer uses), selected by TYPE so new
-    # libraries flow in on driver bumps. Not selected: GLVND/GLX/EGL
-    # client libs (system libglvnd comes from freedesktop-sdk),
-    # OPENCL_WRAPPER (ocl-icd owns libOpenCL), Wine/Xorg-module/
-    # installer internals, and all COMPAT32 rows (no 32-bit multilib).
+    # same metadata nvidia-installer uses), selected by TYPE and ARCH so
+    # new libraries flow in on driver bumps. NATIVE rows install to
+    # %{libdir}; COMPAT32 rows (payload files under 32/) install to
+    # /usr/lib/i386-linux-gnu so 32-bit GL/Vulkan games get hardware
+    # rendering — gaming/steam-libs-i686.bst ships the 32-bit GLVND and
+    # Vulkan loader that dispatch to them. Not selected: GLVND/GLX/EGL
+    # client libs (system libglvnd comes from freedesktop-sdk natively,
+    # gaming/steam-libs-i686.bst for 32-bit), OPENCL_WRAPPER (ocl-icd
+    # owns libOpenCL), Wine/Xorg-module/installer internals, and the
+    # COMPAT32 GBM backend symlink (compositors are 64-bit; nothing
+    # loads a 32-bit GBM backend).
     # Row shape: <name> <mode> <TYPE> <ARCH> [subdir/] [target] MODULE:<tag>
     # awk normalizes rows to fixed columns and flags anything it cannot
     # classify, so a changed manifest format fails the build loudly.
     # SONAME links the manifest does not declare are created by ldconfig
     # at compose integration time.
-    awk '
-        BEGIN {
-            n = split("OPENGL_LIB CUDA_LIB NVCUVID_LIB ENCODEAPI_LIB" \
-                      " UTILITY_LIB TLS_LIB OPENCL_LIB VDPAU_LIB", a, " ")
-            for (i = 1; i <= n; i++) isfile[a[i]] = 1
-            n = split("OPENGL_SYMLINK CUDA_SYMLINK NVCUVID_LIB_SYMLINK" \
-                      " ENCODEAPI_LIB_SYMLINK UTILITY_LIB_SYMLINK" \
-                      " OPENCL_LIB_SYMLINK VDPAU_SYMLINK" \
-                      " GBM_BACKEND_LIB_SYMLINK", b, " ")
-            for (i = 1; i <= n; i++) islink[b[i]] = 1
-        }
-        NF >= 4 && $2 ~ /^[0-9]+$/ && $4 == "NATIVE" && ($3 in isfile || $3 in islink) {
-            subdir = "-"; target = "-"; bad = 0
-            for (i = 5; i <= NF; i++) {
-                if ($i ~ /^MODULE:/ || $i == "/") continue
-                else if ($i ~ /\/$/) subdir = $i
-                else if (target == "-") target = $i
-                else bad = 1
+    install_manifest_arch() {
+        arch="$1"
+        destdir="$2"
+        awk -v arch="$arch" '
+            BEGIN {
+                n = split("OPENGL_LIB CUDA_LIB NVCUVID_LIB ENCODEAPI_LIB" \
+                          " UTILITY_LIB TLS_LIB OPENCL_LIB VDPAU_LIB", a, " ")
+                for (i = 1; i <= n; i++) isfile[a[i]] = 1
+                n = split("OPENGL_SYMLINK CUDA_SYMLINK NVCUVID_LIB_SYMLINK" \
+                          " ENCODEAPI_LIB_SYMLINK UTILITY_LIB_SYMLINK" \
+                          " OPENCL_LIB_SYMLINK VDPAU_SYMLINK" \
+                          " GBM_BACKEND_LIB_SYMLINK", b, " ")
+                for (i = 1; i <= n; i++) islink[b[i]] = 1
             }
-            if (bad || ($3 in islink && target == "-") ||
-                ($3 == "GBM_BACKEND_LIB_SYMLINK" && target ~ /\//)) {
-                print "E", $0
-                next
-            }
-            kind = ($3 in isfile) ? "F" : ($3 == "GBM_BACKEND_LIB_SYMLINK" ? "G" : "L")
-            print kind, $1, subdir, target
-        }' .manifest | \
-    while read -r kind name subdir target; do
-        [ "$subdir" = "-" ] && subdir=""
-        case "$kind" in
-        E)
-            echo "ERROR: unparseable .manifest row: $name $subdir $target" >&2
-            exit 1
-            ;;
-        F)
-            if [ ! -f "$name" ]; then
-                echo "ERROR: .manifest lists $name but it is not in the payload" >&2
+            NF >= 4 && $2 ~ /^[0-9]+$/ && $4 == arch && ($3 in isfile || $3 in islink) {
+                if ($3 == "GBM_BACKEND_LIB_SYMLINK" && arch != "NATIVE") next
+                subdir = "-"; target = "-"; bad = 0
+                for (i = 5; i <= NF; i++) {
+                    if ($i ~ /^MODULE:/ || $i == "/") continue
+                    else if ($i ~ /\/$/) subdir = $i
+                    else if (target == "-") target = $i
+                    else bad = 1
+                }
+                if (bad || ($3 in islink && target == "-") ||
+                    ($3 == "GBM_BACKEND_LIB_SYMLINK" && target ~ /\//)) {
+                    print "E", $0
+                    next
+                }
+                kind = ($3 in isfile) ? "F" : ($3 == "GBM_BACKEND_LIB_SYMLINK" ? "G" : "L")
+                print kind, $1, subdir, target
+            }' .manifest | \
+        while read -r kind name subdir target; do
+            [ "$subdir" = "-" ] && subdir=""
+            # COMPAT32 file rows name the payload path under ./32/; the
+            # installed name is the basename either way.
+            base="${name#./32/}"
+            case "$kind" in
+            E)
+                echo "ERROR: unparseable .manifest row: $name $subdir $target" >&2
                 exit 1
-            fi
-            install -Dm755 "$name" "$LIBDIR/${subdir}${name}"
-            ;;
-        L)
-            [ -z "$subdir" ] || [ -d "$LIBDIR/$subdir" ] || install -d "$LIBDIR/$subdir"
-            ln -sf "$target" "$LIBDIR/${subdir}${name}"
-            ;;
-        G)
-            # FDSDK exposes GL/lib/gbm as a symlink to the Mesa extension's
-            # GL/default/lib/gbm. Install into that target: creating a real
-            # GL/lib/gbm here shadows Mesa's dri_gbm.so on hybrid systems.
-            GBM_DIR="$LIBDIR/GL/default/lib/gbm"
-            install -d "$GBM_DIR"
-            ln -srf "$LIBDIR/$target" "$GBM_DIR/$name"
-            ;;
-        esac
-    done
+                ;;
+            F)
+                if [ ! -f "$name" ]; then
+                    echo "ERROR: .manifest lists $name but it is not in the payload" >&2
+                    exit 1
+                fi
+                install -Dm755 "$name" "$destdir/${subdir}${base}"
+                ;;
+            L)
+                [ -z "$subdir" ] || [ -d "$destdir/$subdir" ] || install -d "$destdir/$subdir"
+                ln -sf "$target" "$destdir/${subdir}${base}"
+                ;;
+            G)
+                # FDSDK exposes GL/lib/gbm as a symlink to the Mesa extension's
+                # GL/default/lib/gbm. Install into that target: creating a real
+                # GL/lib/gbm here shadows Mesa's dri_gbm.so on hybrid systems.
+                GBM_DIR="$destdir/GL/default/lib/gbm"
+                install -d "$GBM_DIR"
+                ln -srf "$destdir/$target" "$GBM_DIR/$base"
+                ;;
+            esac
+        done
+    }
+    install_manifest_arch NATIVE "$LIBDIR"
+    install_manifest_arch COMPAT32 "$LIBDIR32"
 
     # Userspace tools. nvidia-modprobe stays 0755 (not NVIDIA's 4755):
     # nvidia-device-nodes.service invokes it as root, so no unprivileged
@@ -213,6 +230,10 @@ config:
             "%{install-root}/usr/share/pixmaps/nvidia-settings.png"
     fi
 
+    # library_path is a bare soname, so this one JSON serves the 64-bit
+    # and 32-bit Vulkan loaders alike; each resolves its own ELF class
+    # through ld.so (the i386 dirs are on the ld path via
+    # gaming/steam-native.bst's /etc/ld.so.conf.d/00-i386-linux-gnu.conf).
     if [ -f nvidia_icd.json ]; then
         install -Dm644 nvidia_icd.json \
             "%{install-root}/usr/share/vulkan/icd.d/nvidia_icd.json"
@@ -394,23 +415,31 @@ config:
     PRESET
   # Fail the build if any installed NVIDIA ELF has an NVIDIA-internal
   # DT_NEEDED that the manifest TYPE selection above did not install
-  # (e.g. a newly split-out library like libnvidia-gpucomp).
+  # (e.g. a newly split-out library like libnvidia-gpucomp). Each arch
+  # is checked against its own libdir; a 32-bit object must find its
+  # deps in the i386 tree, never the native one.
   - |
     set -euo pipefail
     LIBDIR="%{install-root}%{libdir}"
+    LIBDIR32="%{install-root}/usr/lib/i386-linux-gnu"
     BINDIR="%{install-root}%{bindir}"
     status=0
-    for obj in "$LIBDIR"/lib*.so.* "$LIBDIR"/vdpau/lib*.so.* "$BINDIR"/*; do
-        { [ -f "$obj" ] && [ ! -L "$obj" ]; } || continue
-        for dep in $(objdump -p "$obj" 2>/dev/null | awk '/NEEDED/{print $2}' || true); do
-            case "$dep" in
-              libnvidia-*|libcuda.so*|libnvcuvid.so*|libnvoptix.so*)
-                if [ ! -e "$LIBDIR/$dep" ]; then
-                    echo "ERROR: $(basename "$obj") requires $dep, which is not installed" >&2
-                    status=1
-                fi
-                ;;
-            esac
+    check_closure() {
+        depdir="$1"; shift
+        for obj in "$@"; do
+            { [ -f "$obj" ] && [ ! -L "$obj" ]; } || continue
+            for dep in $(objdump -p "$obj" 2>/dev/null | awk '/NEEDED/{print $2}' || true); do
+                case "$dep" in
+                  libnvidia-*|libcuda.so*|libnvcuvid.so*|libnvoptix.so*)
+                    if [ ! -e "$depdir/$dep" ]; then
+                        echo "ERROR: $(basename "$obj") requires $dep, which is not installed in $depdir" >&2
+                        status=1
+                    fi
+                    ;;
+                esac
+            done
         done
-    done
+    }
+    check_closure "$LIBDIR" "$LIBDIR"/lib*.so.* "$LIBDIR"/vdpau/lib*.so.* "$BINDIR"/*
+    check_closure "$LIBDIR32" "$LIBDIR32"/lib*.so.* "$LIBDIR32"/vdpau/lib*.so.*
     exit "$status"

--- a/elements/gaming/steam-libs-i686-compat.bst
+++ b/elements/gaming/steam-libs-i686-compat.bst
@@ -16,9 +16,17 @@ config:
     mkdir -p "%{install-root}/usr/lib/i386-linux-gnu"
     ln -sfn libbz2.so.1 "%{install-root}/usr/lib/i386-linux-gnu/libbz2.so.1.0"
 
+    # Vulkan manifest discovery link. The i686 vulkan-icd-loader searches
+    # %{libdir}/GL/vulkan/icd.d via EXTRASYSCONFDIR; on x86_64 the mesa
+    # extension glue provides GL/vulkan, but nothing creates it for the
+    # i386 tree, so 32-bit ICDs would go undiscovered without this.
+    mkdir -p "%{install-root}/usr/lib/i386-linux-gnu/GL"
+    ln -sfn default/vulkan "%{install-root}/usr/lib/i386-linux-gnu/GL/vulkan"
+
 public:
   bst:
     split-rules:
       runtime:
         (>):
         - /usr/lib/i386-linux-gnu/libbz2.so.1.0
+        - /usr/lib/i386-linux-gnu/GL/vulkan

--- a/elements/gaming/steam-libs-i686-compose.bst
+++ b/elements/gaming/steam-libs-i686-compose.bst
@@ -50,6 +50,12 @@ build-depends:
 - freedesktop-sdk.bst:cross-compilers/freedesktop-sdk-i686.bst:components/libva.bst
 - freedesktop-sdk.bst:cross-compilers/freedesktop-sdk-i686.bst:components/libvdpau.bst
 - freedesktop-sdk.bst:cross-compilers/freedesktop-sdk-i686.bst:extensions/mesa/mesa.bst
+# 32-bit Vulkan loader so 32-bit Vulkan clients (and Mesa's zink GL driver)
+# can reach the 32-bit ICDs: Mesa's radv/anv below, NVIDIA's from
+# bluefin-nvidia/nvidia-drivers.bst COMPAT32 rows. The loader's
+# EXTRASYSCONFDIR is libdir-scoped, so the i686 build searches
+# /usr/lib/i386-linux-gnu/GL/vulkan/icd.d on its own.
+- freedesktop-sdk.bst:cross-compilers/freedesktop-sdk-i686.bst:components/vulkan-icd-loader.bst
 - freedesktop-sdk.bst:cross-compilers/freedesktop-sdk-i686.bst:components/xorg-lib-ice.bst
 - freedesktop-sdk.bst:cross-compilers/freedesktop-sdk-i686.bst:components/xorg-lib-sm.bst
 - gaming/steam-libs-i686-compat.bst
@@ -88,7 +94,10 @@ public:
       - "/usr/lib/i386-linux-gnu/*.so*"
       - "/usr/lib/i386-linux-gnu/pulseaudio/*.so*"
 
-      # Mesa GL provider and the minimal software/virtio DRI stack needed for GLX.
+      # Mesa GL provider and the complete DRI driver stack. The hardware
+      # drivers (radeonsi, iris, nouveau, ...) must ship too: exporting only
+      # the software/virtio subset left 32-bit GL games (e.g. Half-Life) on
+      # llvmpipe when running on metal, while VMs looked fine via virtio_gpu.
       - "/usr/lib/i386-linux-gnu/GL/default/lib/libGLX_mesa.so*"
       - "/usr/lib/i386-linux-gnu/GL/default/lib/libEGL_mesa.so*"
       - "/usr/lib/i386-linux-gnu/GL/default/lib/libEGL_indirect.so*"
@@ -97,12 +106,20 @@ public:
       - "/usr/lib/i386-linux-gnu/GL/default/lib/libgbm.so*"
       - "/usr/lib/i386-linux-gnu/GL/default/lib/libLLVM.so*"
       - "/usr/lib/i386-linux-gnu/GL/default/lib/libdrm*.so*"
-      - "/usr/lib/i386-linux-gnu/GL/default/lib/dri/libdril_dri.so"
-      - "/usr/lib/i386-linux-gnu/GL/default/lib/dri/virtio_gpu_dri.so"
-      - "/usr/lib/i386-linux-gnu/GL/default/lib/dri/kms_swrast_dri.so"
-      - "/usr/lib/i386-linux-gnu/GL/default/lib/dri/swrast_dri.so"
-      - "/usr/lib/i386-linux-gnu/GL/default/lib/dri/zink_dri.so"
+      - "/usr/lib/i386-linux-gnu/GL/default/lib/dri/*.so"
       - "/usr/lib/i386-linux-gnu/GL/default/share/glvnd/**"
+
+      # 32-bit Vulkan: Mesa ICDs (radv/anv/lvp) and their manifests. The ICD
+      # JSONs live under GL/default/lib/vulkan/icd.d; GL/default/vulkan holds
+      # the fdsdk-layout symlinks into lib/ and share/. GL/vulkan itself is
+      # created by gaming/steam-libs-i686-compat.bst — the i686 loader's
+      # EXTRASYSCONFDIR expects %{libdir}/GL/vulkan/icd.d, and unlike x86_64
+      # no extension glue provides that link for the i386 tree.
+      - "/usr/lib/i386-linux-gnu/GL/default/lib/libvulkan_*.so*"
+      - "/usr/lib/i386-linux-gnu/GL/default/lib/vulkan/**"
+      - "/usr/lib/i386-linux-gnu/GL/default/vulkan/**"
+      - "/usr/lib/i386-linux-gnu/GL/default/share/vulkan/**"
+      - "/usr/lib/i386-linux-gnu/GL/vulkan"
 
       # GLVND/GLX/EGL runtime
       - "/usr/lib/i386-linux-gnu/libEGL.so*"

--- a/elements/gaming/steam-native.bst
+++ b/elements/gaming/steam-native.bst
@@ -107,7 +107,7 @@ config:
     # This keeps libraries such as libxcb.so.1 and libxcb-shm.so.0 ABI-compatible.
     export LD_LIBRARY_PATH="/usr/lib/i386-linux-gnu/GL/default/lib:/usr/lib/i386-linux-gnu${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
-    exec "$LAUNCHSTEAMDIR/$STEAMBOOTSTRAP" ${log_opened+-srt-logger-opened} -cef-disable-gpu "$@"
+    exec "$LAUNCHSTEAMDIR/$STEAMBOOTSTRAP" ${log_opened+-srt-logger-opened} "$@"
     '''
     if old not in text:
         raise SystemExit('failed to locate Steam bootstrap exec block')


### PR DESCRIPTION
## Summary

Native Steam on the gaming images had two performance problems: the client UI was sluggish on every variant, and 32-bit GL games ran on llvmpipe on metal.

1. **Stop passing `-cef-disable-gpu` to the Steam bootstrap** in `gaming/steam-native.bst`. The flag forced steamwebhelper, which renders the entire Steam UI, into software rendering on all variants. CEF falls back to software on its own if GPU init fails, so the hard flag was only costing us.

2. **Install the .run's COMPAT32 rows** in `bluefin-nvidia/nvidia-drivers.bst`. The manifest selection is now parameterized by ARCH and runs twice, NATIVE to `%{libdir}` as before and COMPAT32 into `/usr/lib/i386-linux-gnu`, delivering 32-bit `libGLX_nvidia`, EGL, vdpau, cuda and nvml. The DT_NEEDED closure check now validates each arch against its own libdir. The 32-bit GBM backend symlink is intentionally skipped since no 32-bit compositor exists to load it.

3. **Export the complete 32-bit DRI driver set** in `gaming/steam-libs-i686-compose.bst` instead of the software/virtio subset. The old list left 32-bit GL on llvmpipe for AMD and Intel metal too, masked in VMs by virtio_gpu. Also adds the i686 vulkan-icd-loader and Mesa's 32-bit Vulkan drivers with their ICD manifests.

4. **Create the `GL/vulkan` discovery link** in `gaming/steam-libs-i686-compat.bst`. The i686 loader searches `%{libdir}/GL/vulkan/icd.d` via EXTRASYSCONFDIR, on x86_64 the mesa extension glue provides that link but nothing creates it for the i386 tree.

**Verified:** built the gaming nvidia image end to end and booted it on metal (RTX 3070, driver 610.57.04). The 32-bit `ubuntu12_32/steam` binary holds an NVIDIA GL context, steamwebhelper runs GPU-accelerated with no disable-gpu flag, 32-bit `libGLX_nvidia` resolves all dependencies from the i386 tree, and the Vulkan ICD chain resolves end to end. My validation script passes 69/0 including new checks for these surfaces. Still needs verification: a 32-bit GL title end to end (Half-Life class) and 32-bit hardware GL on AMD/Intel metal.

Fixes: #1275 