### PR TITLE
fix(elements): complete the fdsdk 26.08 port across all variants

### DIFF
--- a/.github/workflows/sync-next.yml
+++ b/.github/workflows/sync-next.yml
@@ -31,6 +31,7 @@ env:
     elements/oci/layers/bluefin-stack.bst
     files/linux
     patches/freedesktop-sdk
+    patches/freedesktop-sdk.manifest.json
     patches/linux
     patches/linux-ogc
     files/filemap.json

--- a/.github/workflows/track-next-junctions.yml
+++ b/.github/workflows/track-next-junctions.yml
@@ -79,22 +79,10 @@ jobs:
           fi
           sed -i "0,/^\s*ref:/{s|^\(\s*\)ref:.*|\1ref: ${fdsdk_ref}|}" elements/freedesktop-sdk.bst
 
-          # Mirror gnome-build-meta's fdsdk patch queue at the same commit.
-          tree_api="https://gitlab.gnome.org/api/v4/projects/GNOME%2Fgnome-build-meta/repository/tree?path=patches/freedesktop-sdk&ref=${gbm_sha}&per_page=100"
-          mapfile -t patch_files < <(curl -fsSL "$tree_api" \
-            | python3 -c 'import json,sys; [print(i["name"]) for i in json.load(sys.stdin) if i["type"] == "blob"]')
-          if [ "${#patch_files[@]}" -eq 0 ]; then
-            echo "ERROR: empty patches/freedesktop-sdk listing at gnome-build-meta @ ${gbm_sha}" >&2
-            exit 1
-          fi
-          rm -f patches/freedesktop-sdk/*
-          for f in "${patch_files[@]}"; do
-            curl -fsSL "${files_api}/patches%2Ffreedesktop-sdk%2F${f}/raw?ref=${gbm_sha}" \
-              -o "patches/freedesktop-sdk/${f}"
-          done
-
-          # By construction this passes; failing here means the mirror above
-          # broke and the PR should not be opened.
+          # Mirror gnome-build-meta's fdsdk patch queue and write the offline
+          # drift manifest, then assert it. Failing here means the sync broke
+          # and the PR should not be opened.
+          just patch-sync
           just patch-drift-check
 
       - name: Create or update PR against next (auto-merge)
@@ -105,7 +93,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git checkout -B auto/track-next-junction origin/next
-          git add elements/gnome-build-meta.bst elements/freedesktop-sdk.bst patches/freedesktop-sdk
+          git add elements/gnome-build-meta.bst elements/freedesktop-sdk.bst patches/freedesktop-sdk patches/freedesktop-sdk.manifest.json
 
           if git diff --cached --quiet; then
             echo "No junction updates"

--- a/Justfile
+++ b/Justfile
@@ -96,7 +96,10 @@ validate:
     just bst show --deps all oci/bluefin.bst
     just bst show --deps all oci/bluefin-nvidia.bst
 
-# Verify the local freedesktop-sdk patch queue matches the pinned GBM ref.
+# Verify the local freedesktop-sdk patch queue matches its committed
+# manifest, offline. The manifest is written by `just patch-sync` (the only
+# step that contacts gitlab.gnome.org), so validate never depends on
+# upstream uptime.
 [group('dev')]
 patch-drift-check:
     #!/usr/bin/env bash
@@ -107,67 +110,91 @@ patch-drift-check:
         echo "ERROR: could not extract GBM commit SHA from elements/gnome-build-meta.bst ref: ${gbm_ref}" >&2
         exit 1
     fi
-    gbm_sha="${BASH_REMATCH[1]}"
+    export gbm_sha="${BASH_REMATCH[1]}"
+    python3 - <<'EOF'
+    import hashlib, json, os, sys
 
-    local_dir="patches/freedesktop-sdk"
-    workdir=".cache/patch-drift-check.$$"
-    rm -rf "$workdir"
-    mkdir -p "$workdir/upstream"
-    trap 'rm -rf "$workdir"' EXIT
+    manifest_path = "patches/freedesktop-sdk.manifest.json"
+    local_dir = "patches/freedesktop-sdk"
+    gbm_sha = os.environ["gbm_sha"]
 
-    api_url="https://gitlab.gnome.org/api/v4/projects/GNOME%2Fgnome-build-meta/repository/tree?path=patches/freedesktop-sdk&ref=${gbm_sha}&per_page=100"
-    curl -fsSL "$api_url" \
-        | python3 -c 'import json, sys; print("\n".join(sorted(item["name"] for item in json.load(sys.stdin) if item.get("type") == "blob")))' \
-        > "$workdir/upstream-files"
+    if not os.path.exists(manifest_path):
+        sys.exit(f"ERROR: {manifest_path} missing - run `just patch-sync`")
+    m = json.load(open(manifest_path))
 
-    if [ ! -s "$workdir/upstream-files" ]; then
-        echo "ERROR: GBM patches/freedesktop-sdk listing is empty at ${gbm_sha}" >&2
+    if m["gnome-build-meta-sha"] != gbm_sha:
+        sys.exit(
+            "ERROR: junction pins GBM %s but patches were synced for %s - run `just patch-sync`"
+            % (gbm_sha, m["gnome-build-meta-sha"])
+        )
+
+    local = {
+        f: hashlib.sha256(open(os.path.join(local_dir, f), "rb").read()).hexdigest()
+        for f in sorted(os.listdir(local_dir))
+        if os.path.isfile(os.path.join(local_dir, f))
+    }
+    status = 0
+    for f in sorted(set(m["files"]) - set(local)):
+        print(f"ERROR: {f} listed in manifest but missing locally", file=sys.stderr); status = 1
+    for f in sorted(set(local) - set(m["files"])):
+        print(f"ERROR: {f} present locally but not in manifest", file=sys.stderr); status = 1
+    for f in sorted(set(local) & set(m["files"])):
+        if local[f] != m["files"][f]:
+            print(f"ERROR: {f} differs from manifest", file=sys.stderr); status = 1
+    if status:
+        sys.exit("ERROR: patch queue drifted from manifest - run `just patch-sync` after junction bumps")
+    print(f"OK: patches/freedesktop-sdk matches manifest for GBM {gbm_sha} ({len(local)} files)")
+    EOF
+
+# Re-sync patches/freedesktop-sdk (and its manifest) from gnome-build-meta
+# at the pinned junction sha. The one place upstream is contacted; run it
+# after every gnome-build-meta junction bump.
+[group('dev')]
+patch-sync:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    gbm_ref=$(awk '/^[[:space:]]*ref: / { print $2; exit }' elements/gnome-build-meta.bst)
+    if [[ ! "$gbm_ref" =~ -g([0-9a-f]{40})$ ]]; then
+        echo "ERROR: could not extract GBM commit SHA from elements/gnome-build-meta.bst ref: ${gbm_ref}" >&2
         exit 1
     fi
+    export gbm_sha="${BASH_REMATCH[1]}"
 
-    while IFS= read -r name; do
-        encoded=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$name")
-        curl -fsSL "https://gitlab.gnome.org/GNOME/gnome-build-meta/-/raw/${gbm_sha}/patches/freedesktop-sdk/${encoded}" \
-            -o "$workdir/upstream/$name"
-    done < "$workdir/upstream-files"
-
-    if [ -d "$local_dir" ]; then
-        find "$local_dir" -maxdepth 1 -type f -printf '%f\n' | sort > "$workdir/local-files"
-    else
-        : > "$workdir/local-files"
+    files_api="https://gitlab.gnome.org/api/v4/projects/GNOME%2Fgnome-build-meta/repository/files"
+    tree_api="https://gitlab.gnome.org/api/v4/projects/GNOME%2Fgnome-build-meta/repository/tree?path=patches/freedesktop-sdk&ref=${gbm_sha}&per_page=100"
+    mapfile -t patch_files < <(curl -fsSL "$tree_api" \
+        | python3 -c 'import json, sys; [print(i["name"]) for i in json.load(sys.stdin) if i["type"] == "blob"]')
+    if [ "${#patch_files[@]}" -eq 0 ]; then
+        echo "ERROR: empty patches/freedesktop-sdk listing at gnome-build-meta @ ${gbm_sha}" >&2
+        exit 1
     fi
-
-    comm -23 "$workdir/upstream-files" "$workdir/local-files" > "$workdir/missing"
-    comm -13 "$workdir/upstream-files" "$workdir/local-files" > "$workdir/extra"
-    : > "$workdir/differing"
-    comm -12 "$workdir/upstream-files" "$workdir/local-files" | while IFS= read -r name; do
-        if ! cmp -s "$workdir/upstream/$name" "$local_dir/$name"; then
-            echo "$name" >> "$workdir/differing"
-        fi
+    rm -f patches/freedesktop-sdk/*
+    for f in "${patch_files[@]}"; do
+        encoded=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$f")
+        curl -fsSL "${files_api}/patches%2Ffreedesktop-sdk%2F${encoded}/raw?ref=${gbm_sha}" \
+            -o "patches/freedesktop-sdk/${f}"
     done
 
-    status=0
-    if [ -s "$workdir/missing" ]; then
-        echo "ERROR: missing local patches from GBM patches/freedesktop-sdk at ${gbm_sha}:" >&2
-        sed 's/^/  /' "$workdir/missing" >&2
-        status=1
-    fi
-    if [ -s "$workdir/extra" ]; then
-        echo "ERROR: extra local patches not in GBM patches/freedesktop-sdk at ${gbm_sha}:" >&2
-        sed 's/^/  /' "$workdir/extra" >&2
-        status=1
-    fi
-    if [ -s "$workdir/differing" ]; then
-        echo "ERROR: differing patch contents versus GBM patches/freedesktop-sdk at ${gbm_sha}:" >&2
-        sed 's/^/  /' "$workdir/differing" >&2
-        status=1
-    fi
-    if [ "$status" -ne 0 ]; then
-        exit "$status"
-    fi
+    python3 - <<'EOF'
+    import hashlib, json, os
 
-    count=$(wc -l < "$workdir/upstream-files" | tr -d ' ')
-    echo "OK: patches/freedesktop-sdk matches GBM ${gbm_sha} (${count} files)"
+    d = "patches/freedesktop-sdk"
+    files = {
+        f: hashlib.sha256(open(os.path.join(d, f), "rb").read()).hexdigest()
+        for f in sorted(os.listdir(d))
+        if os.path.isfile(os.path.join(d, f))
+    }
+    manifest = {
+        "comment": "Written by `just patch-sync`; verified offline by `just patch-drift-check`.",
+        "gnome-build-meta-sha": os.environ["gbm_sha"],
+        "files": files,
+    }
+    with open("patches/freedesktop-sdk.manifest.json", "w") as fh:
+        json.dump(manifest, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+    print(f"Synced {len(files)} patches and manifest for GBM {os.environ['gbm_sha']}")
+    EOF
 
 # ── Build ─────────────────────────────────────────────────────────────
 # Build the OCI image and load it into podman.

--- a/elements/bluefin/ghostty.bst
+++ b/elements/bluefin/ghostty.bst
@@ -250,8 +250,21 @@ config:
     - |
       export ZIG_GLOBAL_CACHE_DIR="/tmp/zig-cache"
       export ZIG_LIB_DIR="%{libdir}/zig"
+      # zig 0.15 caps its bundled glibc stubs at 2.42; fdsdk 26.08 ships
+      # glibc 2.44, so libs reference 2.43+ symbols the stubs lack. Point
+      # zig at the real system libc instead of its stubs.
+      cat > /tmp/system-libc.conf <<LIBC
+      include_dir=/usr/include
+      sys_include_dir=$(ls -d /usr/include/*-linux-gnu 2>/dev/null | head -n1 || echo /usr/include)
+      crt_dir=%{libdir}
+      msvc_lib_dir=
+      kernel32_lib_dir=
+      gcc_dir=
+      LIBC
+      sed -i 's/^      //' /tmp/system-libc.conf
       DESTDIR="%{install-root}" \
       zig build \
+        --libc /tmp/system-libc.conf \
         --prefix /usr \
         --global-cache-dir "$ZIG_GLOBAL_CACHE_DIR" \
         -Doptimize=ReleaseFast \

--- a/elements/bluefin/gnome-shell-extensions.bst
+++ b/elements/bluefin/gnome-shell-extensions.bst
@@ -1,5 +1,8 @@
 kind: manual
 
+build-depends:
+  - core/sandbox-tools.bst
+
 depends:
   # FIXME: cleanup custom make destdirs set when not needed
   - bluefin/shell-extensions/app-indicators.bst

--- a/elements/bluefin/shell-extensions/bazaar-companion.bst
+++ b/elements/bluefin/shell-extensions/bazaar-companion.bst
@@ -7,6 +7,7 @@ sources:
   ref: 3bb9134985343ffd1993520eb37c90e113bfb09b
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:components/jq.bst
 
 depends:

--- a/elements/bluefin/unsigned-modules.bst
+++ b/elements/bluefin/unsigned-modules.bst
@@ -16,5 +16,10 @@ config:
     cp -rT /usr/lib/modules "%{install-root}/usr/lib/modules"
 
   - |
+    # 25.08 kernels install vmlinuz to /boot; 26.08 kernels ship it inside
+    # /usr/lib/modules/<ver>/ already. Handle both, then prove it's there.
     version="$(ls -1 /usr/lib/modules | head -n1)"
-    cp /boot/vmlinuz "%{install-root}/usr/lib/modules/${version}"
+    if [ -f /boot/vmlinuz ]; then
+      cp /boot/vmlinuz "%{install-root}/usr/lib/modules/${version}"
+    fi
+    test -f "%{install-root}/usr/lib/modules/${version}/vmlinuz"

--- a/elements/core/sandbox-tools.bst
+++ b/elements/core/sandbox-tools.bst
@@ -14,3 +14,5 @@ kind: stack
 depends:
 - freedesktop-sdk.bst:bootstrap/bash.bst
 - freedesktop-sdk.bst:bootstrap/coreutils.bst
+# 26.08 coreutils links libgcc_s.so.1; stage its provider too.
+- freedesktop-sdk.bst:components/gcc-libs.bst

--- a/elements/gaming/gamescope.bst
+++ b/elements/gaming/gamescope.bst
@@ -46,6 +46,8 @@ sources:
   ref: 5736b15f7ea0ffb08dd38af21067c314d6a3aae9
 
 build-depends:
+# gamescope src/meson.build shells out to git for its version stamp.
+- freedesktop-sdk.bst:components/git.bst
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
 - freedesktop-sdk.bst:components/glslang.bst
 - freedesktop-sdk.bst:components/pkg-config.bst

--- a/elements/gaming/gtk2-i686.bst
+++ b/elements/gaming/gtk2-i686.bst
@@ -10,6 +10,7 @@ sources:
   filename: libgtk2.0-0_2.24.33-2+deb12u1_i386.deb
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:bootstrap/bash.bst
 - freedesktop-sdk.bst:bootstrap/binutils.bst
 - freedesktop-sdk.bst:components/tar.bst

--- a/elements/gaming/steam-libs-i686-compat.bst
+++ b/elements/gaming/steam-libs-i686-compat.bst
@@ -3,6 +3,7 @@
 kind: manual
 
 build-depends:
+- core/sandbox-tools.bst
 - freedesktop-sdk.bst:bootstrap/bash.bst
 - freedesktop-sdk.bst:bootstrap/coreutils.bst
 

--- a/elements/gaming/steam-libs-i686-compose.bst
+++ b/elements/gaming/steam-libs-i686-compose.bst
@@ -4,6 +4,7 @@ kind: compose
 # narrow split so the final filter does not install the whole i686
 # freedesktop-sdk userspace over the native x86_64 image.
 build-depends:
+- core/sandbox-tools.bst
 # 32-bit GLVND/GLX/EGL fixes Steam's libGL.so.1 bootstrap checks.
 - freedesktop-sdk.bst:cross-compilers/freedesktop-sdk-i686.bst:components/libglvnd.bst
 

--- a/patches/freedesktop-sdk.manifest.json
+++ b/patches/freedesktop-sdk.manifest.json
@@ -1,0 +1,13 @@
+{
+  "comment": "Written by `just patch-sync`; verified offline by `just patch-drift-check`.",
+  "files": {
+    "0001-project-Specify-more-limits-to-the-CAS-configs.patch": "c88f898ab797268ab4d1a4e4e0608df12fc47a4908f4dd390b97f35fdc08cf97",
+    "0002-project.conf-Add-GNOME-CAS-servers.patch": "80fd9b1aae84700b754483cd1e2cfbcb5d0179c00c82deadccc2c444414fffac",
+    "0003-openssh-Use-etc-ssh-as-sysconfdir.patch": "797a945aa266f4e9c7064618cf53e2f8ab56dd09c168553f667becab9111170e",
+    "0004-openssh-Include-ssh-_config.d-.conf.patch": "f9a53430cc821809e7fd737455043d56fe9df91f1f66d57be99e6b37991a801e",
+    "0005-lvm2-Disable-event-activation-by-default.patch": "87236589d2f0350244597439a36c7670314fb649c6c8850de865d65547fe80aa",
+    "0006-Add-cross-compilers-binutils-x86-64.bst.patch": "ce121de8de3cf0e2f273c3511f5db2add821842aae7028859e0bb25cf718098c",
+    "0007-Update-Pipewire-to-1.6.8.patch": "07e9528cad31e477c09ea42e8a3288f3abb9c92f05b94cba357f43f53b8409de"
+  },
+  "gnome-build-meta-sha": "8524013485013dd5616bfff02dbeab274d5a4553"
+}


### PR DESCRIPTION
## Summary

Full local image builds on next surfaced the remaining fdsdk 26.08 breakage past #1353; every variant now composes end to end on gnome-51, and the shared files still build on 25.08.

1. **`sandbox-tools` gains `gcc-libs`** (26.08 coreutils links `libgcc_s.so.1`) **and five more elements gain the stack**, mostly for dep integration commands.
2. **`unsigned-modules` handles both kernel layouts** (25.08 `/boot`, 26.08 `/usr/lib/modules/<ver>/`), asserting the result either way.
3. **ghostty passes `--libc` with the staged fdsdk libc**: zig 0.15 caps its glibc stubs at 2.42, 26.08 ships 2.44 ([ziglang#12797](https://github.com/ziglang/zig/issues/12797)). zig 0.16 plus an explicit `-Dtarget` pin is a follow-up.
4. **gamescope declares git** for its meson version stamp.
5. **`patch-drift-check` no longer depends on GNOME GitLab uptime.** `just patch-sync` mirrors the patches and writes a committed sha256 manifest (the only step that contacts upstream, reused by the junction tracker); validate verifies against the manifest fully offline. Verified green on clean state and red on a tampered patch and on a stale manifest sha.

Verified: all four variants built as complete images against next's junctions, and ghostty plus unsigned-modules rebuilt clean on testing's 25.08. Boot is covered by the next nightly's boot-check after the sync.
