### PR TITLE
ci(release): disable broken GNOME 50 smoke gate on stable promotion

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -160,7 +160,12 @@ jobs:
       # force=false fast-forward fails when main diverges from testing (e.g.
       # when commits land on main via direct merge, bypassing the testing flow).
       fast_forward_sha: ${{ needs.freshness-check.outputs.build_sha }}
-      run_release_gate: ${{ inputs.skip_release_gate != true }}
+      # Gate disabled: the GNOME 50 smoke suites fail identically on every
+      # variant (AT-SPI/shell timing, not image regressions), so the gate can
+      # only block releases. Re-enable by restoring
+      # `run_release_gate: ${{ inputs.skip_release_gate != true }}` once the
+      # smoke fixes land (see fix/smoke-gnome50-gate-failures).
+      run_release_gate: false
     secrets: inherit
 
   # Update the stable bookmark (main) to point to the promoted SHA.


### PR DESCRIPTION
## Summary

The stable promotions on Aug 14 and Aug 15 both failed in the release gate, not in anything image related. The GNOME 50 smoke suites fail the exact same eight scenarios on every variant (Dash to Dock, Search Light, accessibility panel, Files launch in smoke-a; the four GNOME Settings scenarios in smoke-b), which points at AT-SPI and shell timing in the suite rather than regressions in the images. With the gate guaranteed red, no promotion can succeed and stable has been stuck on the July 30 build.

1. **Hardcode `run_release_gate: false`** so promotions stop depending on the broken suites. The `skip_release_gate` input stays in place, and the comment documents how to restore gating once the smoke fixes land (see fix/smoke-gnome50-gate-failures).

Verified: the failing scenario lists were pulled from the Aug 15 run logs and are identical across all four variants, and the testsuite workflow itself has never had a passing baseline on GNOME 50.
