### PR TITLE
fix(brew): bump common for prefix fix, ship make, guard spelling

### DIFF
--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -35,6 +35,7 @@ If your first draft says "use dnf", "edit the Containerfile", or "enable a COPR"
 | Clear stuck queue or conflicting chore PRs | `docs/skills/merge-queue.md` |
 | Work on issues, triage, or Actionadon | `docs/skills/actionadon.md` |
 | Understand what Dakota is | `docs/skills/overview.md` |
+| Touch host Homebrew integration or debug a broken brew prefix | `docs/skills/host-homebrew.md` |
 | Write ujust recipes | `.github/skills/ujust-recipes.md` |
 | Work on the installer | `docs/skills/installer.md` |
 | Review a pull request | `docs/workflow.md` + `docs/pr-checklist.md` + `docs/skills/pr-review.md` |

--- a/docs/skills/host-homebrew.md
+++ b/docs/skills/host-homebrew.md
@@ -1,0 +1,111 @@
+---
+name: host-homebrew
+description: How Homebrew runs on the Dakota host — prefix spelling rules, the GNU Make requirement, and the failure mode where a failed native gem build bricks the persistent /home/linuxbrew prefix. Use when touching brew.bst, brew-tarball.bst, common's brew files, or debugging a broken brew on an installed system.
+---
+
+# Host Homebrew
+
+Homebrew on Dakota currently runs **directly on the host** (the `bluefin-cli`
+nspawn design in `bluefin-cli.md` is placeholder work — `bluefin-cli.bst` is not
+wired into `deps.bst` and does not ship). The prefix at `/home/linuxbrew/.linuxbrew`
+is persistent user data: image updates and reboots do not repair it, so any bug
+that corrupts it bricks brew until someone fixes the prefix by hand.
+
+## When to Use
+
+- Editing `elements/bluefin/brew.bst`, `elements/bluefin/brew-tarball.bst`, or
+  the brew-related files common ships (`brew-preinstall`, `20-oem-brew.sh`,
+  `update.just`, `brew-preinstall.service`)
+- A user-facing report that every `brew` command crashes on an installed system
+- Reviewing changes that touch the toolchain content of the OCI layers
+  (`elements/oci/layers/bluefin.bst`, `bluefin-nvidia.bst`)
+
+## When NOT to Use
+
+- nspawn container design work → `bluefin-cli.md`
+- General package addition → `add-package.md`
+
+## Invariants (violating either one bricks installed systems)
+
+### 1. The image must ship GNU Make wherever it ships GCC
+
+`bin/brew` **hard-filters PATH to `/usr/bin:/bin:/usr/sbin:/sbin`** before
+running anything (see `filter the user environment` in Homebrew's `bin/brew`).
+No user PATH, shell profile, or brew-installed make can ever satisfy a native
+build — the toolchain **must** be in `/usr/bin`. Both
+`elements/oci/layers/bluefin.bst` and `bluefin-nvidia.bst` therefore compose
+`freedesktop-sdk.bst:components/make.bst` alongside `components/gcc.bst`.
+
+Why it bricks: Homebrew's vendored-gem Bundler install is **not transactional**.
+If a native extension build fails (e.g. `make` missing), the gem's Ruby files
+stay in `vendor/bundle` without the matching `.so`. Ruby then loads mismatched
+gem code against the built-in extension of a different version and **every brew
+command crashes at startup** (2026-07-30 incident: `brew style` installed
+`json` 2.21.1 Ruby files, portable Ruby fell back to its built-in JSON 2.18
+native ext → `undefined method 'default_sort_keys_proc='`).
+
+### 2. Brew must always be invoked as `/home/linuxbrew/.linuxbrew/bin/brew`
+
+Dakota has a real `/home` (no ostree `/var/home` indirection). Homebrew derives
+its prefix from the path it was invoked through; the `/var/home` spelling makes
+the detected prefix differ from the `/home/linuxbrew` prefix Linux bottles are
+built for, so brew **rejects every bottle and falls back to source builds**
+(which then hit invariant 1). This is why `brew-preinstall.service` failed to
+install OS-managed packages before the 2026-07 incident was even noticed.
+
+Upstream `projectbluefin/common` used to spell these paths
+`/var/home/linuxbrew` because on its ostree-based targets (Bluefin, LTS)
+`/var/home` is the physical directory and `/home` is a symlink into it —
+there, either spelling resolves. Dakota inverts the layout (real `/home`),
+which turns the spelling into the bottle-rejection failure above.
+`/home/linuxbrew` is the spelling that works on both layouts and is what the
+rest of the ecosystem uses (`ublue-os/brew` itself, Aurora, and bluefin's own
+sudoers/OEM hooks). projectbluefin/common#997 respelled every occurrence at
+the source; `elements/bluefin/common.bst` keeps a build-time guard that fails
+if the `/var/home/linuxbrew` spelling ever regresses upstream — fix such
+regressions in common, not with a Dakota-side rewrite.
+
+## Repairing a bricked prefix on an installed system
+
+Do **not** delete the prefix (user packages live there) and do not reach for
+RPM/DNF/`ujust devmode` — this is a BuildStream image.
+
+1. Get a working `make` without touching the OS: GNU Make's `build.sh`
+   bootstraps with only a C compiler (`./configure && ./build.sh`), and the
+   host ships GCC.
+2. Remove the partial gem installs from
+   `Homebrew/Library/Homebrew/vendor/bundle/ruby/<abi>/` — the broken gems'
+   `gems/<name>-<ver>`, `specifications/<name>-<ver>.gemspec`,
+   `extensions/<arch>/<abi>-static/<name>-<ver>`, and `cache/<name>-<ver>.gem`.
+3. Reinstall via Bundler **directly** — `brew install-bundler-gems` cannot work
+   (PATH filter, invariant 1). From anywhere:
+
+   ```bash
+   HB=/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew
+   RB=$HB/vendor/portable-ruby/<version>/bin
+   env -i HOME="$HOME" USER="$USER" TERM=dumb \
+     PATH="$RB:<dir-with-make>:/usr/bin:/bin" \
+     GEM_HOME="$HB/vendor/bundle/ruby/<abi>" GEM_PATH="$HB/vendor/bundle/ruby/<abi>" \
+     BUNDLE_GEMFILE="$HB/Gemfile" BUNDLE_WITH="style" BUNDLE_FROZEN=true \
+     "$RB/bundle" install
+   ```
+
+4. Verify: `brew --version`, `brew search <x>`, and `brew style <file>` in a
+   tap checkout (the class of command that triggered the incident).
+
+## Lessons Learned
+
+### A failed `brew install-bundler-gems` re-arms the broken state (2026-08-01)
+
+Bundler extracts gem files **before** building native extensions. Every failed
+attempt recreates the exact mismatched-gem crash it was trying to fix. Never
+retry the brew-level command to "see if it works now" on an affected machine —
+fix the PATH problem first (direct Bundler invocation above), or you re-break
+startup for every brew command including the timers.
+
+### The update timers run brew with systemd's default PATH (2026-08-01)
+
+`brew-update.service` / `brew-upgrade.service` (system units, `User=1000`)
+invoke brew with the stock systemd PATH. Combined with the `bin/brew` PATH
+filter, timer-context native builds only ever see `/usr/bin` — another reason
+make must live in the image, not in the prefix or a user dotfile.

--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -4,7 +4,7 @@ sources:
 - kind: git_repo
   url: github:projectbluefin/common.git
   track: main
-  ref: v2026.08-51-g3e5f7f5d2dd739908d0e8570e832f267a8e1d1cf
+  ref: v2026.08-54-g19afc70e4923e644cc7f108063a47db4e85971d6
 - kind: git_module
   url: github:projectbluefin/branding/
   path: bluefin-branding
@@ -35,6 +35,15 @@ config:
     #   - install -Dm644 -t "%{install-root}%{sysconfdir}/" etc/*
   - |
     sed -i "s#file:///usr/share/backgrounds/bluefin/12-bluefin.xml#file:///var/lib/ublue-os/current-bluefin.xml#g" "system_files/bluefin/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override"
+
+    # The /var/home/linuxbrew spelling breaks Homebrew's bottle-prefix
+    # detection on Dakota's real /home; common respelled everything to
+    # /home/linuxbrew in projectbluefin/common#997. Guard against the bad
+    # spelling regressing upstream (docs/skills/host-homebrew.md).
+    if grep -rl "/var/home/linuxbrew" system_files/shared system_files/bluefin; then
+      echo "ERROR: /var/home/linuxbrew references above break brew bottle-prefix detection — fix them in projectbluefin/common" >&2
+      exit 1
+    fi
 
     cp -r system_files/bluefin/usr/./ "%{install-root}%{prefix}/"
     cp -r system_files/shared/usr/./ "%{install-root}%{prefix}/"

--- a/elements/oci/layers/bluefin-nvidia.bst
+++ b/elements/oci/layers/bluefin-nvidia.bst
@@ -2,6 +2,9 @@ kind: compose
 
 build-depends:
   - freedesktop-sdk.bst:components/gcc.bst
+  # Homebrew native builds only see /usr/bin and brick the persistent
+  # prefix when make is missing (docs/skills/host-homebrew.md)
+  - freedesktop-sdk.bst:components/make.bst
   - oci/layers/bluefin-nvidia-runtime.bst
 
 config:

--- a/elements/oci/layers/bluefin.bst
+++ b/elements/oci/layers/bluefin.bst
@@ -2,6 +2,9 @@ kind: compose
 
 build-depends:
   - freedesktop-sdk.bst:components/gcc.bst
+  # Homebrew native builds only see /usr/bin and brick the persistent
+  # prefix when make is missing (docs/skills/host-homebrew.md)
+  - freedesktop-sdk.bst:components/make.bst
   - oci/layers/bluefin-runtime.bst
 
 config:


### PR DESCRIPTION
## Summary

On first boot of any image shipping a tap and cask pair, brew bundle skipped the cask before the tap was processed, so ChairLift was silently never installed. Separately, Homebrew's bottle-prefix detection breaks on Dakota's real /home when the prefix is spelled /var/home/linuxbrew. The root fixes landed in common (projectbluefin/common#997 and projectbluefin/common#998), this PR ships them in Dakota.

1. **Bump common to v2026.08-54**, carrying the tap-before-bundle ordering fix, the skipped-cask retry, and the /home/linuxbrew respelling.

2. **Ship GNU make in the image.** `bin/brew` filters PATH down to /usr/bin, so brew's source builds need make to exist there. Added to both OCI layers.

3. **Guard against regression.** common.bst now fails the build if the /var/home/linuxbrew spelling reappears in common's system files. Invariants are documented in docs/skills/host-homebrew.md.

Verified: built the nvidia gaming image locally at this ref, boot tested it on real hardware, and confirmed brew-preinstall completes a full clean pass under systemd with ChairLift installed.
