### PR TITLE
docs(e2e-ci): spec fisherman installer post-boot assertions, correct status

### DIFF
--- a/docs/skills/e2e-ci.md
+++ b/docs/skills/e2e-ci.md
@@ -116,6 +116,41 @@ Always call the local wrapper workflow:
 Do **not** wire `projectbluefin/testsuite` directly from every caller. Pin once
 in the wrapper, then inherit it everywhere.
 
+## Installer Post-Boot Assertions (fisherman)
+
+Dakota does not own installer/fisherman source (see `installer.md` for the
+repo boundary), but the *installed system* it produces is Dakota's problem —
+so post-boot e2e assertions for a fisherman-driven `bootc install` belong in
+the testsuite's `installer` suite, wired through `run-testsuite.yml`/`e2e.yml`
+like any other suite.
+
+[dakota#651](https://github.com/projectbluefin/dakota/issues/651) tracks
+three assertion gaps against a system installed via fisherman (`tuna-os/fisherman`,
+the `bootc-installer` Go backend). Fisherman has issues enabled, but the
+specific source problems below predate this tracking effort and don't map
+cleanly to a fisherman issue number — dakota#651 is the canonical place to
+keep live upstream references, not the table below.
+
+| # | Assertion (post-boot, on the installed target) | Status |
+|---|---|---|
+| 1 | `flatpak list --system --app` must **not** list `org.bootcinstaller.Installer` (or `.Devel`) — `CopyFlatpaks` must exclude the installer's own Flatpak from the copied system store, not just rely on the firstboot `bluefin-remove-installer.service` cleanup as the only backstop. | Assertion implemented (`installer_post_boot.feature`); executes on every `installer` suite run, but only carries signal against a real fisherman-installed target — it passes vacuously on the direct-kernel-boot CI lane, where the installer flatpak was never present. |
+| 2 | `efibootmgr -v` must show `BootCurrent` plus a Boot entry for the install — requires the installer's `podman run` to bind-mount host `/sys/firmware/efi/efivars` (`-v /sys/firmware/efi/efivars:/sys/firmware/efi/efivars`) so `efibootmgr` can reach host UEFI variables from inside the install container. | Assertion implemented; genuinely conditional — skips when `efibootmgr` exits non-zero (no UEFI firmware in the direct-kernel-boot lane), reports for real against an OVMF / to-filesystem lane. |
+| 3 | `/proc/cmdline` must contain a parseable LUKS UUID via **either** `rd.luks.uuid=` or `rd.luks.name=` — confirms the `luks-tpm2-autounlock` `rd.luks.name=` parsing fix (projectbluefin/common issue 385, merged) works against what fisherman actually writes to the bootloader config on a LUKS install. | Source fix shipped. Assertion **never reports**: it was gated on a `LUKS_ENABLED` env var that nothing ever set, so it skipped on every run including a real LUKS install. `projectbluefin/testsuite` PR 754 replaces the dead env-var gate with a target probe (`lsblk -rno TYPE | grep -qx crypt`); until that (or an equivalent fix) lands, do not read a green `installer` run as evidence this assertion executed. |
+
+**Do not add these as a new inline boot-check gate.** They test the installer
+path (`bootc install to-disk`/`to-filesystem` invoked via fisherman with
+LUKS), which is a different code path than Dakota's own generic-image
+raw-disk build used by `boot-vm`/`generate-bootable-image`/`boot-test`
+(see Hard Gate Pattern above and `Justfile`'s `generate-bootable-image`).
+Mixing the two turns the fast deterministic hard gate into a second,
+installer-shaped e2e suite — the exact anti-pattern called out in Red Flags.
+
+**Lesson: an env-var gate is only as real as the plumbing that sets it.** A
+scenario skipping is not the same as a scenario passing, and a skipped
+scenario reads as green in a suite summary. Before trusting a gated
+assertion, grep the reusable workflow for the writer of the env var the gate
+reads — if there is no writer, the assertion has never actually run.
+
 ## Common Rationalizations
 
 | Rationalization | Reality |
@@ -124,6 +159,9 @@ in the wrapper, then inherit it everywhere.
 | "I'll just make smoke optional with `continue-on-error`." | Not on a reusable-workflow call job. Split the workflow instead. |
 | "bootc already knows the defaults; I can skip the explicit flags." | CI has punished that repeatedly. Use the documented raw-image path. |
 | "The testsuite workflow is easy enough to copy here." | Duplicate wiring drifts. Use the wrapper. |
+| "Fisherman is a different repo, so its e2e coverage isn't Dakota's job." | The installed system it produces is still Dakota's problem. Track coverage gaps here, fix source elsewhere. |
+| "Let's just add the LUKS/UEFI checks to the existing boot-check gate." | That gate tests Dakota's own generic raw-disk build, not the fisherman install path — wrong suite, wrong code path. |
+| "The `installer` suite is green, so the LUKS assertion ran." | Check what the scenario actually did — a dead env-var gate makes every run skip silently and still report green. |
 
 ## Red Flags
 
@@ -132,6 +170,8 @@ in the wrapper, then inherit it everywhere.
 - direct calls to upstream testsuite from multiple workflows
 - red publish runs caused by observational smoke
 - boot-check growing into a second full e2e suite
+- an installer/fisherman post-boot assertion gated on an env var nobody writes
+- a green `installer` suite run treated as proof a LUKS/UEFI assertion executed, without checking whether it skipped
 
 ## Verification
 
@@ -140,3 +180,5 @@ in the wrapper, then inherit it everywhere.
 - [ ] `bootc install to-disk` uses the documented raw-image pattern
 - [ ] Testsuite calls go through `run-testsuite.yml`
 - [ ] The resulting pipeline is faster and more deterministic, not more ambitious
+- [ ] Installer/fisherman post-boot assertions stay in the testsuite `installer` suite, not the inline boot-check gate
+- [ ] A gated assertion's env var actually has a writer somewhere in the pipeline — not just a reader

--- a/docs/skills/installer.md
+++ b/docs/skills/installer.md
@@ -155,6 +155,25 @@ The ISO's `install-flatpaks.sh` installs the bootc-installer as a system Flatpak
 
 **Root cause is in `dakota-iso`** (`install-flatpaks.sh`), but the defensive fix lives in dakota because the installed image should never ship the installer regardless of how it got there.
 
+### Fisherman e2e coverage gaps tracked in dakota (2026-08-11)
+
+Fisherman (`tuna-os/fisherman`, the installer's Go backend) e2e coverage gaps
+are tracked as [dakota#651](https://github.com/projectbluefin/dakota/issues/651)
+even though the source fixes land upstream — Dakota still owns verifying the
+*installed* system. Three post-boot assertions (installer Flatpak exclusion,
+`efibootmgr` UEFI entry presence, `rd.luks.uuid=`/`rd.luks.name=` cmdline
+parsing) are implemented in the testsuite `installer` suite, not Dakota's own
+generic-image boot-check. See `docs/skills/e2e-ci.md` → "Installer Post-Boot
+Assertions (fisherman)" for the current status of each assertion and the
+sequencing rule.
+
+As of this writing, two of the three assertions can report real signal
+against a fisherman-installed target; the LUKS cmdline assertion cannot yet
+because it inherited a dead `LUKS_ENABLED` env-var gate that nothing sets —
+see the linked table for the fix in flight upstream in
+`projectbluefin/testsuite`. Don't read a green `installer` suite run as proof
+all three assertions executed without checking that table first.
+
 ## Dakota vs Dakota-ISO boundary
 
 The installer is NOT built from source in this repo. The boundary:


### PR DESCRIPTION
Closes #651.

## What problem are you solving?

dakota#651 tracks three e2e assertion gaps against a fisherman-driven install (installer Flatpak exclusion, UEFI `efibootmgr` entry, LUKS cmdline format), but the spec for these assertions had never landed cleanly in this repo's skill docs, and the issue thread has since surfaced that one of the three assertions silently never executes.

An earlier attempt at this spec (PR #1304, from a different fork) got `CHANGES_REQUESTED` for two factual errors — it claimed "issues are disabled on tuna-os/fisherman" (false: the API reports `has_issues: true`) and linked specific fisherman issue numbers that don't correspond to the described bugs — and has sat unaddressed since 2026-08-09.

- [x] I am using an agent and I take responsibility for this PR

## Changes

Docs-only, two files:

- **`docs/skills/e2e-ci.md`** — new "Installer Post-Boot Assertions (fisherman)" section with a status table for all three assertions, reflecting what's actually verified as of today:
  - Assertions 1 (Flatpak exclusion) and 2 (UEFI boot entry) are implemented in `projectbluefin/testsuite`'s `installer` suite and dispatch-wired into dakota (`e2e.yml`); each has a real but different reporting caveat (vacuous off a fisherman install / gated on UEFI firmware availability).
  - Assertion 3 (LUKS cmdline): the source fix (projectbluefin/common issue 385) is merged, but the *assertion* never reports — it inherited a `LUKS_ENABLED` env-var gate that nothing in the pipeline ever sets, so it silently skips on every run, including a real LUKS install. `projectbluefin/testsuite` PR 754 (open) replaces the dead gate with a target probe (`lsblk -rno TYPE | grep -qx crypt`).
  - Drops the "issues disabled" claim and the mismatched fisherman issue-number links from the earlier draft; points to dakota#651 itself as the canonical live-reference tracker instead.
  - Adds corresponding rationalization/red-flag/verification entries: a green suite run isn't proof a gated assertion executed — check whether it skipped.
- **`docs/skills/installer.md`** — cross-links the new spec from Lessons Learned with the same up-to-date per-assertion status, so a reader following the installer skill file doesn't have to visit e2e-ci.md to learn assertion 3 doesn't currently execute.

## Why this belongs in dakota

Fisherman/testsuite own the source fix and the assertion implementation respectively; this repo owns tracking that the *installed system* it ships is verified, per `AGENTS.md`'s repo-boundary rule ("the installed system it produces is still Dakota's problem"). No code change — purely closing the loop on #651's own tracking doc.

## Testing

- Docs-only change; no build/lint/e2e surface touched.
- Verified via GitHub API that `tuna-os/fisherman` has issues enabled (`has_issues: true`) and that fisherman issues #1/#2 do not match the bugs described (contra the earlier draft).
- Verified `projectbluefin/common` issue 385 is merged.
- Verified `projectbluefin/testsuite` PR 754 (open, mergeable) implements the LUKS probe fix described.
- Confirmed the two edited files contain no bare `org/repo#NNN` or `/issues/NNN` cross-repo autolink patterns (AGENTS.md rule 4) — cross-repo references use plain text (`projectbluefin/common issue 385`, `projectbluefin/testsuite PR 754`).

## Checklist

- [x] Conventional commit message
- [x] No hardcoded secrets or credentials
- [x] Targets `testing` per CONTRIBUTING.md
- [x] Skill file (`docs/skills/e2e-ci.md`, `docs/skills/installer.md`) updated in this same PR, per the self-improvement mandate