### PR TITLE
fix(image): unbreak fresh-ISO post-install (uwelcome, brew, devmode)

### DIFF
--- a/elements/bluefin/brew-tarball.bst
+++ b/elements/bluefin/brew-tarball.bst
@@ -1,14 +1,17 @@
 kind: manual
 
 sources:
-- kind: remote
+# The docker source pins the per-architecture manifest digest, not the
+# multi-arch index digest, so each arch carries its own ref (tracked with
+# `just bst -o arch <arch> source track bluefin/brew-tarball.bst`).
+- kind: docker
+  url: ghcr:ublue-os/brew
+  track: latest
   (?):
   - arch == "x86_64":
-      url: github_files:ublue-os/packages/releases/download/homebrew-2026-03-03-01-31-47/homebrew-x86_64.tar.zst
-      ref: 46e546da7ac2a4e916f0c89db61e9c0292b90e8b4b6b5662d2c5df5f668fb40c
+      ref: e0edae28a2ce41e2faa05b9a4902488a9a22d5c4a70c94427ccac8904ec5107a
   - arch == "aarch64":
-      url: github_files:ublue-os/packages/releases/download/homebrew-2026-02-17-01-32-11/homebrew-aarch64.tar.zst
-      ref: 08813d100ff0f69c57038b1d397e641789701e0ca109200e1377473cd7bad001
+      ref: aff477fa0ccbbb467946ed12e1ec6cd7726281e555daa152ef64af8f3106a5e6
 
 build-depends:
 - core/sandbox-tools.bst
@@ -23,7 +26,7 @@ variables:
 config:
   install-commands:
   - |
-    mkdir -p "%{install-root}%{datadir}"
-    mv homebrew-%{arch}.tar.zst "%{install-root}%{datadir}/homebrew.tar.zst"
+    install -Dm644 system_files/usr/share/homebrew.tar.zst \
+      "%{install-root}%{datadir}/homebrew.tar.zst"
   - |
     %{install-extra}

--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -21,6 +21,7 @@ depends:
   - bluefin/tealdeer.bst
   - bluefin/ydotool.bst
   - bluefin/umotd.bst
+  - bluefin/uwelcome.bst
 
   - bluefin/common.bst
   - bluefin/user-avatars.bst

--- a/elements/bluefin/uwelcome.bst
+++ b/elements/bluefin/uwelcome.bst
@@ -1,0 +1,27 @@
+# uwelcome renders the login welcome screen and MOTD. common ships the hooks
+# that invoke it (/etc/profile.d/uwelcome.sh, fish greeting, /etc/uwelcome)
+# but builds the binary in its Containerfile, which Dakota does not consume,
+# so we ship the release binary ourselves like umotd.bst.
+kind: manual
+
+sources:
+- kind: remote
+  filename: uwelcome
+  (?):
+  - arch == "x86_64":
+      url: github_files:projectbluefin/uwelcome/releases/download/v0.3.4/uwelcome_0.3.4_linux_amd64
+      ref: f9eba23e8b273ba4add3e4ddfe63a17241caacb82548b78cde187bd5c8021ab6
+  - arch == "aarch64":
+      url: github_files:projectbluefin/uwelcome/releases/download/v0.3.4/uwelcome_0.3.4_linux_arm64
+      ref: 93697c18d9dd99fa77401765576495d0c51b7dbf3a892c45b18bb3487f864362
+
+build-depends:
+- core/sandbox-tools.bst
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+  - install -Dm755 uwelcome "%{install-root}%{bindir}/uwelcome"

--- a/elements/plugins/buildstream-plugins.bst
+++ b/elements/plugins/buildstream-plugins.bst
@@ -4,3 +4,9 @@ sources:
 - kind: tar
   url: pypi:source/b/buildstream-plugins/buildstream-plugins-2.5.0.tar.gz
   ref: 49c57dec88c0b4558f474520c2e29c69ecd42a1e5c07423baae5b29b153e54a6
+# apache/buildstream-plugins#91 (open upstream): the docker source only
+# accepts Docker v2 media types, so registries serving OCI manifests
+# (ghcr.io, used by bluefin/brew-tarball.bst) 404 on fetch. Drop the patch
+# when the PR merges and the junction moves to a release containing it.
+- kind: patch_queue
+  path: patches/buildstream-plugins

--- a/files/just-overrides/default.just
+++ b/files/just-overrides/default.just
@@ -359,7 +359,7 @@ probe:
         gum style --foreground 214 --margin "0 2" \
             "Goose is not installed."
         gum style --foreground 245 --margin "0 4" \
-            "Install it first:  ujust bbrew  →  select the 'ai' menu option"
+            "Install it first:  brew bundle --file=/usr/share/ublue-os/homebrew/ai-tools.Brewfile"
         exit 1
     fi
 

--- a/files/just-overrides/system.just
+++ b/files/just-overrides/system.just
@@ -13,43 +13,34 @@ bluefin-cli:
 devmode:
     @ujust toggle-devmode
 
-# Toggle between Bluefin and the Developer Experience
+# Toggle the Developer Experience (groups + optional dev flatpaks and fonts)
 [group('System')]
 toggle-devmode:
     #!/usr/bin/env bash
-    set -e
-    BOOTED_JSON=$(sudo bootc status --json 2>/dev/null || echo '{}')
-    CURRENT_IMAGE=$(echo "$BOOTED_JSON" | jq -r '.status.booted.image.image.image // empty')
-    if [[ -z "${CURRENT_IMAGE}" ]]; then
-        echo "ERROR: could not determine the booted image from bootc status"
-        exit 1
-    fi
-    # Extract image tag (everything after the last colon)
-    IMAGE_TAG="${CURRENT_IMAGE##*:}"
-    # Extract base name without tag
-    IMAGE_REPO="${CURRENT_IMAGE%:*}"
-    IMAGE_BASE_NAME="$(basename "${IMAGE_REPO}")"
-    set +e
-
-    if grep -q -E -e "dx$" <<< "${IMAGE_BASE_NAME}" ; then
-        gum confirm "Would you like to disable developer mode?" || exit 0
-        echo "Rebasing to a non developer image"
-        NEW_IMAGE="$(sed "s/\-dx//" <<< ${IMAGE_REPO}):${IMAGE_TAG}"
-        pkexec bootc switch --enforce-container-sigpolicy "${NEW_IMAGE}"
+    set -euo pipefail
+    # Dakota bakes the developer stack into every image (podman, distrobox,
+    # skopeo, git, flatpak-builder, the brew toolchain, ...) and publishes no
+    # -dx variant, so unlike Bluefin there is no image rebase here. Developer
+    # mode is group membership plus optional extras, and works the same on a
+    # fresh ISO install with no registry-bound bootc image.
+    if id -nG "$(id -un)" | grep -qw docker ; then
+        gum confirm "Developer mode is on (docker/libvirt/incus/serial groups). Disable it?" || exit 0
+        for g in docker incus-admin libvirt dialout ; do
+            sudo gpasswd -d "$(id -un)" "$g" 2>/dev/null || true
+        done
+        echo "Developer groups removed. Log out and back in for this to take effect."
         exit 0
     fi
 
     gum confirm "Would you like to enable developer mode?" || exit 0
-    echo "Rebasing to a developer image"
-    NEW_IMAGE="${IMAGE_REPO}-dx:${IMAGE_TAG}"
-    pkexec bootc switch --enforce-container-sigpolicy "${NEW_IMAGE}"
+    ujust dx-group
     if gum confirm "Do you want to also install the default development flatpaks?" ; then
         ADD_DEVMODE=1 ujust install-system-flatpaks 0 1
     fi
     if gum confirm "Do you want to install extra monospace fonts?" ; then
         brew bundle install --file=/usr/share/ublue-os/homebrew/fonts.Brewfile
     fi
-    echo "Use ujust dx-group to add your user to the correct groups and complete the installation after rebooting into the development image"
+    echo "Log out and back in (or reboot) to pick up the new group memberships."
 
 # Configure docker,incus-admin,libvirt, container manager, serial permissions
 [group('System')]
@@ -92,7 +83,7 @@ install-system-flatpaks $confirm="1" $dx_only="0":
     brew bundle --file="${TARGET_FLATPAK_FILE:-/usr/share/ublue-os/homebrew/system-flatpaks.Brewfile}"
 
 # Install default system flatpaks (alias for install-system-flatpaks)
-# For additional applications, use: ujust bbrew
+# For additional applications, use ChairLift (Applications page)
 [group('System')]
 bluefin-apps:
     echo "Installing default system flatpaks..."

--- a/include/aliases.yml
+++ b/include/aliases.yml
@@ -29,6 +29,7 @@ aliases:
   freedesktop_software: https://www.freedesktop.org/software/
   freerdp: https://pub.freerdp.com/
   ftp_gnu_org: https://ftp.gnu.org/gnu/
+  ghcr: https://ghcr.io/
   github_files: https://github.com/
   gitlab_files: https://gitlab.com/
   gnome_downloads: https://download.gnome.org/sources/

--- a/patches/buildstream-plugins/pr-91.patch
+++ b/patches/buildstream-plugins/pr-91.patch
@@ -1,0 +1,166 @@
+From 004475e0dfe42bb13bef2cdae7e1884e21bc5d64 Mon Sep 17 00:00:00 2001
+From: Avi Deitcher <avi@deitcher.net>
+Date: Tue, 30 Sep 2025 15:04:35 +0300
+Subject: [PATCH] add OCI types and docker auth to docker source plugin
+
+Signed-off-by: Avi Deitcher <avi@deitcher.net>
+---
+ src/buildstream_plugins/sources/docker.py | 86 ++++++++++++++++++++---
+ 1 file changed, 77 insertions(+), 9 deletions(-)
+
+diff --git a/src/buildstream_plugins/sources/docker.py b/src/buildstream_plugins/sources/docker.py
+index 62c4d76..200352f 100644
+--- a/src/buildstream_plugins/sources/docker.py
++++ b/src/buildstream_plugins/sources/docker.py
+@@ -106,6 +106,7 @@
+ import shutil
+ import tarfile
+ import urllib.parse
++import base64
+ 
+ import requests
+ 
+@@ -168,23 +169,78 @@ def urljoin(url, *args):
+     return url
+ 
+ 
++def _load_docker_config_credentials(registry_url):
++    """
++    Loads credentials for a given registry from $DOCKER_CONFIG/config.json or ~/.docker/config.json.
++    Returns a tuple of (username, password) or None if not found.
++    """
++    docker_config_path = os.environ.get("DOCKER_CONFIG", os.path.expanduser("~/.docker"))
++    config_file = os.path.join(docker_config_path, "config.json")
++    if not os.path.exists(config_file):
++        return None
++
++    try:
++        with open(config_file, "r") as f:
++            config = json.load(f)
++        auths = config.get("auths", {})
++        # Accept both with or without scheme
++        # Normalize the registry urls for matching
++        candidates = [
++            registry_url,
++            registry_url.lstrip("https://").lstrip("http://"),
++            "https://" + registry_url.lstrip("https://").lstrip("http://"),
++            "http://" + registry_url.lstrip("https://").lstrip("http://"),
++        ]
++        for key in auths:
++            for candidate in candidates:
++                # Exact match or registry host match
++                if key == candidate or key == urllib.parse.urlparse(candidate).netloc:
++                    auth_entry = auths[key]
++                    if "auth" in auth_entry:
++                        auth_b64 = auth_entry["auth"]
++                        auth_decoded = base64.b64decode(auth_b64).decode("utf-8")
++                        username, password = auth_decoded.split(":", 1)
++                        return username, password
++                    # Support for 'username' and 'password' fields
++                    if "username" in auth_entry and "password" in auth_entry:
++                        return auth_entry["username"], auth_entry["password"]
++        return None
++    except Exception:
++        return None
++
+ # Handles authentication with a bearer token
+ class BearerAuth(requests.auth.AuthBase):
+-    def __init__(self, api_timeout=3):
++    def __init__(self, api_timeout=3, registry_url=None):
+         self.token = None
+         self.api_timeout = api_timeout
+ 
++        self.username = None
++        self.password = None
++        if registry_url:
++            creds = _load_docker_config_credentials(registry_url)
++            if creds:
++                self.username, self.password = creds
++
+     def __call__(self, r):
+         if self.token:
+             r.headers["Authorization"] = "Bearer {}".format(self.token)
++        elif self.username and self.password:
++            # Set HTTP Basic Auth header if token is not yet available
++            userpass = "{}:{}".format(self.username, self.password).encode("utf-8")
++            r.headers["Authorization"] = "Basic {}".format(base64.b64encode(userpass).decode("utf-8"))
+         return r
+ 
+     def refresh_token(self, auth_challenge):
+         auth_vars = parse_bearer_authorization_challenge(auth_challenge)
+-        # Respond to an Www-Authenticate challenge by requesting the necessary
+-        # token from the 'realm' (endpoint) that we were given in the challenge.
+         request_url = "{realm}?service={service}&scope={scope}".format(**auth_vars)
+-        response = requests.get(request_url, timeout=self.api_timeout)
++
++        headers = {}
++        # If username and password are available, use HTTP Basic Auth for token endpoint
++        if self.username and self.password:
++            userpass = "{}:{}".format(self.username, self.password).encode("utf-8")
++            headers["Authorization"] = "Basic {}".format(base64.b64encode(userpass).decode("utf-8"))
++
++        response = requests.get(request_url, timeout=self.api_timeout, headers=headers)
+         response.raise_for_status()
+         self.token = response.json()["token"]
+ 
+@@ -205,7 +261,7 @@ def __init__(self, endpoint, api_timeout=3):
+         self.endpoint = endpoint
+         self.api_timeout = api_timeout
+ 
+-        self.auth = BearerAuth(api_timeout)
++        self.auth = BearerAuth(api_timeout, endpoint)
+ 
+     def _request(self, subpath, extra_headers=None, stream=False, _reauthorized=False):
+         if not extra_headers:
+@@ -279,6 +335,8 @@ def manifest(
+         accept_types = [
+             "application/vnd.docker.distribution.manifest.v2+json",
+             "application/vnd.docker.distribution.manifest.list.v2+json",
++            "application/vnd.oci.image.index.v1+json",
++            "application/vnd.oci.image.manifest.v1+json",
+         ]
+ 
+         manifest_url = urljoin(image_path, "manifests", urllib.parse.quote(reference))
+@@ -316,8 +374,11 @@ def manifest(
+                 manifest=response.text,
+             )
+ 
+-        if manifest["mediaType"] == "application/vnd.docker.distribution.manifest.list.v2+json":
+-            # This is a "fat manifest", we need to narrow down to a specific
++        if manifest["mediaType"] in (
++            "application/vnd.docker.distribution.manifest.list.v2+json",
++            "application/vnd.oci.image.index.v1+json",
++        ):
++            # This is an "index", we need to narrow down to a specific
+             # architecture.
+             for sub in manifest["manifests"]:
+                 if sub["platform"]["architecture"] == architecture and sub["platform"]["os"]:
+@@ -332,7 +393,10 @@ def manifest(
+                 "No images found for architecture {}, OS {}".format(architecture, os_),
+                 manifest=response.text,
+             )
+-        if manifest["mediaType"] == "application/vnd.docker.distribution.manifest.v2+json":
++        elif manifest["mediaType"] in (
++            "application/vnd.docker.distribution.manifest.v2+json",
++            "application/vnd.oci.image.manifest.v1+json",
++        ):
+             return response.text, our_digest
+         else:
+             raise DockerManifestError(
+@@ -570,7 +634,10 @@ def fetch(self):
+                     raise SourceError(e) from e
+ 
+                 for layer in manifest["layers"]:
+-                    if layer["mediaType"] != "application/vnd.docker.image.rootfs.diff.tar.gzip":
++                    if layer["mediaType"] not in (
++                        "application/vnd.docker.image.rootfs.diff.tar.gzip",
++                        "application/vnd.oci.image.layer.v1.tar+gzip",
++                    ):
+                         raise SourceError("Unsupported layer type: {}".format(layer["mediaType"]))
+ 
+                     layer_digest = layer["digest"]
+@@ -727,3 +794,4 @@ def _assert_tarinfo_safe(self, member: tarfile.TarInfo, target_dir: str):
+ # Plugin entry point
+ def setup():
+     return DockerSource
++

--- a/project.conf
+++ b/project.conf
@@ -95,6 +95,7 @@ plugins:
       - make
     sources:
       - patch
+      - docker
 
   - origin: junction
     junction: plugins/buildstream-plugins-community.bst


### PR DESCRIPTION
## Summary

Fresh ISO installs land on a broken first boot: no welcome screen or MOTDs, brew erroring with trust prompts, stale ujust hints, and `ujust devmode` failing. One pass over the post-install experience.

1. **Ship the `uwelcome` binary the login hooks expect.** common#815's hooks came in via #1315, but the binary is built in common's Containerfile, which Dakota does not consume. New `bluefin/uwelcome.bst` ships the v0.3.4 release binary, mirroring `umotd.bst`.

2. **Pull the Homebrew tarball from `ghcr.io/ublue-os/brew`.** The old pins point at ublue-os/packages releases that stopped in March, and Homebrew 6 treats stale taps as untrusted. Now a docker source with per-arch manifest refs, vendoring apache/buildstream-plugins#91 since the stock plugin only speaks the Docker v2 protocol and ghcr serves OCI manifests; the patch drops when that PR merges.

3. **Point users at ChairLift instead of the removed bbrew** in two just-overrides.

4. **Make `toggle-devmode` Dakota-shaped.** It rebased to a dx image Dakota never publishes, and failed even earlier on fresh installs with no registry ref. Now it toggles the dx groups plus optional flatpaks and fonts, no bootc involved.

**Verified:** all four image variants build with the new elements; brew-tarball fetches end to end and the artifact contains a valid tarball from the 2026-08-15 upstream build; uwelcome sha256s match the release assets; system.just parses. Not yet verified: a first-login boot check that uwelcome and the MOTD render.

Related: apache/buildstream-plugins#91, projectbluefin/common#815
