### PR TITLE
fix: restore Bluefin dinosaur avatars in GNOME user-account picker (#353)

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -23,6 +23,7 @@ depends:
   - bluefin/umotd.bst
 
   - bluefin/common.bst
+  - bluefin/user-avatars.bst
   - bluefin/just-overrides.bst
   - bluefin/zswap-config.bst
   - bluefin/swapfile.bst

--- a/elements/bluefin/user-avatars.bst
+++ b/elements/bluefin/user-avatars.bst
@@ -1,0 +1,21 @@
+kind: manual
+
+# Points GNOME's avatar chooser (gnome-control-center) and gnome-initial-setup's
+# account page at bluefin-common's dinosaur avatar directory. See the keyfile
+# for the full explanation. Fixes: projectbluefin/dakota#353
+sources:
+- kind: local
+  path: files/user-avatars
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - |
+    install -Dm644 07-dakota-avatar-directories \
+      "%{install-root}%{sysconfdir}/dconf/db/distro.d/07-dakota-avatar-directories"
+  - "%{install-extra}"

--- a/files/user-avatars/07-dakota-avatar-directories
+++ b/files/user-avatars/07-dakota-avatar-directories
@@ -1,0 +1,17 @@
+# Restore the Bluefin dinosaur avatar icons in the GNOME "Users" account-picture
+# picker (fixes: projectbluefin/dakota#353).
+#
+# bluefin-common ships Bluefin's custom (dinosaur-themed) avatars under a
+# `bluefin/` category subdirectory: system_files/bluefin/usr/share/pixmaps/faces/bluefin/*.jpg
+# (installed here as /usr/share/pixmaps/faces/bluefin/*.jpg by bluefin/common.bst).
+#
+# gnome-control-center's avatar chooser (panels/system/users/cc-avatar-chooser.c)
+# and gnome-initial-setup's account page only enumerate files directly inside
+# <datadir>/pixmaps/faces/ — they never recurse into subdirectories. Without an
+# explicit avatar-directories setting, both silently fall back to Fedora/GNOME's
+# stock (near-empty) pixmaps/faces dir and Bluefin's avatars never appear.
+#
+# Setting org.gnome.desktop.interface avatar-directories tells both UIs to scan
+# our bluefin/ subdirectory explicitly.
+[org/gnome/desktop/interface]
+avatar-directories=['/usr/share/pixmaps/faces/bluefin']


### PR DESCRIPTION
## Problem

gnome-control-center's avatar chooser (cc-avatar-chooser.c) and gnome-initial-setup's account page only enumerate files directly inside `<datadir>/pixmaps/faces/` — they never recurse into subdirectories.

bluefin-common ships its dinosaur-themed avatars in a `bluefin/` category subdirectory (`/usr/share/pixmaps/faces/bluefin/*.jpg`), so both UIs silently fall back to Fedora/GNOME's near-empty stock faces dir and Bluefin's avatars never appear.

## Fix

Set `org.gnome.desktop.interface avatar-directories` via a distro dconf override to point both UIs at the bluefin/ subdirectory, matching the existing dconf-override pattern used elsewhere in this repo.

### Files changed

- `elements/bluefin/user-avatars.bst` — new BST element (manual kind) that installs the dconf override
- `files/user-avatars/07-dakota-avatar-directories` — dconf keyfile setting `avatar-directories=[/usr/share/pixmaps/faces/bluefin]`
- `elements/bluefin/deps.bst` — added `bluefin/user-avatars.bst` dependency after `bluefin/common.bst`

Closes #353