### PR TITLE
ci(build): queue runs FIFO with stale-run gate, detach source tracker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,9 @@ name: Build Bluefin dakota
 on:
   push:
     # next builds per content push too: syncs and merged junction bumps queue
-    # behind testing in the shared concurrency group, and superseded pending
-    # runs collapse burst days to one build of the newest state.
+    # behind testing in the shared concurrency group. queue: max keeps every
+    # queued run (FIFO) instead of superseding — the stale-check job below
+    # collapses burst days to one build of the newest state per branch.
     branches: [testing, next]
     paths:
       - "elements/**"
@@ -26,9 +27,14 @@ env:
   IMAGE_NAME: dakota
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
+# queue: max holds up to 100 pending runs FIFO. The default (queue: single)
+# keeps only ONE pending run per group and cancels the previous pending run
+# whenever a new one arrives — so a testing push followed ~40s later by the
+# sync-next push to next silently discarded the testing build (2026-08-22).
 concurrency:
   group: dakota-bst-build-global
   cancel-in-progress: false
+  queue: max
 
 jobs:
   verify-default-branch:
@@ -47,9 +53,47 @@ jobs:
             exit 1
           fi
 
+  # With queue: max every push queues its own run instead of superseding the
+  # previous pending one. A run that waited in the queue may be stale by the
+  # time it starts: a newer push run for the same branch is already queued
+  # and will build a superset of this state. Skip the expensive build then.
+  stale-check:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+    outputs:
+      stale: ${{ steps.check.outputs.stale }}
+    steps:
+      - name: Check for newer queued run on this branch
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          newer=0
+          # Concurrency-held runs surface as "queued" or "pending" depending
+          # on where they wait; count both.
+          for status in queued pending; do
+            n=$(gh run list \
+              --repo "${{ github.repository }}" \
+              --workflow build.yml \
+              --branch "${{ github.ref_name }}" \
+              --event push \
+              --status "$status" \
+              --json databaseId \
+              --jq "[.[] | select(.databaseId > ${{ github.run_id }})] | length")
+            newer=$((newer + n))
+          done
+          if [ "$newer" -gt 0 ]; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+            echo "${newer} newer queued run(s) for ${{ github.ref_name }} — skipping stale build"
+          else
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
-    needs: [verify-default-branch]
-    if: (!cancelled()) && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'push')
+    needs: [verify-default-branch, stale-check]
+    if: (!cancelled()) && needs.stale-check.outputs.stale != 'true' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'push')
     runs-on: ubuntu-24.04
     timeout-minutes: 350
     # The BuildBox backend has four action slots. Start every image variant

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,4 +52,9 @@ jobs:
           chmod +x actionlint
 
       - name: Run actionlint
-        run: ./actionlint -color .github/workflows/*.yml
+        # -ignore: actionlint <= v1.7.12 predates the `queue` concurrency key
+        # (GitHub changelog 2026-05-07). Drop once rhysd/actionlint#657 ships.
+        run: |
+          ./actionlint -color \
+            -ignore 'unexpected key "queue" for "concurrency" section' \
+            .github/workflows/*.yml

--- a/.github/workflows/track-bst-sources.yml
+++ b/.github/workflows/track-bst-sources.yml
@@ -21,8 +21,13 @@ on:
 
 permissions: read-all
 
+# Own group, deliberately NOT dakota-bst-build-global: tracking only queries
+# upstream repos and release URLs to resolve refs — it never builds and never
+# touches the CAS, so it has no reason to wait behind (or contend with)
+# multi-hour BST builds. On 2026-08-22 the scheduled tracker entering the
+# shared build group cancelled the pending next build.
 concurrency:
-  group: dakota-bst-build-global
+  group: dakota-source-track
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
## Summary

Last night's testing build for #1379 never ran: the sync-next push superseded the pending testing build, then the scheduled tracker superseded the next build. Root cause is that `dakota-bst-build-global` defaults to `queue: single`, which keeps one pending run per group and cancels the previous one whenever a new run arrives.

1. **`build.yml`** adds `queue: max` so pending runs queue FIFO instead of superseding, plus a `stale-check` job that skips a push build when a newer run for the same branch is already queued, preserving the collapse-to-newest behavior per branch.

2. **`track-bst-sources.yml`** moves to its own `dakota-source-track` group, tracking only resolves refs and never touches the CAS.

3. **`codeql.yml`** actionlint gets a scoped ignore for the `queue` key until rhysd/actionlint#657 ships.

Related: the testing merge queue's `min_entries_to_merge_wait_minutes` was raised from 5 to 30 in repo settings so auto-merge PRs coalesce into one group and one build.
