### PR TITLE
ci(e2e): expose installer suite on workflow_dispatch (fisherman post-boot assertions)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,16 @@
 #
 # Only runs on workflow_dispatch — PRs do not publish a testing build first,
 # so running smoke here would test a stale :testing image, not the PR's code.
+#
+# The `installer` suite runs the fisherman post-boot assertions (UEFI boot
+# entry via efibootmgr, installer Flatpak exclusion, LUKS rd.luks.name=
+# cmdline format) over SSH against the target image. Implemented in
+# projectbluefin/testsuite (tests/installer/features/installer_post_boot.feature);
+# tracked by projectbluefin/dakota#651 with the spec in docs/skills/e2e-ci.md
+# -> "Installer Post-Boot Assertions (fisherman)". The UEFI/LUKS scenarios
+# skip unless the target is a fisherman-installed UEFI+LUKS system, so on
+# the standard direct-kernel-boot lane only the Flatpak-exclusion assertion
+# runs; the suite is meaningful against a to-filesystem install.
 
 name: E2E Tests — GNOME 50
 
@@ -18,7 +28,7 @@ on:
         required: false
         default: "ghcr.io/projectbluefin/dakota:testing"
       suites:
-        description: "Comma-separated GUI suites: smoke,developer,dx,software,vanilla-gnome"
+        description: "Comma-separated suites: smoke,developer,dx,software,vanilla-gnome,installer (installer = SSH-only fisherman post-boot assertions)"
         required: false
         default: "smoke"
 


### PR DESCRIPTION
## Summary

[dakota#651](https://github.com/projectbluefin/dakota/issues/651) tracks e2e coverage gaps against a fisherman (`bootc-installer` Go backend) to-filesystem install. The post-boot assertions themselves are implemented and merged in `projectbluefin/testsuite` (#697, `tests/installer/features/installer_post_boot.feature`), and the dakota-side spec lives in open PR #1304 — but as noted in the issue thread, **no dakota workflow requests the `installer` suite**, so the assertions can't be run from this repo at all.

This PR closes that gap on the only safe surface: the **workflow_dispatch-only** `e2e.yml`.

- Adds `installer` to the `suites` dispatch input (the testsuite reusable workflow already registers and supports it).
- Documents the suite in the workflow header: what the three post-boot assertions are, where they're implemented (testsuite #697), the tracking issue/spec location (dakota#651, `docs/skills/e2e-ci.md`), and the skip semantics — UEFI/LUKS scenarios skip unless the target is a fisherman-installed UEFI+LUKS system, so on the standard direct-kernel-boot lane only the Flatpak-exclusion assertion runs.

**Explicitly out of scope (per the #1304 sequencing rule):** wiring `installer` into `publish-smoke.yml` or any automated pipeline. Those assertions verify upstream fisherman/common source fixes that haven't shipped yet, so they must land skip-until-fixed — a maintainer sequencing decision, not something to bundle here. This change is dispatch-only and cannot turn any automated CI red.

Refs #651 (tracking); complements #1304 (spec docs).

## Verification

- Workflow-only change: no build/lint required.
- `installer` suite verified present in `projectbluefin/testsuite`'s reusable `e2e.yml` (suites input + SSH-only runner path).
- YAML is a comment block + one quoted scalar change; parsed structure unchanged.

- [x] I am using an agent and I take responsibility for this PR
