### PR TITLE
fix(gaming): pin Steam .deb to versioned pool URL; CDN swaps content

### DIFF
--- a/elements/gaming/steam-native.bst
+++ b/elements/gaming/steam-native.bst
@@ -7,11 +7,16 @@
 # self-updates into the user's home directory on first launch.
 kind: manual
 
+# The CDN's client/installer/steam.deb is an unversioned URL: Valve's
+# 1.0.0.87 release changed its content under our pinned sha256 and broke
+# every fetch (testing CI, 2026-08-03). The apt pool serves the identical
+# payload at a versioned path that never changes once published, so pin
+# that instead; bumps are an explicit url+ref+filename change here.
 sources:
 - kind: remote
-  url: steam-static:client/installer/steam.deb
-  ref: b44634a6a604ca7c8b23809d0f2a921a0348bb2081c8cb8944116d0799872b70
-  filename: steam-1.0.0.85.deb
+  url: steam-repo:steam/pool/steam/s/steam/steam-launcher_1.0.0.87_amd64.deb
+  ref: 765aba9a0ed339a50226ceb614fcc9879a991ba184098bc8de920efb12c714a4
+  filename: steam-launcher_1.0.0.87_amd64.deb
 
 build-depends:
 - freedesktop-sdk.bst:bootstrap/bash.bst
@@ -59,7 +64,7 @@ config:
   - |
     mkdir -p deb data "%{install-root}"
     cd deb
-    ar x ../steam-1.0.0.85.deb
+    ar x ../steam-launcher_1.0.0.87_amd64.deb
     cd ..
     tar -xf deb/data.tar.xz -C data
 

--- a/include/aliases.yml
+++ b/include/aliases.yml
@@ -67,6 +67,9 @@ aliases:
   github-raw: https://raw.githubusercontent.com/
   # Valve's Steam launcher/bootstrap CDN
   steam-static: https://cdn.fastly.steamstatic.com/
+  # Valve's apt repo; pool keeps versioned launcher .debs, unlike the CDN
+  # installer path whose content churns under a pinned sha256
+  steam-repo: https://repo.steampowered.com/
   # i386 .debs for Steam 32-bit compat libs
   debian: https://deb.debian.org/debian/
 


### PR DESCRIPTION
## Summary

The gaming builds on testing fail at source fetch ([run 30866704620](https://github.com/projectbluefin/dakota/actions/runs/30866704620)). `steam-native.bst` pins Valve's CDN installer URL, which is an unversioned slot Valve republishes in place: our sha256 was taken when it served 1.0.0.85, and it now serves 1.0.0.87. Nothing noticed until #1278 changed the element, since builds had been reusing the cached source ever since.

1. **Fetch from Valve's apt pool instead.** Pool paths are versioned and never change once published, and `steam-launcher_1.0.0.87_amd64.deb` is byte-identical to today's CDN file. Future bumps become an explicit url+ref+filename change. Adds a `steam-repo` alias.

2. **Move the pin to 1.0.0.87.** The payload structure and the `bin_steam.sh` exec block our patch anchors on are unchanged, so nothing else needed to move.

**Verified:** clean fetch from the new URL, sha256 matches, the patch applies, and the artifact carries the LD_LIBRARY_PATH seeding with no `-cef-disable-gpu`.

Related: #1278