### PR TITLE
ci(e2e): correct installer-suite gating docs and add a dispatch recipe

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,15 +8,31 @@
 # Only runs on workflow_dispatch — PRs do not publish a testing build first,
 # so running smoke here would test a stale :testing image, not the PR's code.
 #
-# The `installer` suite runs the fisherman post-boot assertions (UEFI boot
-# entry via efibootmgr, installer Flatpak exclusion, LUKS rd.luks.name=
-# cmdline format) over SSH against the target image. Implemented in
-# projectbluefin/testsuite (tests/installer/features/installer_post_boot.feature);
-# tracked by projectbluefin/dakota#651 with the spec in docs/skills/e2e-ci.md
-# -> "Installer Post-Boot Assertions (fisherman)". The UEFI/LUKS scenarios
-# skip unless the target is a fisherman-installed UEFI+LUKS system, so on
-# the standard direct-kernel-boot lane only the Flatpak-exclusion assertion
-# runs; the suite is meaningful against a to-filesystem install.
+# The `installer` suite runs the fisherman post-boot assertions over SSH
+# against the target image. Implemented in projectbluefin/testsuite
+# (tests/installer/features/installer_post_boot.feature); tracked by
+# projectbluefin/dakota#651.
+#
+# The three assertions gate themselves independently — none of them fails on a
+# target that simply lacks the feature:
+#
+#   * UEFI boot entry (efibootmgr -v)  — skips when efibootmgr exits non-zero,
+#     i.e. the target did not boot via UEFI or /sys is unreachable.
+#   * Installer Flatpak exclusion       — always runs.
+#   * LUKS cmdline (rd.luks.name= /     — runs only when the target actually has
+#     rd.luks.uuid=)                      a LUKS volume, detected at runtime by
+#                                         probing the DUT for a `crypt` device.
+#
+# So on the standard direct-kernel-boot lane only the Flatpak-exclusion
+# assertion does real work; the suite is meaningful against a to-filesystem
+# install. Run it with `just e2e-installer`.
+#
+# Caveat while this is being sequenced: the LUKS runtime probe is
+# projectbluefin/testsuite#754. Until that merges AND the `@v1` tag this
+# workflow pins moves to include it, the LUKS scenario skips unconditionally —
+# it gated on a LUKS_ENABLED env var that nothing sets, so it has never
+# executed. Treat a green `installer` run as covering the Flatpak assertion
+# (plus UEFI on a UEFI target), not the common#385 LUKS fix.
 
 name: E2E Tests — GNOME 50
 

--- a/Justfile
+++ b/Justfile
@@ -1185,6 +1185,36 @@ verify image_ref="":
     fi
     exit "${STATUS}"
 
+# ── E2E dispatch ─────────────────────────────────────────────────────
+# e2e.yml is workflow_dispatch-only — PRs do not publish a :testing build
+# first, so running smoke on a PR would test a stale image. Dispatching it was
+# a loose `gh workflow run` incantation with no recipe until now.
+#
+# Dispatch the e2e workflow against a published image.
+[group('test')]
+e2e suites="smoke" image="ghcr.io/projectbluefin/dakota:testing":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "gh CLI is required to dispatch the e2e workflow" >&2
+        exit 2
+    fi
+    echo "==> Dispatching e2e: suites={{suites}} image={{image}}"
+    gh workflow run e2e.yml \
+        --repo projectbluefin/dakota \
+        --field image="{{image}}" \
+        --field suites="{{suites}}"
+    echo "==> Watch it with: gh run list --repo projectbluefin/dakota --workflow e2e.yml --limit 5"
+
+# Only meaningful against a fisherman to-filesystem install — see the header
+# of .github/workflows/e2e.yml for which of the three assertions gate on what.
+# Usage: just e2e-installer ghcr.io/projectbluefin/dakota:testing
+#
+# Dispatch the fisherman post-boot assertions (projectbluefin/dakota#651).
+[group('test')]
+e2e-installer image="ghcr.io/projectbluefin/dakota:testing":
+    just e2e installer "{{image}}"
+
 # ── Lint ─────────────────────────────────────────────────────────────
 [group('test')]
 lint:

--- a/docs/skills/workflow-map.md
+++ b/docs/skills/workflow-map.md
@@ -87,7 +87,7 @@ Successful publish.yml on testing   ← PARALLEL, DECOUPLED
 | `.github/workflows/build-aarch64.yml` | aarch64 OCI build + GHCR push | `push: testing/main` (BST-affecting paths), `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch`. Fully decoupled — never in `needs:` of publish/promote/release. |
 | `.github/workflows/publish.yml` | export, sign, boot-check, promote tags | `workflow_run` from build |
 | `.github/workflows/publish-smoke.yml` | observational smoke only | `workflow_run` from publish |
-| `.github/workflows/e2e.yml` | PR-facing testsuite check | `pull_request` |
+| `.github/workflows/e2e.yml` | testsuite suite runner (delegates to the `projectbluefin/testsuite` reusable workflow) | `workflow_dispatch` **only** — not `pull_request`. PRs do not publish a `:testing` build first, so a PR-triggered run would test a stale image, not the PR's code. Dispatch it with `just e2e <suites> [image]`; `just e2e-installer` runs the fisherman post-boot assertions (#651). |
 | `.github/workflows/lab-check.yml` | MergeRaptor-owned `testing-lab / dakota` Check Run for the Kubernetes lab | `repository_dispatch: lab-check` |
 | `.github/workflows/execute-release.yml` | SHA freshness check → cosign verify → stable release | `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch`. Skips if `:testing` digest equals `:stable` digest. |
 | `.github/workflows/sync-next-from-main.yml` | merge main into next (preserve junction refs) | `push: main`, `workflow_dispatch` |


### PR DESCRIPTION
Refs #651. Base is `testing`, matching #1304 / #1316.

## What was actually left on #651

The three assertions themselves are implemented and merged in `projectbluefin/testsuite` (#697), and #1316 exposed the `installer` suite on this workflow's `suites` input. Checking what remained, one of the three does not work and two docs statements are wrong.

### 1. The LUKS assertion has never run — and this workflow's header says otherwise

The header claimed:

> The UEFI/LUKS scenarios skip unless the target is a fisherman-installed UEFI+LUKS system

That is true for UEFI (the step skips on a non-zero `efibootmgr` exit). It is **not** true for LUKS. That scenario gated on a `LUKS_ENABLED` environment variable, and `git grep LUKS_ENABLED` in testsuite returns two lines — both readers, in `tests/installer/features/environment.py`, no writer:

- the reusable `e2e.yml` exports a fixed env list to the `common|lifecycle|installer` branch (`VM_IP`, `VM_USER`, `SSH_KEY`, `SSH_PORT`, `ZSTD_CHUNKED`);
- it exposes no input to add another, so this repo cannot supply it either.

So the scenario has skipped unconditionally since it landed, on every target including a LUKS one — and a skipped scenario reads as a green report. The projectbluefin/common#385 assertion this issue asks for has never been exercised.

The header now spells out how each of the three assertions gates itself, plus an explicit caveat so nobody reads a green `installer` run as LUKS coverage. **The actual fix is projectbluefin/testsuite#754** (replaces the dead env-var gate with a runtime `lsblk -rno TYPE | grep -qx crypt` probe on the DUT). This note can be deleted once that merges *and* the `@v1` tag this workflow pins moves to include it.

### 2. `workflow-map.md` documented `e2e.yml` as a PR check

The ownership table had `| e2e.yml | PR-facing testsuite check | pull_request |`. It is `workflow_dispatch`-only — the workflow's own header explains why (PRs do not publish a `:testing` build first, so a PR-triggered run tests a stale image, not the PR's code). Corrected, and it now names the entry point.

### 3. Dispatching e2e had no `just` recipe

AGENTS.md: *"All maintenance tasks must be `just` recipes. No loose shell commands."* and *"Every agent action must be replicable by a human via the Justfile."* Running the installer suite was a remembered `gh workflow run` incantation. Added:

```
just e2e <suites> [image]          # dispatch any suite set
just e2e-installer [image]         # the fisherman post-boot assertions (#651)
```

## Verification

| Check | Result |
|---|---|
| `just --summary` | parses |
| `just --list` | both recipes appear under `test` with clean one-line docs |
| `just --dry-run e2e-installer` | expands to `just e2e installer "ghcr.io/projectbluefin/dakota:testing"` → the intended `gh workflow run` |
| `.github/workflows/e2e.yml` YAML parse | OK — `jobs: [e2e]`, `inputs: [image, suites]` unchanged |
| `just check-publish-workflow` | pass |
| `python3 -m unittest scripts.test_check_publish_workflow` | 6 tests, OK |

`just lint` / `just boot-test` are not applicable and were not run: this PR changes no BuildStream element, no image content, and no CI trigger, so it cannot alter the built image. The only executable addition is a dispatch recipe, verified with `--dry-run`. (Neither is runnable in this environment — no podman/bcvk.)

`just --unstable --fmt --check` fails, but it **already fails on `testing` unmodified** — the pre-existing offender is elsewhere in the file. I did not reformat the Justfile, since that would bury this change in unrelated churn.

## Scope notes

- **Kept off `docs/skills/e2e-ci.md` and `docs/skills/installer.md`** — open PR #1304 owns both. That PR is still blocked on CHANGES_REQUESTED (its fisherman issue references are wrong); I verified those review points independently and they hold: `tuna-os/fisherman` and `projectbluefin/fisherman` both report `has_issues: true`, and fisherman #1/#2 are "Flatpak-packaged installer" (closed) and "support composefs-native and plain ostree images" (open) — neither is the Flatpak-exclusion or efivars bind-mount fix. I also could not find any upstream issue that *does* track those two fixes in either repo, so "drop the specific numbers" looks like the only accurate option available to that PR.
- **No cross-repo input added.** Adding a `luks_enabled` input here would fail until the reusable workflow declares it, so the fix belongs upstream first (testsuite#754), not in a workflow that would break on dispatch.

Assisted-by: Claude Opus 5 via Claude Code

---
🐝 **Hive Agent**: `contributor` | **SHA:** `c10e6d6`
