### PR TITLE
fix(audio): unfold pcsp install command; YAML folding emptied artifact

### DIFF
--- a/elements/bluefin/wireplumber-pcsp.bst
+++ b/elements/bluefin/wireplumber-pcsp.bst
@@ -17,5 +17,6 @@ variables:
 
 config:
   install-commands:
-  - install -Dm644 51-disable-pcsp.conf \
+  - |
+    install -Dm644 51-disable-pcsp.conf \
       "%{install-root}%{datadir}/wireplumber/wireplumber.conf.d/51-disable-pcsp.conf"


### PR DESCRIPTION
## Summary

The #1248 fix merged in #1257 never reached `:testing`: YAML folding collapsed the install command's line continuation into a backslash-space, so `install` wrote into a junk path, exited 0, and BuildStream cached an empty artifact. Converting the command to a literal block fixes it.

**Verified:** cached artifact `6380347d` is empty; rebuilt locally with this change and the config file lands at the correct path. Image assembly still needs confirming on the next daily testing build.

Fixes: #1248
Related: #1257
