### PR TITLE
fix: restore Bluefin dinosaur avatars in GNOME user-account picker

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -23,6 +23,7 @@ depends:
   - bluefin/umotd.bst
 
   - bluefin/common.bst
+  - bluefin/user-avatars.bst
   - bluefin/just-overrides.bst
   - bluefin/zswap-config.bst
   - bluefin/swapfile.bst

--- a/elements/bluefin/user-avatars.bst
+++ b/elements/bluefin/user-avatars.bst
@@ -1,0 +1,21 @@
+kind: manual
+
+# Points GNOME's avatar chooser (gnome-control-center) and gnome-initial-setup's
+# account page at bluefin-common's dinosaur avatar directory. See the keyfile
+# for the full explanation. Fixes: projectbluefin/dakota#353
+sources:
+- kind: local
+  path: files/user-avatars
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    install -Dm644 07-dakota-avatar-directories \
+      "%{install-root}%{sysconfdir}/dconf/db/distro.d/07-dakota-avatar-directories"
+  - "%{install-extra}"

--- a/files/user-avatars/07-dakota-avatar-directories
+++ b/files/user-avatars/07-dakota-avatar-directories
@@ -1,0 +1,17 @@
+# Restore the Bluefin dinosaur avatar icons in the GNOME "Users" account-picture
+# picker (fixes: projectbluefin/dakota#353).
+#
+# bluefin-common ships Bluefin's custom (dinosaur-themed) avatars under a
+# `bluefin/` category subdirectory: system_files/bluefin/usr/share/pixmaps/faces/bluefin/*.jpg
+# (installed here as /usr/share/pixmaps/faces/bluefin/*.jpg by bluefin/common.bst).
+#
+# gnome-control-center's avatar chooser (panels/system/users/cc-avatar-chooser.c)
+# and gnome-initial-setup's account page only enumerate files directly inside
+# <datadir>/pixmaps/faces/ — they never recurse into subdirectories. Without an
+# explicit avatar-directories setting, both silently fall back to Fedora/GNOME's
+# stock (near-empty) pixmaps/faces dir and Bluefin's avatars never appear.
+#
+# Setting org.gnome.desktop.interface avatar-directories tells both UIs to scan
+# our bluefin/ subdirectory explicitly.
+[org/gnome/desktop/interface]
+avatar-directories=['/usr/share/pixmaps/faces/bluefin']


### PR DESCRIPTION
## Summary

Closes #353 — Bluefin's custom dinosaur-themed avatars never show up in the
GNOME Users account-picture picker on Dakota.

## Root cause of why #353 is still open

The fix for this was already written, reviewed, and merged in #1241 — but
#1241 was merged directly into `main`. Per `docs/workflow.md`, `main` is a
release bookmark only, fast-forwarded from `testing` by
`execute-release.yml`, and **must not be used as a PR base**. All content
PRs are required to target `testing`, the actual development trunk that
gets built and shipped.

Because #1241 landed on `main` instead of `testing`, the fix never made it
into any built/shipped image (verified: `elements/bluefin/user-avatars.bst`
exists on `upstream/main` but not on `upstream/testing`), which is why #353
is still open despite a merged 'fix'.

## Change

This PR re-applies the exact same, already-reviewed change from #1241
(cherry-picked, 3 files, no modifications) onto `testing`:

- `elements/bluefin/user-avatars.bst` — new manual element installing a
  distro dconf override.
- `files/user-avatars/07-dakota-avatar-directories` — sets
  `org.gnome.desktop.interface avatar-directories` to
  `['/usr/share/pixmaps/faces/bluefin']`, so gnome-control-center's avatar
  chooser and gnome-initial-setup's account page (which only enumerate
  `<datadir>/pixmaps/faces/` directly, no recursion) pick up Bluefin's
  dinosaur avatars from the `bluefin/` subdirectory already shipped by
  `bluefin/common.bst`.
- `elements/bluefin/deps.bst` — wires in the new element.

## Testing

- [ ] `just validate` passes
- [ ] `just boot-test` passes (automated boot smoke test)
- [ ] `just lint` passes on a built image
- [ ] `just boot-fast` or `just boot-vm` — desktop comes up, no regressions

Not run in this environment — no BuildStream/podman available here (same
constraint noted in #1241 and in #1296). This is a byte-identical port of
previously merged, reviewed content; please treat CI `validate` + `e2e` on
`testing` as the gate, same as for any other PR.

## Note on #1296

#1296 (open, targets `main`) proposes an alternative approach (flattening
files at build time instead of the dconf `avatar-directories` override) and
has the same base-branch issue flagged by the bot. Maintainers may prefer
that approach instead — either way, whichever fix lands should target
`testing`, not `main`.

Closes #353

- [x] I am using an agent and I take responsibility for this PR

Assisted-by: Claude Sonnet 5 via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>