### PR TITLE
fix(packages): ship fastfetch binary expected by common wrapper

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -17,6 +17,7 @@ depends:
 
   - bluefin/ghostty.bst
 
+  - bluefin/fastfetch.bst
   - bluefin/gum.bst
   - bluefin/tealdeer.bst
   - bluefin/ydotool.bst

--- a/elements/bluefin/fastfetch.bst
+++ b/elements/bluefin/fastfetch.bst
@@ -1,0 +1,18 @@
+# System info tool; common's ublue-fastfetch wrapper expects it on the image.
+kind: cmake
+
+sources:
+- kind: git_repo
+  url: github:fastfetch-cli/fastfetch.git
+  track: "[0-9]*.[0-9]*.[0-9]*"
+  ref: 2.67.1-0-g4dd2f2d34bf80f3e66b26d3869467de88ee1ca52
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-cmake.bst
+# Headers enable wayland/drm/dbus features; the libs are dlopen'd at runtime.
+- freedesktop-sdk.bst:components/wayland.bst
+- freedesktop-sdk.bst:components/libdrm.bst
+- freedesktop-sdk.bst:components/dbus.bst
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst


### PR DESCRIPTION
## Summary

Running `fastfetch` on a stock Dakota install fails with `which: no fastfetch`, reported in #1396. Common stages its `ublue-fastfetch` wrapper and config on every image, but the binary itself comes from the distro package set on Bluefin, Aurora, and LTS. Dakota composes from BuildStream elements instead, so nothing ever shipped the binary and the wrapper points at a program that does not exist. The only machines where it worked were ones where someone had already installed it through brew.

1. **New `elements/bluefin/fastfetch.bst`** builds fastfetch 2.67.1 from the upstream tag with cmake, pinned by ref with version-glob tracking so normal source tracking can bump it. Wayland, libdrm, and dbus are build-depends only: their headers at configure time enable the display and terminal detection features, and the libraries are dlopen'd at runtime, so the runtime dependency stays `runtime-minimal`.

2. **`elements/bluefin/deps.bst` picks up the element** so every variant stages `/usr/bin/fastfetch` alongside the other CLI tools.

**Verified:** the element builds clean locally and the install manifest shows `/usr/bin/fastfetch` plus the presets and man page at the expected paths. Full image build and a boot on real hardware are still pending before this promotes.

Related: #1396
