### PR TITLE
ci(next): build next images on every content push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,10 @@ name: Build Bluefin dakota
 
 on:
   push:
-    branches: [testing]
+    # next builds per content push too: syncs and merged junction bumps queue
+    # behind testing in the shared concurrency group, and superseded pending
+    # runs collapse burst days to one build of the newest state.
+    branches: [testing, next]
     paths:
       - "elements/**"
       - "patches/**"

--- a/docs/skills/workflow-map.md
+++ b/docs/skills/workflow-map.md
@@ -83,7 +83,7 @@ Successful publish.yml on testing   ← PARALLEL, DECOUPLED
 
 | Workflow | Owns | Normal trigger |
 |---|---|---|
-| `.github/workflows/build.yml` | BST build into remote CAS | `push: testing` (BST + CI-build-path files), `workflow_dispatch`, `schedule: daily 13:00 UTC`. `validate` lives in `validate.yml`; this workflow does not run on `pull_request` or `merge_group`. |
+| `.github/workflows/build.yml` | BST build into remote CAS | `push: testing/next` (BST + CI-build-path files), `workflow_dispatch`, `schedule: daily 13:00 UTC`. `validate` lives in `validate.yml`; this workflow does not run on `pull_request` or `merge_group`. |
 | `.github/workflows/build-aarch64.yml` | aarch64 OCI build + GHCR push | `push: testing/main` (BST-affecting paths), `workflow_run` from `publish.yml` on `testing`, `workflow_dispatch`. Fully decoupled — never in `needs:` of publish/promote/release. |
 | `.github/workflows/publish.yml` | export, sign, boot-check, promote tags | `workflow_run` from build |
 | `.github/workflows/publish-smoke.yml` | observational smoke only | `workflow_run` from publish |


### PR DESCRIPTION
## Summary

The next branch is fully automated but nothing builds its images: `build.yml` only triggers on pushes to testing, so the stream has never published one. This adds `next` to `push.branches` with the same paths filter. Next builds queue behind testing in the shared concurrency group, superseded pending runs collapse burst days into one build, and `publish.yml` already promotes `:next`/`:btw` after boot-check. Push triggers run the workflow at the pushed ref, so this lands on testing and reaches next through the sync.

Verified: actionlint passes. The first next image build will be dispatched manually and watched.
