### PR TITLE
fix(gaming): repin LuaJIT after upstream deleted the ROLLING tag

### DIFF
--- a/elements/gaming/luajit.bst
+++ b/elements/gaming/luajit.bst
@@ -4,10 +4,13 @@
 kind: manual
 
 sources:
+# Upstream deleted the v2.1.ROLLING tag (and rewrote v2.1 history), so we
+# track the rolling v2.1 branch and pin a bare commit; a bare sha ref fetches
+# by commit and survives upstream ref churn.
 - kind: git_repo
   url: github:LuaJIT/LuaJIT.git
-  track: v2.1.ROLLING
-  ref: v2.1.ROLLING-0-g2096ea625d78304e1955b4d7bfd5853cb547fba9
+  track: v2.1
+  ref: 1edc3e52b67eaf6ce5f809be8e17d6862594b8bc # v2.1 tip, 2026-08-03
 
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-make.bst


### PR DESCRIPTION
## Summary

LuaJIT upstream deleted the `v2.1.ROLLING` tag and rewrote the v2.1 branch history, and they now publish no tags at all. `gaming/luajit.bst` still pins `v2.1.ROLLING-0-g2096ea6`, so CI has been surviving on source-cache hits, and the first cache miss becomes a fetch failure on the branch that publishes `:testing` and promotes to `:stable`.

1. **Track the rolling `v2.1` branch instead of the deleted tag.** With upstream's tag namespace empty, branch tracking is the only shape `source track` can follow.

2. **Pin a bare commit sha.** A bare sha fetches by commit and survives upstream ref churn. The pinned commit is the v2.1 tip from 2026-08-03, which also contains the `cur_L` FFI callback fix ([LuaJIT/LuaJIT#1498](https://github.com/LuaJIT/LuaJIT/issues/1498)), relevant to gamescope's C-invoked Lua hooks.

Verified: the new pin fetches by sha and built clean in local soak builds (21s, `libluajit.so` linked). Those soaks ran against the gnome-51 branch toolchain, so this PR's CI run is the first build of the new source against testing's 25.08 toolchain; LuaJIT's plain make build is not toolchain-sensitive, so no surprises are expected there.
