### PR TITLE
ci(aarch64): stop queueing x86 builds behind ARM in the CAS group

### DIFF
--- a/.github/workflows/build-aarch64.yml
+++ b/.github/workflows/build-aarch64.yml
@@ -37,10 +37,11 @@ env:
   # ("image not known", exit 125) — masked by job-level continue-on-error.
   BUILD_IMAGE_TAG: aarch64
 
-# All BuildStream cache writers share one CAS serialization group. ARM remains
-# decoupled from x86 publication and release, but cannot contend for CAS writes.
+# Own serialization group: aarch64 builds run on ARM runners with their own
+# BST cache and must never queue x86 builds behind them (an aarch64 build
+# held the global group for an hour while a next image waited, 2026-08-18).
 concurrency:
-  group: dakota-bst-build-global
+  group: dakota-aarch64-build
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary

The aarch64 build shares `dakota-bst-build-global`, so today an hour-long ARM build held the queue while the first next image sat pending behind it. ARM runs on its own runners with its own BST cache, so it gets its own `dakota-aarch64-build` group and can never delay an x86 build again. CAS write contention from one concurrent ARM build is negligible next to what publish exports already impose.