### PR TITLE
fix(elements): stage sandbox shell explicitly for fdsdk 26.08

### DIFF
--- a/elements/bluefin-nvidia/nvidia-container-toolkit-preset.bst
+++ b/elements/bluefin-nvidia/nvidia-container-toolkit-preset.bst
@@ -5,6 +5,9 @@ description: |
   /var/run/cdi/nvidia.yaml is generated at boot and refreshed whenever
   the driver or toolkit binaries change.
 
+build-depends:
+- core/sandbox-tools.bst
+
 depends:
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 

--- a/elements/bluefin-nvidia/nvidia-device-nodes.bst
+++ b/elements/bluefin-nvidia/nvidia-device-nodes.bst
@@ -5,6 +5,9 @@ description: |
   the GDM greeter races the first root NVML client for them and NVIDIA
   EGL init fails.
 
+build-depends:
+- core/sandbox-tools.bst
+
 depends:
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 - bluefin-nvidia/nvidia-drivers.bst

--- a/elements/bluefin-nvidia/nvidia-kargs.bst
+++ b/elements/bluefin-nvidia/nvidia-kargs.bst
@@ -11,6 +11,9 @@ description: |
 
   bootc applies these from /usr/lib/bootc/kargs.d/ on switch/upgrade.
 
+build-depends:
+- core/sandbox-tools.bst
+
 depends:
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 

--- a/elements/bluefin-nvidia/nvidia-modprobe-config.bst
+++ b/elements/bluefin-nvidia/nvidia-modprobe-config.bst
@@ -2,6 +2,9 @@ kind: manual
 description: |
   Modprobe glue for NVIDIA on Wayland: enable KMS + fbdev, blacklist nouveau.
 
+build-depends:
+- core/sandbox-tools.bst
+
 depends:
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 

--- a/elements/bluefin/bindmounts.bst
+++ b/elements/bluefin/bindmounts.bst
@@ -1,6 +1,7 @@
 kind: manual
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/bluefin-cli.bst
+++ b/elements/bluefin/bluefin-cli.bst
@@ -5,6 +5,7 @@ sources:
   path: files/bluefin-cli
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/bootc-install-config.bst
+++ b/elements/bluefin/bootc-install-config.bst
@@ -5,6 +5,7 @@ sources:
   path: files/bootc-install
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/brew-tarball.bst
+++ b/elements/bluefin/brew-tarball.bst
@@ -11,6 +11,7 @@ sources:
       ref: 08813d100ff0f69c57038b1d397e641789701e0ca109200e1377473cd7bad001
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 runtime-depends:

--- a/elements/bluefin/brew.bst
+++ b/elements/bluefin/brew.bst
@@ -1,5 +1,8 @@
 kind: manual
 
+build-depends:
+- core/sandbox-tools.bst
+
 sources:
 - kind: git_repo
   url: github:ublue-os/brew.git

--- a/elements/bluefin/common.bst
+++ b/elements/bluefin/common.bst
@@ -13,6 +13,7 @@ sources:
   path: files/wallpaper-month
 
 build-depends:
+- core/sandbox-tools.bst
 - gnome-build-meta.bst:gnomeos-deps/just.bst
 
 depends:

--- a/elements/bluefin/composefs-loop-udisks-ignore.bst
+++ b/elements/bluefin/composefs-loop-udisks-ignore.bst
@@ -5,6 +5,7 @@ sources:
     path: files/udev
 
 build-depends:
+  - core/sandbox-tools.bst
   - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/countme.bst
+++ b/elements/bluefin/countme.bst
@@ -5,6 +5,7 @@ sources:
   path: files/countme
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/distrobox.bst
+++ b/elements/bluefin/distrobox.bst
@@ -4,6 +4,7 @@
 kind: manual
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:components/go.bst
 
 depends:

--- a/elements/bluefin/firstboot-date.bst
+++ b/elements/bluefin/firstboot-date.bst
@@ -5,6 +5,7 @@ sources:
   path: files/firstboot
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/firstboot-services.bst
+++ b/elements/bluefin/firstboot-services.bst
@@ -7,6 +7,7 @@ sources:
   path: files/service-overrides
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/fprintd-system-auth.bst
+++ b/elements/bluefin/fprintd-system-auth.bst
@@ -57,6 +57,7 @@ public:
 
 # No external sources — the file is inline.
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 # Stage after the stock file so this override wins the overlap deterministically.

--- a/elements/bluefin/ghostty.bst
+++ b/elements/bluefin/ghostty.bst
@@ -4,6 +4,7 @@ variables:
   strip-binaries: ""
 
 build-depends:
+  - core/sandbox-tools.bst
   - bluefin/zig.bst
   - freedesktop-sdk.bst:components/tar.bst
   - freedesktop-sdk.bst:components/gzip.bst

--- a/elements/bluefin/gum.bst
+++ b/elements/bluefin/gum.bst
@@ -11,6 +11,7 @@ sources:
       ref: b0b9ed95cbf7c8b7073f17b9591811f5c001e33c7cfd066ca83ce8a07c576f9c
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/jetbrains-mono-nerd-font.bst
+++ b/elements/bluefin/jetbrains-mono-nerd-font.bst
@@ -1,6 +1,7 @@
 kind: manual
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 - freedesktop-sdk.bst:components/libarchive.bst
 - freedesktop-sdk.bst:components/bzip2.bst

--- a/elements/bluefin/jetbrains-mono.bst
+++ b/elements/bluefin/jetbrains-mono.bst
@@ -1,6 +1,7 @@
 kind: manual
 
 build-depends:
+  - core/sandbox-tools.bst
   - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 depends:

--- a/elements/bluefin/just-overrides.bst
+++ b/elements/bluefin/just-overrides.bst
@@ -5,6 +5,7 @@ sources:
   path: files/just-overrides
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/migrate-var-home-passwd.bst
+++ b/elements/bluefin/migrate-var-home-passwd.bst
@@ -14,6 +14,7 @@ sources:
   path: files/migrate-var-home-passwd
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/network.bst
+++ b/elements/bluefin/network.bst
@@ -2,6 +2,7 @@ kind: manual
 
 # No external sources - all files are inline.
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/papers-thumbnailer.bst
+++ b/elements/bluefin/papers-thumbnailer.bst
@@ -1,6 +1,7 @@
 kind: manual
 
 build-depends:
+- core/sandbox-tools.bst
 - gnome-build-meta.bst:core/papers.bst
 
 depends:

--- a/elements/bluefin/plymouth-bluefin-theme.bst
+++ b/elements/bluefin/plymouth-bluefin-theme.bst
@@ -8,6 +8,7 @@ runtime-depends:
   - gnome-build-meta.bst:core-deps/plymouth.bst
 
 build-depends:
+  - core/sandbox-tools.bst
   - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/shell-extensions/disable-ext-validator.bst
+++ b/elements/bluefin/shell-extensions/disable-ext-validator.bst
@@ -1,5 +1,8 @@
 kind: manual
 
+build-depends:
+- core/sandbox-tools.bst
+
 depends:
   - gnome-build-meta.bst:sdk/glib.bst
   - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst

--- a/elements/bluefin/shell-extensions/gradia-capture.bst
+++ b/elements/bluefin/shell-extensions/gradia-capture.bst
@@ -7,6 +7,7 @@ sources:
   ref: 9e441493a132e9f38d3a7fdf5d7f0d55a0a36369
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 - freedesktop-sdk.bst:components/jq.bst
 

--- a/elements/bluefin/swapfile.bst
+++ b/elements/bluefin/swapfile.bst
@@ -17,6 +17,7 @@ sources:
   path: files/swapfile
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/tailscale.bst
+++ b/elements/bluefin/tailscale.bst
@@ -11,6 +11,7 @@ sources:
       ref: 2b64e9ade7e73034b5ec9e9bcd537f5ddd14ae3abb435e57e929e7486ae42660
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 - freedesktop-sdk.bst:components/sed.bst
 

--- a/elements/bluefin/tealdeer.bst
+++ b/elements/bluefin/tealdeer.bst
@@ -24,6 +24,7 @@ sources:
     filename: completions_fish
 
 build-depends:
+  - core/sandbox-tools.bst
   - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/umotd.bst
+++ b/elements/bluefin/umotd.bst
@@ -12,6 +12,7 @@ sources:
       ref: d6da4d57f81e6c15d7738b9bd986ffc6915fa79a40426bcca079c2079ec60b06
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/unsigned-modules.bst
+++ b/elements/bluefin/unsigned-modules.bst
@@ -1,6 +1,7 @@
 kind: manual
 
 build-depends:
+- core/sandbox-tools.bst
 - filename: freedesktop-sdk.bst:components/linux.bst
   strict: true
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst

--- a/elements/bluefin/user-avatars.bst
+++ b/elements/bluefin/user-avatars.bst
@@ -8,6 +8,7 @@ sources:
   path: files/user-avatars
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/uupd.bst
+++ b/elements/bluefin/uupd.bst
@@ -12,6 +12,7 @@ sources:
   base-dir: ""
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/wallpaper-month.bst
+++ b/elements/bluefin/wallpaper-month.bst
@@ -5,6 +5,7 @@ sources:
   path: files/firstboot
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/wallpapers.bst
+++ b/elements/bluefin/wallpapers.bst
@@ -10,6 +10,7 @@ sources:
   base-dir: ""
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:components/sed.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 

--- a/elements/bluefin/wireplumber-pcsp.bst
+++ b/elements/bluefin/wireplumber-pcsp.bst
@@ -10,6 +10,7 @@ sources:
   path: files/wireplumber
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/xdg-terminal-exec.bst
+++ b/elements/bluefin/xdg-terminal-exec.bst
@@ -7,6 +7,7 @@ sources:
   ref: v0.14.3-0-g065925df9f419008159258ae169018bfd23df71b
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/zig.bst
+++ b/elements/bluefin/zig.bst
@@ -11,6 +11,7 @@ sources:
       ref: 958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 
 variables:

--- a/elements/bluefin/zswap-config.bst
+++ b/elements/bluefin/zswap-config.bst
@@ -11,6 +11,9 @@ description: |
   bluefin/swapfile.bst; zram is disabled via an integration command in
   oci/layers/bluefin-stack.bst.
 
+build-depends:
+- core/sandbox-tools.bst
+
 depends:
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 

--- a/elements/core/ntsync-modules-load.bst
+++ b/elements/core/ntsync-modules-load.bst
@@ -2,6 +2,9 @@
 # Wine/Proton probe /dev/ntsync directly; without this nothing loads it.
 kind: manual
 
+build-depends:
+- core/sandbox-tools.bst
+
 depends:
 - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 

--- a/elements/core/sandbox-tools.bst
+++ b/elements/core/sandbox-tools.bst
@@ -1,0 +1,16 @@
+# Shell and coreutils for element build sandboxes.
+#
+# freedesktop-sdk 26.08 slimmed public-stacks/runtime-minimal.bst down to
+# libraries only (glibc, symlinks, gcc-libs, locale); on 25.08 it also
+# carried bash and coreutils, which is what gave our manual elements a
+# working `sh` for their configure/build/install commands. Every element
+# that runs sandbox commands build-depends on this stack instead of
+# relying on its runtime base to smuggle in a shell.
+#
+# Widen this stack (not the individual elements) if element commands need
+# more tools than bash and coreutils provide.
+kind: stack
+
+depends:
+- freedesktop-sdk.bst:bootstrap/bash.bst
+- freedesktop-sdk.bst:bootstrap/coreutils.bst

--- a/include/os-release.yml
+++ b/include/os-release.yml
@@ -1,5 +1,10 @@
 # Shared os-release / image-info.json generator; instantiating elements
 # set %{os-release-repo} (oci/os-release.bst, bluefin-nvidia/os-release.bst).
+# If an instantiating element declares its own build-depends, YAML
+# composition REPLACES this list (no merge) — carry sandbox-tools along.
+build-depends:
+  - core/sandbox-tools.bst
+
 depends:
   - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
 


### PR DESCRIPTION
## Summary

The first next build on gnome-51 failed in ~40 elements with "Staged artifacts do not provide command 'sh'": fdsdk 26.08 slimmed `runtime-minimal` to libraries only, and our manual elements were implicitly getting their sandbox shell from it. This adds `core/sandbox-tools.bst` (bash + coreutils) and build-depends it from the 42 affected elements. Build-depends stage into sandboxes only, 62 insertions and zero deletions, so runtime deps and image contents are unchanged. Lands on testing (the dep is valid on 25.08 too), the sync carries it to next.

Verified: all four variant graphs resolve, and the previously failing elements build against the gnome-51 junctions locally with this applied. The full next build is the remaining check.
