### PR TITLE
feat(bluefin): add brlaser CUPS driver

### DIFF
--- a/elements/bluefin/brlaser.bst
+++ b/elements/bluefin/brlaser.bst
@@ -1,0 +1,20 @@
+# Brother CUPS printer driver for monochrome laser printers.
+kind: cmake
+
+sources:
+- kind: git_repo
+  url: github:pdewacht/brlaser.git
+  track: "v[0-9]*"
+  ref: 23117fe9e0266396e4791cdae84d979928aed135 # v6 (peeled commit)
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-cmake.bst
+- freedesktop-sdk.bst:components/cups.bst
+
+depends:
+- freedesktop-sdk.bst:components/cups.bst
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  cmake-local: >-
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -48,6 +48,7 @@ depends:
   - bluefin/wireplumber-pcsp.bst
   - bluefin/countme.bst
   - bluefin/alsa-utils.bst
+  - bluefin/brlaser.bst
   # - bluefin/lsp-plugins-lv2.bst
 
   # Include things missing from the gnomeos base image


### PR DESCRIPTION
Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

## What problem are you solving?
<!-- Write this in your own words. One paragraph. No AI. -->

- [x] I am using an agent and I take responsibility for this PR

---

## Changes

I needed to print something on my dakota computer, I added brlaser CUPS drivers and it worked. I'm sharing the change here in case it's something upstream want, this package is already in regular bluefin spin.

I don't know any other method to add printer drivers, this is not really convenient this way though.

## Testing

- [x] `just validate` passes
- [ ] `just boot-test` passes (automated boot smoke test)
- [x] `just lint` passes on a built image
- [x] `just boot-fast` or `just boot-vm` — desktop comes up, no regressions

I can't use `just boot-test` or `just boot-fast` on dakota, they error with this message:

```
bcvk not found. Attempting to install via cargo...
ERROR: bcvk is not installed and cargo is not available for auto-install.

Install bcvk manually:
  Cargo:       cargo install --locked --git https://github.com/bootc-dev/bcvk bcvk
  Fedora 42+:  sudo dnf install bcvk

Also ensure qemu-kvm and virtiofsd are installed on the host.
error: recipe `_ensure-bcvk` failed with exit code 1
```

However, `just show-me-the-future` works fine, and I also booted the image and used the drivers.

## Checklist

- [x] New BST elements wired into `deps.bst`
- [ ] Patches in `patches/` regenerated if junction refs changed

## Community verification (bug-fix PRs)

If this PR fixes a bug, add verify-steps to the issue so the community can confirm
the fix works on their hardware after the next nightly ships:

````markdown
```verify
# Steps for users to verify this fix:
systemctl status <affected-service>
# or whatever the user should check
```
````

Users will run `ujust verify <issue-number>` which fetches these steps automatically.
