### PR TITLE
test: add avatar-audit to catch #353-class dinosaur-avatar regressions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -190,6 +190,11 @@ jobs:
           BUILD_IMAGE_NAME: ${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
         run: just swap-audit
 
+      - name: Audit user-avatar configuration
+        env:
+          BUILD_IMAGE_NAME: ${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}
+        run: just avatar-audit
+
       - name: Login to GHCR
         env:
           GH_ACTOR: ${{ github.actor }}

--- a/Justfile
+++ b/Justfile
@@ -1258,3 +1258,81 @@ swap-audit:
         [ "$STATUS" -eq 0 ] && echo "PASS: swap/zram configuration OK"
         exit "$STATUS"
         '
+
+# ── Avatar audit ─────────────────────────────────────────────────────
+# Assert the Bluefin dinosaur avatars are actually reachable by GNOME's
+# account-picture pickers. Guards against the #353 regression class, where
+# the art shipped fine but nothing pointed GNOME at it.
+#
+# Two independent ways this breaks silently, both checked here:
+#   1. common.bst stops ingesting /usr/share/pixmaps/faces/bluefin/*.jpg.
+#   2. The dconf override ships but never reaches the compiled distro db
+#      (element dropped from the layer, or `dconf update` did not run).
+#
+# org.gnome.desktop.interface avatar-directories REPLACES the default face
+# dirs rather than adding to them (gnome-control-center
+# panels/system/users/cc-avatar-chooser.c, gnome-initial-setup
+# pages/account/um-photo-dialog.c), so a stale or typo'd path yields an
+# empty picker with no fallback. Every listed dir is therefore checked for
+# existence and for actual .jpg content.
+[group('test')]
+avatar-audit:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # Use sudo unless already root
+    SUDO_CMD=""
+    if [ "$(id -u)" -ne 0 ]; then
+        SUDO_CMD="sudo"
+    fi
+
+    echo "==> Auditing user-avatar configuration in {{image_name}}:{{image_tag}}..."
+    $SUDO_CMD podman run --rm --pull=never \
+        "{{image_name}}:{{image_tag}}" \
+        bash -c '
+        set -uo pipefail
+        STATUS=0
+        fail() { echo "FAIL: $1" >&2; STATUS=1; }
+
+        Q=$(printf "\047")
+        KEYFILE=/etc/dconf/db/distro.d/07-dakota-avatar-directories
+        DB=/etc/dconf/db/distro
+
+        # The art itself, straight from bluefin/common.bst.
+        compgen -G "/usr/share/pixmaps/faces/bluefin/*.jpg" > /dev/null \
+            || fail "no Bluefin avatar art under /usr/share/pixmaps/faces/bluefin"
+
+        # The distro dconf profile must read the distro db at all.
+        grep -qx "system-db:distro" /etc/dconf/profile/user 2>/dev/null \
+            || fail "/etc/dconf/profile/user does not read system-db:distro"
+
+        if [ ! -f "$KEYFILE" ]; then
+            fail "$KEYFILE missing"
+        elif [ ! -f "$DB" ]; then
+            fail "compiled dconf db $DB missing -- did dconf update run?"
+        else
+            VALUE=$(sed -n "s/^avatar-directories=//p" "$KEYFILE")
+            if [ -z "$VALUE" ]; then
+                fail "avatar-directories key missing from $KEYFILE"
+            else
+                DIRS=$(printf "%s" "$VALUE" | tr -d "[]${Q} " | tr "," "\n" | grep -v "^$")
+                if [ -z "$DIRS" ]; then
+                    fail "avatar-directories is empty -- the picker would show nothing"
+                else
+                    while read -r dir; do
+                        [ -d "$dir" ] \
+                            || { fail "avatar-directories lists $dir, which is not in the image"; continue; }
+                        compgen -G "${dir}/*.jpg" > /dev/null \
+                            || fail "$dir contains no .jpg faces"
+                        # gvdb keeps strings verbatim, so the compiled db can
+                        # be grepped without a dconf/D-Bus round trip.
+                        grep -qaF "$dir" "$DB" \
+                            || fail "$dir absent from compiled $DB -- override did not reach the db"
+                    done <<< "$DIRS"
+                fi
+            fi
+        fi
+
+        [ "$STATUS" -eq 0 ] && echo "PASS: user-avatar configuration OK"
+        exit "$STATUS"
+        '

--- a/docs/skills/oci-layers.md
+++ b/docs/skills/oci-layers.md
@@ -213,3 +213,26 @@ Two load-bearing examples:
 Final NVIDIA OCI assembly must assert that `GL/lib/gbm` remains a symlink and
 that both `dri_gbm.so` and `nvidia-drm_gbm.so` resolve through it. Check the
 composed path with `ls -ld` before choosing any install location under `GL/`.
+
+### Files present in the image are not the same as files GNOME will find (2026-08-07)
+
+Landing an asset under the right path is not the same as the consuming
+component seeing it. `bluefin/common.bst` correctly installs Bluefin's
+dinosaur avatars at `/usr/share/pixmaps/faces/bluefin/*.jpg`, and they show
+up fine in `just bst artifact list-contents oci/layers/bluefin.bst`, but
+GNOME's avatar pickers (`cc-avatar-chooser.c` in gnome-control-center,
+`um-photo-dialog.c` in gnome-initial-setup) only enumerate files directly
+inside a faces dir — they never recurse into subdirectories. A vendor
+subdirectory like `bluefin/` is invisible to them by default (#353).
+
+The fix is `org.gnome.desktop.interface avatar-directories`
+(`elements/bluefin/user-avatars.bst`,
+`files/user-avatars/07-dakota-avatar-directories`), but this key **replaces**
+the default system faces dirs rather than adding to them — both pickers try
+the configured dirs first and only fall back to the built-in
+`<datadir>/pixmaps/faces` if that yields zero faces. A typo'd or missing
+path in `avatar-directories` therefore doesn't degrade to the stock icons;
+it produces an empty picker. `just avatar-audit` checks the art exists, the
+key is present, and every listed directory is both on disk and reachable in
+the compiled `/etc/dconf/db/distro` — the same class of "shipped but not
+reachable" gap that `swap-audit` guards for zram/kargs.

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -23,6 +23,7 @@ depends:
   - bluefin/umotd.bst
 
   - bluefin/common.bst
+  - bluefin/user-avatars.bst
   - bluefin/just-overrides.bst
   - bluefin/zswap-config.bst
   - bluefin/swapfile.bst

--- a/elements/bluefin/user-avatars.bst
+++ b/elements/bluefin/user-avatars.bst
@@ -1,0 +1,21 @@
+kind: manual
+
+# Points GNOME's avatar chooser (gnome-control-center) and gnome-initial-setup's
+# account page at bluefin-common's dinosaur avatar directory. See the keyfile
+# for the full explanation. Fixes: projectbluefin/dakota#353
+sources:
+- kind: local
+  path: files/user-avatars
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    install -Dm644 07-dakota-avatar-directories \
+      "%{install-root}%{sysconfdir}/dconf/db/distro.d/07-dakota-avatar-directories"
+  - "%{install-extra}"

--- a/files/user-avatars/07-dakota-avatar-directories
+++ b/files/user-avatars/07-dakota-avatar-directories
@@ -1,0 +1,17 @@
+# Restore the Bluefin dinosaur avatar icons in the GNOME "Users" account-picture
+# picker (fixes: projectbluefin/dakota#353).
+#
+# bluefin-common ships Bluefin's custom (dinosaur-themed) avatars under a
+# `bluefin/` category subdirectory: system_files/bluefin/usr/share/pixmaps/faces/bluefin/*.jpg
+# (installed here as /usr/share/pixmaps/faces/bluefin/*.jpg by bluefin/common.bst).
+#
+# gnome-control-center's avatar chooser (panels/system/users/cc-avatar-chooser.c)
+# and gnome-initial-setup's account page only enumerate files directly inside
+# <datadir>/pixmaps/faces/ — they never recurse into subdirectories. Without an
+# explicit avatar-directories setting, both silently fall back to Fedora/GNOME's
+# stock (near-empty) pixmaps/faces dir and Bluefin's avatars never appear.
+#
+# Setting org.gnome.desktop.interface avatar-directories tells both UIs to scan
+# our bluefin/ subdirectory explicitly.
+[org/gnome/desktop/interface]
+avatar-directories=['/usr/share/pixmaps/faces/bluefin']


### PR DESCRIPTION
## Summary

Closes #353 — Bluefin's dinosaur-themed avatars never appear in the GNOME
Users account-picture picker on Dakota.

## Why #353 is still open

The fix was already written and merged in #1241, but it landed on `main`
(the release bookmark, fast-forwarded from `testing` and never a valid PR
base per `docs/workflow.md`) instead of `testing`, so it never shipped in a
built image. `elements/bluefin/user-avatars.bst` exists on `upstream/main`
but not on `upstream/testing`.

This PR cherry-picks that exact, already-reviewed 3-file change
(`c5828e0`, byte-identical to #1241) onto `testing`, and adds a CI check so
this class of "shipped but unreachable" bug gets caught before merge instead
of silently regressing again.

Note: #1302 independently re-applies the same cherry-pick onto `testing`.
This PR is equivalent for that part; the addition here is the `avatar-audit`
Justfile recipe below. Maintainers should pick whichever PR they prefer for
the base fix — happy to close this in favor of #1302 if the audit recipe is
cherry-picked over there instead, or vice versa.

## What's new: `just avatar-audit`

Added a `swap-audit`-style Justfile recipe, wired into `publish.yml` right
after `swap-audit`, that inspects the *built* image rather than just the
source tree:

- Bluefin avatar art actually exists under
  `/usr/share/pixmaps/faces/bluefin/*.jpg`.
- `/etc/dconf/profile/user` reads `system-db:distro` at all.
- The `07-dakota-avatar-directories` keyfile is present.
- Every directory listed in `avatar-directories` exists in the image, has
  `.jpg` faces, and is actually present in the *compiled*
  `/etc/dconf/db/distro` (catches `dconf update` ordering regressions, not
  just keyfile-not-installed).

This matters because `org.gnome.desktop.interface avatar-directories`
**replaces** GNOME's default faces dirs rather than falling back to them
(`cc-avatar-chooser.c` in gnome-control-center, `um-photo-dialog.c` in
gnome-initial-setup both try configured dirs first and only fall back to
`<datadir>/pixmaps/faces` if that yields zero faces) — so a stale, typo'd,
or dropped override doesn't degrade to stock icons, it silently empties the
picker entirely. That failure mode is invisible from `just bst artifact
list-contents` alone, which is exactly what let #353 go unnoticed even
though the art was correctly ingested the whole time.

Also documented this pattern in `docs/skills/oci-layers.md` under Lessons
Learned per the repo's self-improvement mandate — "files present in the
built image" and "files GNOME will actually discover" are different claims,
and this is the second time that gap has bitten this repo (see the FDSDK
GL-merge-symlink lesson just above it).

## Testing

- `just check-publish-workflow` and `python3 -m unittest
  scripts.test_check_publish_workflow` pass.
- `just --summary` / `just --dry-run avatar-audit` confirm the Justfile
  parses and the recipe body is well-formed.
- The audit script's inner logic was extracted and run standalone against 7
  synthetic image-root fixtures (happy path + 6 failure modes: missing
  keyfile, stale compiled db, dangling directory reference, empty target
  directory, dconf profile not reading the distro db, empty
  `avatar-directories` value) — all pass/fail as expected.
- Could not run `just validate` / `just build` / `just boot-test` / `just
  lint` in this environment (no BuildStream/podman available, same
  constraint noted in #1241, #1296, #1302); requesting CI `validate` + `e2e`
  on `testing` as the gate, and a maintainer build to confirm `avatar-audit`
  passes against the real image.

```verify
# Settings → Users → click your account picture → dinosaur avatars should
# appear in the picker (or on a fresh install, gnome-initial-setup's
# account page should offer them).
gsettings get org.gnome.desktop.interface avatar-directories
# expect: ['/usr/share/pixmaps/faces/bluefin']
ls /usr/share/pixmaps/faces/bluefin/*.jpg
```

- [x] I am using an agent and I take responsibility for this PR
