### PR TITLE
fix(common): flatten Bluefin face icons into /usr/share/pixmaps/faces

### DIFF
--- a/docs/skills/oci-layers.md
+++ b/docs/skills/oci-layers.md
@@ -213,3 +213,24 @@ Two load-bearing examples:
 Final NVIDIA OCI assembly must assert that `GL/lib/gbm` remains a symlink and
 that both `dri_gbm.so` and `nvidia-drm_gbm.so` resolve through it. Check the
 composed path with `ls -ld` before choosing any install location under `GL/`.
+
+### Bluefin content shipped in a subdirectory GNOME reads non-recursively (2026-08-13)
+
+`projectbluefin/common` ships the Bluefin user-avatar art under
+`system_files/bluefin/usr/share/pixmaps/faces/bluefin/`, which
+`elements/bluefin/common.bst` copies verbatim into the image. GNOME's account
+avatar chooser (`cc-avatar-chooser.c` in gnome-control-center, and
+gnome-initial-setup's account page) scans `/usr/share/pixmaps/faces`
+non-recursively, so the files were present in the image but never visible to
+users (dakota#353).
+
+`ublue-os/bluefin` handles this in `build_files/base/05-override-install.sh` by
+flattening `faces/bluefin/*` over `faces/` at build time. The BST equivalent is
+a flatten step in the `install-commands` of `elements/bluefin/common.bst`, plus
+an `overlap-whitelist` entry for `/usr/share/pixmaps/faces/*` because the
+flattened filenames collide with the GNOME OS defaults from
+`core/gnome-control-center.bst`.
+
+General rule: when `common` places files in a vendor subdirectory, check
+whether the consuming component actually scans subdirectories before assuming
+the copy is sufficient.

--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -25,6 +25,9 @@ public:
     - /etc/environment
     - /etc/containers/policy.json
     - /usr/share/pixmaps/gnome-boot-logo.png
+    # Bluefin user-avatar art replaces the GNOME OS defaults shipped by
+    # core/gnome-control-center.bst (same 15 filenames).
+    - /usr/share/pixmaps/faces/*
 
 variables:
   strip-binaries: ""
@@ -65,6 +68,15 @@ config:
     cp "%{install-root}%{datadir}/pixmaps/fedora-logo-icon.png" "%{install-root}%{datadir}/pixmaps/img-logo-icon-dark.png"
     # Override GNOME OS boot logo with Bluefin branding
     cp "%{install-root}%{datadir}/pixmaps/fedora-gdm-logo.png" "%{install-root}%{datadir}/pixmaps/gnome-boot-logo.png"
+    # User-avatar art: common ships Bluefin faces under faces/bluefin/, but
+    # gnome-control-center only reads %{datadir}/pixmaps/faces (non-recursive),
+    # so the images never appear in the account-avatar chooser. Flatten them
+    # over the GNOME OS defaults, matching ublue-os/bluefin's
+    # build_files/base/05-override-install.sh.
+    if [ -d "%{install-root}%{datadir}/pixmaps/faces/bluefin" ]; then
+      mv "%{install-root}%{datadir}/pixmaps/faces/bluefin/"* "%{install-root}%{datadir}/pixmaps/faces/"
+      rmdir "%{install-root}%{datadir}/pixmaps/faces/bluefin"
+    fi
     install -Dm755 bluefin-wallpaper-month-sync "%{install-root}%{prefix}/libexec/bluefin-wallpaper-month-sync"
     install -Dm644 bluefin-wallpaper-month.service "%{install-root}%{prefix}/lib/systemd/system/bluefin-wallpaper-month.service"
     mkdir -p "%{install-root}%{prefix}/lib/systemd/system/multi-user.target.wants"


### PR DESCRIPTION
## Summary

Fixes #353 — Bluefin's custom dinosaur-themed avatars never showed up in the
GNOME Users account-picture picker on Dakota, even though the image files are
correctly ingested from `projectbluefin/common`.

## Root cause

`bluefin-common` ships these avatars under a `bluefin/` category subdirectory:
`/usr/share/pixmaps/faces/bluefin/*.jpg` (named after GNOME's old stock face
filenames — `bicycle.jpg`, `cat.jpg`, etc. — but the artwork itself is
Bluefin's own).

GNOME's avatar pickers only look directly inside `<datadir>/pixmaps/faces/`:

- `cc-avatar-chooser.c` (`get_system_facesdirs`/`add_faces_from_dirs`) in gnome-control-center
- gnome-initial-setup's account page (`um-photo-dialog.c`)

Neither recurses into subdirectories, so the `bluefin/` folder is silently
skipped and both UIs fall back to Fedora/GNOME's near-empty stock
`pixmaps/faces` dir. `elements/bluefin/common.bst` already copies the files
correctly; nothing tells GNOME to look in the `bluefin/` subdirectory or to
merge those files into the flat directory GNOME actually scans.

## Fix

`ublue-os/bluefin` solves this exact problem in
`build_files/base/05-override-install.sh` by flattening `faces/bluefin/*` over
`faces/` at build time. This PR ports that pattern to the BST element:

- `elements/bluefin/common.bst` `install-commands`: after all other
  `pixmaps` munging, move `%{datadir}/pixmaps/faces/bluefin/*` into
  `%{datadir}/pixmaps/faces/` and remove the now-empty subdirectory, guarded
  by a `-d` test.
- Same element's `overlap-whitelist`: add `/usr/share/pixmaps/faces/*`. The
  flattened filenames are identical to the GNOME OS defaults from
  `core/gnome-control-center.bst`, so the overlap is intentional and must be
  declared or BuildStream will refuse to compose the layer.
- `docs/skills/oci-layers.md`: record the vendor-subdirectory pattern per the
  skill-contribution mandate in `AGENTS.md`.

## Testing

- Verified `elements/bluefin/common.bst` still parses as valid YAML.
- Extracted and shell-checked (`bash -n`) the modified `install-commands`
  heredoc block after substituting BST variables — syntax is valid.
- Could not run `just bst`, `just validate`, `just build`, `just lint`, or
  `just boot-test` in this environment (no podman/BuildStream runtime
  available). Requesting CI `validate` + `e2e` as the gate, per
  `docs/skills/ci.md`'s "Publishing is the deliverable" guidance.

What to check after a CI build:
```
just bst artifact list-contents oci/layers/bluefin.bst | grep pixmaps/faces
# expect 15 entries directly under usr/share/pixmaps/faces, no faces/bluefin/
```

Note: `files/filemap.json` and `files/fakecap-manifest.tsv` still list the old
`faces/bluefin/*` paths; regenerating them requires `bst artifact
list-contents` against a populated local cache, which isn't available here —
flagging for CI/maintainer regeneration if required.

- [ ] I am using an agent and I take responsibility for this PR

Closes #353

Assisted-by: Claude Sonnet 5 via GitHub Copilot
