### PR TITLE
ci(next): add patches/linux-ogc to the sync overlay

### DIFF
--- a/.github/workflows/sync-next.yml
+++ b/.github/workflows/sync-next.yml
@@ -32,6 +32,7 @@ env:
     files/linux
     patches/freedesktop-sdk
     patches/linux
+    patches/linux-ogc
     files/filemap.json
     files/fakecap-manifest.tsv
 


### PR DESCRIPTION
## Summary

The first sync-next run after the next reset failed on its own drop guard, flagging exactly one path: `patches/linux-ogc`. That directory arrived with the OGC 7.2-rc7 kernel bump after `NEXT_OWNED` was last widened, so the sync correctly refused to delete a patch the gaming kernel needs to compile. Until this lands, every push to testing produces one of these red runs.

1. **One line in `NEXT_OWNED`.** `patches/linux-ogc` joins `patches/freedesktop-sdk` and `patches/linux`, which are already in the list, so the sync preserves it the same way it preserves the other patch queues next carries.

Verified: the workflow YAML parses, and the failing run's guard output lists only this path, so nothing else is missing from the list. I will dispatch sync-next once this merges and confirm the run goes green.
