### PR TITLE
docs(e2e): correct installer suite skip conditions in workflow header

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,10 +13,25 @@
 # cmdline format) over SSH against the target image. Implemented in
 # projectbluefin/testsuite (tests/installer/features/installer_post_boot.feature);
 # tracked by projectbluefin/dakota#651 with the spec in docs/skills/e2e-ci.md
-# -> "Installer Post-Boot Assertions (fisherman)". The UEFI/LUKS scenarios
-# skip unless the target is a fisherman-installed UEFI+LUKS system, so on
-# the standard direct-kernel-boot lane only the Flatpak-exclusion assertion
-# runs; the suite is meaningful against a to-filesystem install.
+# -> "Installer Post-Boot Assertions (fisherman)". Of the three scenarios,
+# only Flatpak exclusion can currently report a result here:
+#
+#   * UEFI   — skips when `efibootmgr` exits non-zero, which is the case on
+#              the direct-kernel-boot lane (no UEFI firmware, no efivars).
+#              Reports against a to-filesystem install on an OVMF lane.
+#   * LUKS   — gated on LUKS_ENABLED, which the testsuite reusable workflow
+#              does not export (it passes an explicit env list: VM_IP,
+#              VM_USER, SSH_KEY, SSH_PORT, ZSTD_CHUNKED). environment.py
+#              defaults it to "false", so this scenario skips on *every*
+#              run, including against a real LUKS install. Making it report
+#              needs a LUKS_ENABLED passthrough in projectbluefin/testsuite
+#              first; there is no dakota-side lever for it.
+#   * Flatpak— runs, but only carries signal against a fisherman-installed
+#              target, since org.bootcinstaller is never in the store on a
+#              direct-kernel-booted image.
+#
+# Treat a green `installer` run on the standard lane as "not broken", not as
+# evidence that the fisherman fixes shipped.
 
 name: E2E Tests — GNOME 50
 


### PR DESCRIPTION
## What problem are you solving?

The workflow header that shipped with the installer suite tells you the LUKS scenario skips "unless the target is a fisherman-installed UEFI+LUKS system." That reads like the assertion is waiting for the right lane. It isn't — it skips on every run, on every lane, including against a real LUKS install, and nothing in dakota can change that. Anyone reading a green `installer` run today would reasonably conclude the LUKS cmdline assertion from #651 is live coverage. It isn't, and the header should say so.

- [x] I am using an agent and I take responsibility for this PR

---

## Changes

Comment-only edit to the `installer` suite note in `.github/workflows/e2e.yml`, replacing one inaccurate sentence with a per-scenario breakdown of what can actually report.

**The finding.** `tests/installer/features/environment.py` in testsuite gates the `@luks` scenario on:

```python
context.luks_enabled = os.environ.get("LUKS_ENABLED", "false").lower() in ("true", "1", "yes")
...
if "luks" in scenario.tags and not context.luks_enabled:
    scenario.skip("LUKS_ENABLED not set — skip LUKS cmdline scenarios on non-LUKS install")
```

`LUKS_ENABLED` is never exported. The `installer` branch of the reusable `e2e.yml` (pinned here at `@v1`) prefixes behave with an explicit env list and nothing else:

```bash
PYTHONPATH="$(pwd)" \
VM_IP=127.0.0.1 \
VM_USER=bluefin-test \
SSH_KEY=/tmp/vm_key \
SSH_PORT=2222 \
ZSTD_CHUNKED="${ZSTD_CHUNKED}" \
python3 tests/shared/behave_retry.py ...
```

A code search for `LUKS_ENABLED` across both `projectbluefin/testsuite` and `projectbluefin/dakota` returns exactly one hit: the defaulted read above. There is no input on the reusable workflow to set it either — its `workflow_call` inputs are `image`, `target-image`, `suites`, `skip_native_apps`, `chunked_enabled`, `screenshot_flatpaks`, `test_ref`, `test_repository`. So the scenario skips unconditionally.

The other two, stated accurately in the new header:

- **UEFI** — genuinely conditional. Skips when `efibootmgr` exits non-zero, which is what happens on the direct-kernel-boot lane (no UEFI firmware, no efivars). The original sentence was correct for this one.
- **Flatpak** — executes, but only carries signal against a fisherman-installed target. `org.bootcinstaller` is never in the store on a direct-kernel-booted image, so `assert "org.bootcinstaller" not in output` passes vacuously there.

**No behavior change.** I verified the edit is comment-only by stripping comments from both versions and diffing:

```
$ diff <(git show upstream/testing:.github/workflows/e2e.yml | grep -vE '^\s*#') \
       <(grep -vE '^\s*#' .github/workflows/e2e.yml)
# (no output — identical)
```

## Why this is docs and not a fix

Making the LUKS assertion report requires a `LUKS_ENABLED` passthrough in `projectbluefin/testsuite`'s reusable workflow. There is no dakota-side lever: adding an input here that the reusable workflow doesn't accept would make the job fail outright, so the dakota half cannot land first. Recording the real state is the change that belongs in this repo.

## Testing

- [x] Comment-only — non-comment content byte-identical to `upstream/testing` (diff above)
- [x] No trailing whitespace, no tabs, file ends with newline (`pre-commit` hygiene hooks)
- [x] Every added line begins with `#`
- [ ] `actionlint` — not run locally (unavailable in this environment); CI covers it, and the diff adds no workflow syntax

## Checklist

- [x] Conventional commit message
- [x] No hardcoded secrets or credentials
- [x] Targets `testing` per CONTRIBUTING.md

Refs #651. Does not close it — see the issue comment for why the tracking issue still has an open gap after testsuite#697, dakota#1304, and dakota#1316.
