### PR TITLE
fix(image): create plugdev and nintendo_switch groups for udev rules

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -34,6 +34,7 @@ depends:
   - bluefin/wallpaper-month.bst
   - bluefin/bootc-install-config.bst
   - bluefin/composefs-loop-udisks-ignore.bst
+  - bluefin/udev-groups.bst
   - bluefin/gnome-epub-thumbnailer.bst
   - bluefin/papers-thumbnailer.bst
   - bluefin/wallpapers.bst

--- a/elements/bluefin/udev-groups.bst
+++ b/elements/bluefin/udev-groups.bst
@@ -1,0 +1,17 @@
+kind: manual
+
+sources:
+  - kind: local
+    path: files/sysusers
+
+build-depends:
+  - core/sandbox-tools.bst
+  - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+    - install -Dm644 bluefin-udev-groups.conf "%{install-root}/usr/lib/sysusers.d/bluefin-udev-groups.conf"
+    - "%{install-extra}"

--- a/files/sysusers/bluefin-udev-groups.conf
+++ b/files/sysusers/bluefin-udev-groups.conf
@@ -1,0 +1,8 @@
+# Groups referenced by udev rules that arrive via common's hardware rule
+# set but exist only on Fedora-based images; nothing in fdsdk or
+# gnome-build-meta creates them, so device nodes silently fall back to
+# root ownership (#1285).
+#   plugdev          50-zsa.rules (ZSA keyboard flashing via Keymapp/Oryx)
+#   nintendo_switch  10-switch.rules (Switch APX/RCM jig access)
+g plugdev -
+g nintendo_switch -


### PR DESCRIPTION
## Summary

Every dakota boot logs a wall of `Failed to resolve group` errors from udev (#1285). Digging through them, they split into two classes: most fire inside the initramfs before the group database exists and are harmless noise, but two groups are referenced by shipped rules and never exist at all, so the affected devices silently stay root-owned.

1. **`50-zsa.rules` wants `plugdev` and `10-switch.rules` wants `nintendo_switch`.** Both rules arrive via common's hardware rule set, written for Fedora-based images where those groups exist. Nothing in fdsdk or gnome-build-meta creates them, which breaks ZSA keyboard flashing and Switch APX jig access for non-root users.
2. **The fix ships a sysusers fragment instead of a static group file.** `elements/bluefin/udev-groups.bst` installs `/usr/lib/sysusers.d/bluefin-udev-groups.conf`. Fresh images get the groups baked by the existing compose-time `systemd-sysusers --root /layer` pass, and existing installs are healed on first boot after update when `systemd-sysusers.service` appends the missing entries to their merged `/etc/group`, which a static file could never do through the ostree /etc merge.

**Verified:** `bst build` succeeds and the checked-out artifact contains exactly the one conf at the right path, and `systemd-sysusers --root` against a scratch root creates both groups. Still needs a booted image to confirm device nodes pick up the new groups after a udev trigger. This intentionally does not touch the initramfs-phase noise, which is upstream initramfs behavior and stays visible in #1285.

Related: #1285

````markdown
```verify
getent group plugdev nintendo_switch
```
````
