### PR TITLE
fix(chunkah): preserve export mtimes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "elements/**"
       - "patches/**"
+      - "Justfile"
       - "project.conf"
       - "include/**"
   # Fires daily at 13:00 UTC — 5 hours after the gnome-build-meta nightly

--- a/Justfile
+++ b/Justfile
@@ -298,8 +298,11 @@ export variant="default":
     # and the multi-layer output breaks composefs xattr injection in chunka.
     # Fixes: projectbluefin/dakota#841 (boot failure on :testing 2026-06-13)
     DATE_TAG="$(date -u +%Y%m%d)"
-    # shellcheck disable=SC2086
-    printf 'FROM %s\nRUN sed -i "s/^VERSION_ID=.*/VERSION_ID=\\"%s\\"/" /usr/lib/os-release \\\n    && sed -i "s/^IMAGE_VERSION=.*/IMAGE_VERSION=\\"%s\\"/" /usr/lib/os-release\n' "$IMAGE_ID" "$DATE_TAG" "$DATE_TAG" \
+    # Preserve the deterministic source mtimes. sed -i changes the parent
+    # directory mtime, which otherwise invalidates every Chunkah layer that
+    # carries /usr/lib metadata even when its component files are unchanged.
+    # shellcheck disable=SC2016,SC2086
+    printf 'FROM %s\nRUN OS_RELEASE_MTIME="$(stat -c %%y /usr/lib/os-release)" \\\n    && USR_LIB_MTIME="$(stat -c %%y /usr/lib)" \\\n    && sed -i "s/^VERSION_ID=.*/VERSION_ID=\\"%s\\"/" /usr/lib/os-release \\\n    && sed -i "s/^IMAGE_VERSION=.*/IMAGE_VERSION=\\"%s\\"/" /usr/lib/os-release \\\n    && touch -d "$OS_RELEASE_MTIME" /usr/lib/os-release \\\n    && touch -d "$USR_LIB_MTIME" /usr/lib\n' "$IMAGE_ID" "$DATE_TAG" "$DATE_TAG" \
         | $SUDO_CMD podman build --pull=never --security-opt label=type:unconfined_t --squash-all ${LABEL_ARGS} -t "${FINAL_NAME}:${FINAL_TAG}" -f - .
     $SUDO_CMD podman rmi "$IMAGE_ID" || true
 


### PR DESCRIPTION
## Summary

Bootc upgrades were redownloading most of the image because the export-time `sed -i` update to `/usr/lib/os-release` changed `/usr/lib`'s mtime. Chunkah includes that parent-directory metadata in component layers, so otherwise unchanged layers received new digests on every publication.

1. **Preserve deterministic mtimes.** The export Containerfile now captures the original mtimes for `/usr/lib/os-release` and `/usr/lib`, performs the existing version substitutions, restores the file mtime, then restores the directory mtime last. This does not change any `os-release` values or version semantics.
2. **Trigger the image build.** `Justfile` is now included in the x86 build workflow's push paths so the repair produces a testing publication and flows into next through the existing sync.

A live NVIDIA Gaming upgrade between two testing publications that differed only in GitHub workflow files reused 21 of 120 layers and left 3,075.1 MiB behind new layer digests. The 703.2 MiB firmware layer had unchanged firmware timestamps, while `/usr/lib` changed from `2026-08-20 09:42:06` to `2026-08-21 09:42:52`.

Verified: `just validate`, `just check-publish-workflow`, its six unit tests, `actionlint`, rendered-recipe `shellcheck`, an exact-nanosecond fixture, and a Podman `--squash-all` integration fixture pass. Full Chunkah layer comparison, image lint, and post-publish OTA verification remain for CI and the resulting testing publication. The first fixed OTA may still be large because installed clients cache the previous volatile layer digests; subsequent publications are the regression target.
