### PR TITLE
fix(common): flatten Bluefin face icons into /usr/share/pixmaps/faces

### DIFF
--- a/docs/skills/oci-layers.md
+++ b/docs/skills/oci-layers.md
@@ -181,3 +181,22 @@ The OCI assembly script in `elements/oci/bluefin.bst` must run steps in this exa
 4. `build-oci` (assemble image)
 
 Running `ldconfig` after `build-oci` has no effect. Running `build-oci` before `dconf update` produces an image with stale/missing dconf databases.
+
+### Bluefin content shipped in a subdirectory GNOME reads non-recursively (2026-08-07)
+
+`projectbluefin/common` ships the Bluefin user-avatar art under
+`system_files/bluefin/usr/share/pixmaps/faces/bluefin/`, which
+`elements/bluefin/common.bst` copies verbatim into the image. GNOME's account
+avatar chooser scans `/usr/share/pixmaps/faces` non-recursively, so the files
+were present in the image but never visible to users (dakota#353).
+
+`ublue-os/bluefin` handles this in `build_files/base/05-override-install.sh` by
+flattening `faces/bluefin/*` over `faces/` at build time. The BST equivalent is
+a flatten step in the `install-commands` of `elements/bluefin/common.bst`, plus
+an `overlap-whitelist` entry for `/usr/share/pixmaps/faces/*` because the
+flattened filenames collide with the GNOME OS defaults from
+`core/gnome-control-center.bst`.
+
+General rule: when `common` places files in a vendor subdirectory, check whether
+the consuming component actually scans subdirectories before assuming the copy
+is sufficient.

--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -25,6 +25,9 @@ public:
     - /etc/environment
     - /etc/containers/policy.json
     - /usr/share/pixmaps/gnome-boot-logo.png
+    # Bluefin user-avatar art replaces the GNOME OS defaults shipped by
+    # core/gnome-control-center.bst (same 15 filenames).
+    - /usr/share/pixmaps/faces/*
 
 variables:
   strip-binaries: ""
@@ -64,6 +67,15 @@ config:
     cp "%{install-root}%{datadir}/pixmaps/fedora-logo-icon.png" "%{install-root}%{datadir}/pixmaps/img-logo-icon-dark.png"
     # Override GNOME OS boot logo with Bluefin branding
     cp "%{install-root}%{datadir}/pixmaps/fedora-gdm-logo.png" "%{install-root}%{datadir}/pixmaps/gnome-boot-logo.png"
+    # User-avatar art: common ships Bluefin faces under faces/bluefin/, but
+    # gnome-control-center only reads %{datadir}/pixmaps/faces (non-recursive),
+    # so the images never appear in the account-avatar chooser. Flatten them
+    # over the GNOME OS defaults, matching ublue-os/bluefin's
+    # build_files/base/05-override-install.sh.
+    if [ -d "%{install-root}%{datadir}/pixmaps/faces/bluefin" ]; then
+      mv "%{install-root}%{datadir}/pixmaps/faces/bluefin/"* "%{install-root}%{datadir}/pixmaps/faces/"
+      rmdir "%{install-root}%{datadir}/pixmaps/faces/bluefin"
+    fi
     install -Dm755 bluefin-wallpaper-month-sync "%{install-root}%{prefix}/libexec/bluefin-wallpaper-month-sync"
     install -Dm644 bluefin-wallpaper-month.service "%{install-root}%{prefix}/lib/systemd/system/bluefin-wallpaper-month.service"
     mkdir -p "%{install-root}%{prefix}/lib/systemd/system/multi-user.target.wants"


### PR DESCRIPTION
Closes #353

## Problem

`projectbluefin/common` ships the Bluefin user-avatar art under
`system_files/bluefin/usr/share/pixmaps/faces/bluefin/` (15 JPEGs, including the
dinosaur images). `elements/bluefin/common.bst` copies `system_files/bluefin/usr/`
verbatim, so those files land at `/usr/share/pixmaps/faces/bluefin/` in the image
— confirmed by `files/fakecap-manifest.tsv:657723-657737`, which maps all 15 to
`bluefin/common.bst`.

GNOME's account-avatar chooser reads `/usr/share/pixmaps/faces` only, so the
images are present on disk but never offered to users. `ublue-os/bluefin` solves
this in `build_files/base/05-override-install.sh` (lines 29-32) by flattening
`faces/bluefin/*` over `faces/` at build time; dakota has no equivalent step.

## Change

- `elements/bluefin/common.bst` `install-commands`: move
  `%{datadir}/pixmaps/faces/bluefin/*` into `%{datadir}/pixmaps/faces/` and
  remove the now-empty subdirectory, guarded by a `-d` test.
- Same element `overlap-whitelist`: add `/usr/share/pixmaps/faces/*`. The
  flattened filenames are identical to the GNOME OS defaults from
  `core/gnome-control-center.bst` (`files/fakecap-manifest.tsv:657738-657752`),
  so the overlap is intentional and must be declared.
- `docs/skills/oci-layers.md`: record the vendor-subdirectory pattern.

## Validation

Not run — this environment has no container runtime (`podman`/`docker` absent),
so `just bst`, `just validate`, `just build`, `just lint`, and `just boot-test`
all cannot execute here. The change is unverified by build; please treat CI
`validate` + `e2e` as the gate.

What to check after a build:
```bash
just bst artifact list-contents oci/layers/bluefin.bst | grep pixmaps/faces
# expect 15 entries directly under usr/share/pixmaps/faces, no faces/bluefin/
```

Note on generated files: `files/filemap.json` and `files/fakecap-manifest.tsv`
still list the old `faces/bluefin/*` paths. Regenerating them requires
`bst artifact list-contents` against a populated local cache
(`docs/skills/ci.md`, "Generated Files"), which is not possible here. They are
refreshed by the monthly `update-filemap.yml` workflow; a maintainer can run
`workflow_dispatch` with `force_regenerate` after merge if an immediate refresh
is wanted. Stale entries are non-fatal — `fakecap-restore` skips paths that do
not exist (`files/fakecap/fakecap-restore.c:67-73`); the effect is only that the
15 avatars are unlabelled for chunkah layer assignment until regeneration.

- [x] I am using an agent and I take responsibility for this PR