### PR TITLE
fix(ci): tolerate owned paths absent from next during sync

### DIFF
--- a/.github/workflows/sync-next.yml
+++ b/.github/workflows/sync-next.yml
@@ -87,7 +87,15 @@ jobs:
           git reset --hard origin/testing
           # rm first so owned directories don't keep testing-only files.
           git rm -r -q --ignore-unmatch -- "${owned[@]}"
-          git checkout "$old" -- "${owned[@]}"
+          # Restore owned paths that exist at the old tip; ones born on
+          # testing (e.g. a fresh manifest) reach next via the tracker.
+          for p in "${owned[@]}"; do
+            if git cat-file -e "$old:$p" 2>/dev/null; then
+              git checkout "$old" -- "$p"
+            else
+              echo "note: $p absent at old next tip; skipping restore"
+            fi
+          done
           if git diff --cached --quiet; then
             echo "next-owned files already match testing; publishing bare sync"
           else


### PR DESCRIPTION
## Summary

The #1356 sync run failed: `patches/freedesktop-sdk.manifest.json` joined `NEXT_OWNED` but does not exist on next yet, and the overlay checkout hard-fails on a pathspec with no match. The restore now skips owned paths absent from the old tip with a logged note; the tracker delivers the manifest to next on its next run. Verified by running the extracted script against the live refs, reproducing the failure condition and producing a correct sync.