### PR TITLE
fix(elements): stop using /dev/stdin for inline file writes

### DIFF
--- a/docs/skills/add-package.md
+++ b/docs/skills/add-package.md
@@ -80,7 +80,8 @@ install-commands:
         upstream.service > upstream.service.patched
     install -Dm644 -t "%{install-root}%{indep-libdir}/systemd/system" upstream.service.patched
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/systemd/system-preset/80-name.preset" <<'PRESET'
+    install -Dm644 /dev/null "%{install-root}%{indep-libdir}/systemd/system-preset/80-name.preset"
+    cat > "%{install-root}%{indep-libdir}/systemd/system-preset/80-name.preset" <<'PRESET'
     enable service-name.service
     PRESET
 ```

--- a/docs/skills/packaging-gnome-extensions.md
+++ b/docs/skills/packaging-gnome-extensions.md
@@ -131,8 +131,8 @@ To set default extension preferences, install a dconf keyfile:
 install-commands:
   # ... install extension ...
   - |
-    install -Dm644 /dev/stdin \
-      "%{install-root}%{datadir}/glib-2.0/schemas/10-<name>.gschema.override" <<'OVERRIDE'
+    install -Dm644 /dev/null "%{install-root}%{datadir}/glib-2.0/schemas/10-<name>.gschema.override"
+    cat > "%{install-root}%{datadir}/glib-2.0/schemas/10-<name>.gschema.override" <<'OVERRIDE'
     [org.gnome.shell]
     enabled-extensions=['<uuid>@example.com']
     OVERRIDE

--- a/docs/skills/packaging-go.md
+++ b/docs/skills/packaging-go.md
@@ -121,7 +121,8 @@ install-commands:
 install-commands:
   # ... install binary ...
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/systemd/system/project.service" <<'SERVICE'
+    install -Dm644 /dev/null "%{install-root}%{indep-libdir}/systemd/system/project.service"
+    cat > "%{install-root}%{indep-libdir}/systemd/system/project.service" <<'SERVICE'
     [Unit]
     Description=Project daemon
     After=network.target
@@ -134,7 +135,8 @@ install-commands:
     WantedBy=multi-user.target
     SERVICE
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/systemd/system-preset/80-project.preset" <<'PRESET'
+    install -Dm644 /dev/null "%{install-root}%{indep-libdir}/systemd/system-preset/80-project.preset"
+    cat > "%{install-root}%{indep-libdir}/systemd/system-preset/80-project.preset" <<'PRESET'
     enable project.service
     PRESET
 ```

--- a/docs/skills/packaging-rust.md
+++ b/docs/skills/packaging-rust.md
@@ -122,7 +122,8 @@ Rust elements require human review when bumping refs because `cargo2` regenerati
 install-commands:
   # ... install binary ...
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/systemd/system/project.service" <<'SERVICE'
+    install -Dm644 /dev/null "%{install-root}%{indep-libdir}/systemd/system/project.service"
+    cat > "%{install-root}%{indep-libdir}/systemd/system/project.service" <<'SERVICE'
     [Unit]
     Description=Project
     After=network.target
@@ -135,7 +136,8 @@ install-commands:
     WantedBy=multi-user.target
     SERVICE
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/systemd/system-preset/80-project.preset" <<'PRESET'
+    install -Dm644 /dev/null "%{install-root}%{indep-libdir}/systemd/system-preset/80-project.preset"
+    cat > "%{install-root}%{indep-libdir}/systemd/system-preset/80-project.preset" <<'PRESET'
     enable project.service
     PRESET
 ```

--- a/elements/bluefin-nvidia/nvidia-device-nodes.bst
+++ b/elements/bluefin-nvidia/nvidia-device-nodes.bst
@@ -24,6 +24,7 @@ config:
     install -Dm644 nvidia-device-nodes.service \
         "%{install-root}%{indep-libdir}/systemd/system/nvidia-device-nodes.service"
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/systemd/system-preset/80-nvidia-device-nodes.preset" <<'PRESET'
+    install -Dm644 /dev/null "%{install-root}%{indep-libdir}/systemd/system-preset/80-nvidia-device-nodes.preset"
+    cat > "%{install-root}%{indep-libdir}/systemd/system-preset/80-nvidia-device-nodes.preset" <<'PRESET'
     enable nvidia-device-nodes.service
     PRESET

--- a/elements/bluefin-nvidia/nvidia-drivers.bst
+++ b/elements/bluefin-nvidia/nvidia-drivers.bst
@@ -407,7 +407,8 @@ config:
             "%{install-root}/usr/share/doc/nvidia/LICENSE"
     fi
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/systemd/system-preset/80-nvidia-pm.preset" <<'PRESET'
+    install -Dm644 /dev/null "%{install-root}%{indep-libdir}/systemd/system-preset/80-nvidia-pm.preset"
+    cat > "%{install-root}%{indep-libdir}/systemd/system-preset/80-nvidia-pm.preset" <<'PRESET'
     enable nvidia-suspend.service
     enable nvidia-resume.service
     enable nvidia-hibernate.service

--- a/elements/bluefin/fprintd-system-auth.bst
+++ b/elements/bluefin/fprintd-system-auth.bst
@@ -69,7 +69,8 @@ variables:
 config:
   install-commands:
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{sysconfdir}/pam.d/system-auth" <<'EOF'
+    install -Dm644 /dev/null "%{install-root}%{sysconfdir}/pam.d/system-auth"
+    cat > "%{install-root}%{sysconfdir}/pam.d/system-auth" <<'EOF'
     auth        required      pam_env.so
     auth        sufficient    pam_fprintd.so
     -auth       sufficient    pam_systemd_home.so

--- a/elements/bluefin/migrate-var-home-passwd.bst
+++ b/elements/bluefin/migrate-var-home-passwd.bst
@@ -28,6 +28,7 @@ config:
     install -Dm644 bluefin-migrate-var-home-passwd.service \
             "%{install-root}%{indep-libdir}/systemd/system/bluefin-migrate-var-home-passwd.service"
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/systemd/system-preset/80-bluefin-migrate-var-home-passwd.preset" <<'PRESET'
+    install -Dm644 /dev/null "%{install-root}%{indep-libdir}/systemd/system-preset/80-bluefin-migrate-var-home-passwd.preset"
+    cat > "%{install-root}%{indep-libdir}/systemd/system-preset/80-bluefin-migrate-var-home-passwd.preset" <<'PRESET'
     enable bluefin-migrate-var-home-passwd.service
     PRESET

--- a/elements/core/ntsync-modules-load.bst
+++ b/elements/core/ntsync-modules-load.bst
@@ -11,6 +11,7 @@ variables:
 config:
   install-commands:
   - |
-    install -Dm644 /dev/stdin "%{install-root}%{indep-libdir}/modules-load.d/ntsync.conf" <<'EOF'
+    install -Dm644 /dev/null "%{install-root}%{indep-libdir}/modules-load.d/ntsync.conf"
+    cat > "%{install-root}%{indep-libdir}/modules-load.d/ntsync.conf" <<'EOF'
     ntsync
     EOF

--- a/elements/gaming/inputplumber.bst
+++ b/elements/gaming/inputplumber.bst
@@ -33,7 +33,8 @@ config:
   # udev autostart rules, but enabling the service makes handheld support work
   # even when devices enumerate before udev catches up.
   - |
-    install -Dm644 /dev/stdin "%{install-root}/usr/lib/systemd/system-preset/92-gaming-inputplumber.preset" <<'EOF'
+    install -Dm644 /dev/null "%{install-root}/usr/lib/systemd/system-preset/92-gaming-inputplumber.preset"
+    cat > "%{install-root}/usr/lib/systemd/system-preset/92-gaming-inputplumber.preset" <<'EOF'
     enable inputplumber.service
     enable inputplumber-suspend.service
     EOF

--- a/elements/gaming/steam-flatpak-compat.bst
+++ b/elements/gaming/steam-flatpak-compat.bst
@@ -23,7 +23,8 @@ variables:
 config:
   install-commands:
   - |
-    install -Dm755 /dev/stdin "%{install-root}/usr/bin/steam" <<'EOF'
+    install -Dm755 /dev/null "%{install-root}/usr/bin/steam"
+    cat > "%{install-root}/usr/bin/steam" <<'EOF'
     #!/usr/bin/env sh
     exec /usr/bin/flatpak run com.valvesoftware.Steam "$@"
     EOF

--- a/elements/gaming/steam-native.bst
+++ b/elements/gaming/steam-native.bst
@@ -82,7 +82,8 @@ config:
     # steamdeps command so Valve's launcher does not emit python-apt/dpkg noise
     # before continuing.
     rm -rf "%{install-root}/etc/apt"
-    install -Dm755 /dev/stdin "%{install-root}/usr/lib/steam/bin_steamdeps.py" <<'EOF'
+    install -Dm755 /dev/null "%{install-root}/usr/lib/steam/bin_steamdeps.py"
+    cat > "%{install-root}/usr/lib/steam/bin_steamdeps.py" <<'EOF'
     #!/usr/bin/env sh
     exit 0
     EOF
@@ -92,7 +93,8 @@ config:
     # bundled scout runtime can load an older libxcb.so.1 before our matching
     # host libxcb-shm.so.0, causing undefined symbols such as
     # xcb_send_request_with_fds.
-    install -Dm644 /dev/stdin "%{install-root}/etc/ld.so.conf.d/00-i386-linux-gnu.conf" <<'EOF'
+    install -Dm644 /dev/null "%{install-root}/etc/ld.so.conf.d/00-i386-linux-gnu.conf"
+    cat > "%{install-root}/etc/ld.so.conf.d/00-i386-linux-gnu.conf" <<'EOF'
     /usr/lib/i386-linux-gnu/GL/default/lib
     /usr/lib/i386-linux-gnu
     EOF


### PR DESCRIPTION
## Problem

The distributed (BuildBarn remote execution) Dakota build fails at `bluefin/fprintd-system-auth.bst` and `bluefin/migrate-var-home-passwd.bst`:

```
install: cannot stat '/dev/stdin': No such file or directory
```

bb_runner chroots into the action input root, which has no `/dev/stdin`. Any element writing an inline config file with `install -Dm644 /dev/stdin ... <<'EOF'` fails.

## Fix

`docs/skills/buildstream.md` **already documents** the correct two-step pattern — it had just never been applied. Applied it to all 9 element sites and the 4 packaging docs still teaching the broken form:

```sh
install -Dm644 /dev/null "target"
cat > "target" <<'EOF'
```

`install -D` still creates parent directories and sets the mode, so local-build behaviour is unchanged.

## Verification
- 0 residual `/dev/stdin` uses in `elements/`
- all `.bst` files still parse as YAML
- surfaced by a live distributed build on the lab (projectbluefin/lab#605 unblocked the pipeline)